### PR TITLE
Add Claude/human issue-handoff workflow (agent labels + /agent-queue)

### DIFF
--- a/.claude/commands/agent-queue.md
+++ b/.claude/commands/agent-queue.md
@@ -1,0 +1,54 @@
+---
+description: Work the Iosis GitHub issue queue — scan issues labeled agent/claude and take the next step on each until human input is needed
+---
+
+You are working the **Iosis issue queue**. Issues labeled `agent/claude` are in your court; `agent/human` are waiting on a person. Your job is to advance the `agent/claude` issues one step each, then hand back. Repo: `Phaazoid/Godoiosis` (gh is authed). Work from `C:\Iosis\Godoiosis`.
+
+## 1. Pull the queue
+
+```
+gh issue list --repo Phaazoid/Godoiosis --label agent/claude --state open --json number,title,labels,milestone
+```
+
+If `$ARGUMENTS` names specific issue numbers, work only those. Otherwise work the whole queue, highest priority first: `priority/P0-blocking` → `priority/P1-soon` → `priority/P2-someday`.
+
+## 2. For each issue, figure out the next step — from the REAL code, not theory
+
+Read the issue body (`gh issue view N`), every `docs/design/*.md` it links, AND the actual source files it names. CLAUDE.md is law: ground everything in the codebase — reading files beats theorizing (theorizing has wasted turns before). Then pick one path:
+
+- **Gameplay code** (`Classes/`, `Scenes/`, `game.gd`): *the user types it.* Draft a **walkthrough** — do NOT edit those files yourself. Format:
+  - **Summary** — one-line restatement of the fix.
+  - **Where** — file + line anchors for every touch point.
+  - **Fix** — the complete change as a `gdscript` block (typed end-to-end; the user pastes/types it verbatim).
+  - **Test coverage** — the gdUnit4 case to add under `tests/` once it lands.
+  - **Provenance** — what surfaced it / what you read to confirm.
+- **`tests/`, `docs/`, `CLAUDE.md`, other non-gameplay scaffolding** (standing exception — you MAY edit these directly): just do the work, then post a comment summarizing what landed + the commit SHA.
+- **Blocked on a human decision / design fork**: post a comment stating exactly the decision needed and the options, then leave it for the human (it becomes `agent/human`).
+
+Honor the design laws — no randomness; the action queue never lies (preview == execution; derived actions are computed, not stored); future AI uses the player's `SquadManager.queue_action` API. Don't bake anything still fluid (elemental specifics, runes, final weapon numbers) into a "fix."
+
+## 3. Post the comment — provenance is mandatory
+
+Author the comment body with the **Write tool** (correct UTF-8), then:
+
+```
+gh issue comment N --repo Phaazoid/Godoiosis --body-file <file>
+```
+
+NEVER pass non-ASCII via an inline `-b "..."` / PowerShell here-string — PS 5.1 mojibakes it before upload (see the encoding memo / `powershell-gh-nonascii-encoding` memory). Every comment:
+- **leads with** `🤖 Claude says:`
+- **ends with** `— Claude (Opus 4.8) · <today's date>`
+
+## 4. Flip the label
+
+After acting on an issue:
+
+```
+gh issue edit N --repo Phaazoid/Godoiosis --remove-label agent/claude --add-label agent/human
+```
+
+(When a human later replies that a fix needs rework, they flip it back to `agent/claude` and you revise on the next run.)
+
+## 5. Stop and report
+
+When every `agent/claude` issue has been advanced — or the rest genuinely need human input — stop and summarize per issue: what you did and what it's now waiting on. Do **not** close issues yourself unless explicitly asked. Verify any non-ASCII you posted via `gh api` (capturing gh stdout on the PS console re-mojibakes the display), not by eyeballing the terminal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,15 @@ Tactical RPG (Fire Emblem-influenced), Godot 4.6, GDScript. Solo hobbyist develo
 - Claude MAY directly create/edit: `CLAUDE.md`, `docs/`, `tests/`, GitHub issue text, and other non-gameplay scaffolding (standing exception granted 2026-06-12).
 - After walkthroughs land, *verify by reading the actual files* before debugging from theory — transcription drift is the most common failure mode.
 
+## GitHub issue workflow (Claude ↔ human handoff)
+
+Open work lives in [GitHub Issues](https://github.com/Phaazoid/Godoiosis/issues). Two **mutually exclusive** assignment labels say whose turn it is (exactly one per open issue):
+
+- **`agent/claude`** — Claude owns the next step: draft/revise a fix walkthrough, or (for `tests/` & `docs/`) just do the work directly.
+- **`agent/human`** — a human owns the next step: type a posted walkthrough, make a design decision, or test. Flip an issue back to `agent/claude` (with a reply) when a fix needs rework.
+
+Run **`/agent-queue`** to have Claude scan the `agent/claude` issues and advance each one, then hand back. Every comment Claude posts under the user's account **leads with `🤖 Claude says:`** and **ends with** `— Claude (Opus 4.8) · <date>`, authored via the Write tool → `gh issue comment --body-file` (never an inline non-ASCII arg — Windows PowerShell 5.1 mojibakes it before upload; see the encoding note in `tests/README.md`). After acting, Claude flips the label to `agent/human`.
+
 ## Design laws (non-negotiable)
 
 1. **No randomness in gameplay.** No hit/miss rolls, no crit chance, nothing. Combat is fully deterministic. (Old design docs mentioning crits predate this law.)


### PR DESCRIPTION
- CLAUDE.md: document the agent/claude <-> agent/human label scheme, the "Claude says:" comment provenance convention, and the /agent-queue command.
- .claude/commands/agent-queue.md: project slash command that scans agent/claude issues, posts code-verified walkthroughs (or does tests/docs directly), and flips the label to agent/human.