### PR TITLE
docs(design): distill wiki long-tail (weapons, terrain, philosophy, triage ledger)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Run **`/agent-queue`** to have Claude scan the `agent/claude` issues and advance
 
 ## Design wiki
 
-`C:\Iosis\Drive Wiki` — exported Google Drive wiki. **Partially ancient**: anything mentioning crits/hit-miss/action-points, plus all of `Code/Headers/`, is from a GameMaker-era version. The export has **no recoverable dates** (verified; don't re-investigate) — judge era by content and confirm with the user. Distill surviving material into `docs/design/` with user sign-off.
+`C:\Iosis\Drive Wiki` — exported Google Drive wiki. **Partially ancient**: anything mentioning crits/hit-miss/action-points, plus all of `Code/Headers/`, is from a GameMaker-era version. The export has **no recoverable dates** (verified; don't re-investigate) — judge era by content and confirm with the user. Distill surviving material into `docs/design/` with user sign-off. **Triage complete (2026-06-17, #32) — see [`docs/design/wiki-triage.md`](docs/design/wiki-triage.md): the design-session systems plus weapons/terrain/philosophy are distilled; everything else is logged distilled / discard (GameMaker-era) / defer. Don't re-triage from scratch.**
 
 ## Milestones
 

--- a/docs/design/alchemy-kit.md
+++ b/docs/design/alchemy-kit.md
@@ -122,3 +122,10 @@ Every wiki "chance of crit / 20% shock / Hit-50 / Avo" → a **deterministic com
 7. **[OPEN] Dual-cast / joint transmutation** between alchemists (Stone lore + some L5 runes imply it) — squad-flavored co-cast?
 
 Cross-refs: [progression.md](progression.md), [will-and-death.md](will-and-death.md), [squad-system.md](squad-system.md), `../../CLAUDE.md` (the three laws). Sibling session: **Elemental system** (backlog 🔴). Wiki distilled: `Systems Mechanics/Alchemy.docx` (newest half), `Economy/Items/Runes/*`, `Story/World Mechanics/Alchemy/*`, `Story/Plot/World History/*`, `Story/Locations/Paracelsus/*`, `Story/Characters/Playable/Isaac.docx`, `Story/Themes/*`, `Battle Mechanics/Elemental Combinatrix.docx`, `Code/Algorithms/Rune Based Algorithms.docx`, `Systems Mechanics/Stats Overview.docx`.
+
+## Captured ideas — wiki scratchpad (2026-06-17)
+
+Folds into the open forks above; noted during the #32 triage:
+
+- **Rune-carving as the customization UX** (fork 1): players physically *carve* runes — a tactile front-end to the capacity-board model.
+- **Innate / untested affinities** (fork 2): unlisted units might use a given rune *poorly* without a formal affinity, and affinities can be **grown, not created** — fitting the no-leveling identity-stat model. (Lore guardrail: gold transmutation is *possible* but consumes more runestone than the gold is worth — flavor, not a player action.)

--- a/docs/design/philosophy.md
+++ b/docs/design/philosophy.md
@@ -1,0 +1,26 @@
+# Design Philosophy — Gameplay Axioms
+
+**Status: NORTH STAR (short, stable).** Distilled 2026-06-17 (issue #32) from `Game Mechanics/Gameplay Philosophies`, `Intended Player Behavior/*`, and `Home`. These are the *why* behind the non-negotiable **Laws** in `../../CLAUDE.md`; when a design choice is unclear, it should serve these.
+
+## The pitch (one line)
+
+A turn-based tactical RPG of **steampunk mechanisms and alchemic runes** — in the Fire Emblem / FFT / XCOM / Advance Wars lineage, set apart by **squad combat** and a deterministic **elemental combinatrix**.
+
+## Axioms
+
+1. **Combat is worth watching.** Battles should be interesting to *watch* resolve — the player sets a plan and enjoys its execution; they shouldn't have to micromanage every beat.
+2. **Influence, then watch.** The player shapes the outcome *before* execution (the plan) and, in places, *during* it (mid-battle decisions / charges) — but is comfortable letting a planned turn play out.
+3. **Emergent, within predictable bounds.** Outcomes emerge from interacting systems (squads × elements × terrain) yet stay **inside bounds the player can foresee** — *"it won't be a surprise if someone dies."* This is the design reason behind **Law #1 (no randomness).**
+4. **The preview never lies.** Whatever the game shows about how a turn will unfold must match what happens (**Law #2**). Hidden information is allowed only through *explainable* means — e.g. a **perception stat** that reveals enemy detail, or a telegraphed-but-undirected overwatch — never by the preview asserting something false. (See the deferred battle-preview thread in [wiki-triage.md](wiki-triage.md).)
+5. **Go wide, not tall.** No basic leveling. Units grow by **specializing across systems** — squads, Will, weapon proficiency, aura, jobs — rarely by raw stat inflation; most effective stats stay small. (See [progression.md](progression.md).)
+6. **Respect the player's time.** A standing genre problem (FE) is late-game levels ballooning in length. Iosis wants **bounded, resumable sessions** — design encounters and the job board so play fits a sitting.
+
+## What these rule out
+
+Crits, hit/miss, dodge %, and "surprise" deaths (Axiom 3 + Law #1). Mandatory grinding (Axiom 5). Previews that mislead (Axiom 4 + Law #2).
+
+> **Scope note:** Law #1 governs the **battlefield.** Meta-progression *outside* combat may use randomness — e.g. a random menu of upgrade choices when a proficiency levels (see [progression.md](progression.md)). The turn never rolls dice; the campaign layer may.
+
+## Sources & cross-refs
+
+Wiki: `Gameplay Philosophies`, `Intended Player Behavior/{Tactics, Session Length}`, `Home`. See `../../CLAUDE.md` (the three Laws), [progression.md](progression.md), [squad-system.md](squad-system.md).

--- a/docs/design/progression.md
+++ b/docs/design/progression.md
@@ -53,4 +53,12 @@ Resolves the wiki's open question *"Alchemists == Mechanists??"* — not two cla
 - Roguelike power-normalization for imported units.
 - See [will-and-death.md](will-and-death.md) for the Will / limb-loss forks.
 
-Cross-refs: [will-and-death.md](will-and-death.md), [squad-system.md](squad-system.md), `../../CLAUDE.md` (design laws).
+## Captured ideas — wiki scratchpad (2026-06-17, unsorted)
+
+Noted from `Scratchpad` during the #32 triage; not yet integrated decisions:
+
+- **Randomness in *upgrades* is allowed; randomness in *combat* is not.** Law #1 governs the battlefield — but offering a **random subset of choices** when a proficiency/weapon advances (à la *Mewgenics*) is fine, and even encourages experimentation. The meta-layer may roll dice; the turn never does.
+- **Optional job/class-lite layer.** Classless-first stays the default, but an adopted "job" (spend X resource → role Z) could grant a flat stat change / stat caps (a tank caps movement) plus a trainable ability pool, swappable if you re-qualify. *"Even in a classless society, people have jobs."*
+- **Double-attacks as a weapon property, not a stat rule.** Rather than FE's speed-derived doubling, make multi-hit a property of specific weapons, **gated** by stats (better stats → more uses) — keeps growth horizontal.
+
+Cross-refs: [will-and-death.md](will-and-death.md), [squad-system.md](squad-system.md), [weapons.md](weapons.md), `../../CLAUDE.md` (design laws).

--- a/docs/design/squad-system.md
+++ b/docs/design/squad-system.md
@@ -74,3 +74,4 @@ The queue UI renders `ActionQueueDisplayEntry` lists built by `SquadManager.get_
 - Death handling: a unit hitting 0 HP currently just frees itself — squad cleanup on death is undesigned (blocked on the death/Will/downed-state design, which intersects squads heavily: leader downs, defending downed allies).
 - `choose_counter_target` policy (C3) is a placeholder awaiting feel-testing.
 - Squad-formation UX rules (who may join whom, range checks at join time) live partly in `game.gd` (`can_join_squad`, `can_squad_up`) — candidates to migrate into `SquadManager`.
+- **Squad archetypes by leader specialization** (idea, undesigned): a leader's dominant stat could shape the squad's identity — e.g. a DEF leader yields a defensive squad (holds ground, blocks for members). Intersects the surfaced weapon/Will "block" thread ([weapons.md](weapons.md)). Captured from the wiki scratchpad during the #32 triage.

--- a/docs/design/terrain.md
+++ b/docs/design/terrain.md
@@ -1,0 +1,58 @@
+# Terrain — States & Modifications
+
+**Status: CATALOG (workshop).** Distilled 2026-06-17 (issue #32) from `Systems Mechanics/Terrain Modification` and the terrain/weather threads in [elemental-interactions.md](elemental-interactions.md), reconciled with the implemented tile model. Per the dev: terrain and elemental are **two docs that reference each other heavily** — this one catalogs **what tiles can be and do** (not all of it elemental); the elemental docs own the *reaction* rules. AP-cost and "Avo" numbers from the wiki are stripped (Law #1 / no action points / no dodge).
+
+## The tile model (implemented — [LOCKED shape])
+
+The board is a `TileMapLayer` (`Grid`). Tiles already carry **custom data** the game reads today:
+
+- `walkable: bool` — pathing gate (`is_walkable`).
+- `move_cost: int` — terrain weight added in `movement_cost`.
+- a per-cell **terrain icon** (`GridUtils.get_terrain_icon_at_cell`), surfaced in the action queue.
+
+Everything below layers **on top of** that base tile: dynamic, per-cell **state** that units, runes, and weapons apply and read. State must round-trip through scenario save/load (`ScenarioData.tile_data`).
+
+## Modification layers ([WORKSHOP] — from the wiki, de-RNG'd)
+
+A cell holds at most **one ground** + **one atmosphere** modification, but **many object** modifications (stack mines/cover); **1-time** effects fire and don't persist. Some tiles (water/lake) refuse ground/object mods.
+
+| Layer | Persistence | Examples |
+|---|---|---|
+| **Ground** | until overwritten | Wet, Fire (→ Steam if Wet), Fault |
+| **Atmosphere** | until dispersed | Steam / Fog / Smoke, Tornado |
+| **Object** | stacks; until consumed | Landmine, Cover, Powder Barrel, Flammable |
+| **1-time** | instantaneous | Gust (clears atmosphere) |
+
+## State catalog ([WORKSHOP])
+
+Each is **deterministic and telegraphed**. ✦ = also an elemental state (shared vocabulary with [elemental-system.md](elemental-system.md)); the rest are terrain-native.
+
+- **Wet ✦** — Water-advantage / Fire-disadvantage; raises move cost; freezes into a walkable **Ice bridge**.
+- **Fire ✦** — damages units crossing; on Wet → **Steam**; expires in ~2 turns unless the tile is **Flammable**.
+- **Steam / Fog / Smoke ✦** — cuts **vision and command (LDR) range** for units inside (the "solo smoke" effect already in elemental-interactions).
+- **Ice ✦** — frozen water; special movement.
+- **Flammable** (object) — catches from adjacent Fire; forests/timber are Flammable children; burns down over turns.
+- **Powder Barrel** (object) — chain-explodes on AoE/Fire; **inert while Wet**.
+- **Landmine** (object) — AoE when crossed; type sets damage/range.
+- **Cover** (object) — defensive benefit to occupants (DEF; the "Avo" half is dead under Law #1 → reframe as flat mitigation or a block bonus).
+- **Fault** (ground) — heavy move penalty; strips object mods.
+- **Tornado** (atmosphere) — Air damage on cross + **shove** (the wiki's "move randomly 1 square" → de-RNG'd to a deterministic directional shove).
+- **Moving terrain** — fast rivers, trains, landslides, airships (fixed paths; de-randomized "moving terrain" — see elemental-interactions "fixed-path lava/rivers").
+
+## "Attack the map" ([WORKSHOP] — shared with elemental)
+
+Terrain is a **target**, not just a backdrop — this is where terrain & elemental overlap most, so they're owned jointly: Drill/EARTH break boulders (open paths, leave Cover rubble) · FIRE burns brambles · EARTH raises a destructible wall · WATER floods low ground (→ freeze → Ice bridge) · conductive rails. The full list lives in [elemental-interactions.md](elemental-interactions.md) ("attack the map"); **terrain.md owns the persistent-state bookkeeping, elemental owns the reaction.**
+
+## Atmosphere as chemistry (captured — [WORKSHOP], from scratchpad)
+
+A deeper model the dev floated: the **atmosphere layer is gaseous materia** (default ≈ "inert air" + "vital air"), and **gases diffuse to neighboring tiles toward equilibrium.** That would make Smoke/Steam/gas mods **spread and dissipate** on a known cadence rather than sitting static, and couples to the **weather** subsystem (Doldrums → gas lingers; High Winds → gas disperses; see elemental-interactions "Weather & atmosphere"). Ties to [alchemy-kit.md](alchemy-kit.md)'s materia model. **Not committed — captured.**
+
+## Open questions
+
+- How much terrain state is **authored per level** vs **emergent** from play? (Weather sets baselines — elemental-interactions.)
+- Does Cover / blocking pull from a DEF stat, and does that intersect the weapon **block** thread? ([weapons.md](weapons.md))
+- Serialization shape for live tile state in `ScenarioData.tile_data`.
+
+## Sources & cross-refs
+
+Wiki: `Systems Mechanics/Terrain Modification`, scratchpad atmosphere notes. Code: `Grid` custom data (`walkable`, `move_cost`), `movement_cost`, `GridUtils`, `ScenarioData.tile_data`. See [elemental-system.md](elemental-system.md), [elemental-interactions.md](elemental-interactions.md), [weapons.md](weapons.md).

--- a/docs/design/weapons.md
+++ b/docs/design/weapons.md
@@ -1,0 +1,50 @@
+# Weapons — Identities & Philosophy
+
+**Status: IDENTITIES + PHILOSOPHY (workshop); BALANCE OPEN (won't lock for a long time).** Distilled 2026-06-17 (issue #32) from the wiki (`Economy/Items/Weapons/{Main info, Weapon List, Upgrade System}`, `Code/Headers/Enums`) and reconciled with the implemented `WeaponData` / `WeaponCatalog`. Per the dev: *the outlines are here; specifics — especially balancing numbers — are not locked and won't be for a while.* So this captures **what each weapon family is for** and **the rules weapons obey**, not tuned stats.
+
+## The architecture (implemented — [LOCKED shape])
+
+A weapon is **policy + geometry**, split the same way as the rest of combat (see `../../CLAUDE.md`):
+
+- **`WeaponData` = policy** — `power`, `scaling_stat`, `can_counter`, `hits_allies`, `weapon_type`, `elemental_damage_type`, plus a reference to an `attack_pattern`.
+- **`AttackPattern` = geometry** — pure cell math (selectable vs affected cells). Terrain/LoS filtering belongs at the resolution layer, not the pattern (planned flag: `arcs_over_obstacles`).
+- Weapons are **content authored as `.tres`**: base types in `WeaponCatalog.TYPES`, customized variants written by the in-game Weapon Editor to `Resources/WeaponVariants/`. **Implemented base types so far: Chainsword, Springspear, FireRune** — the families below are the design target, not all built yet.
+
+> **Enum debt (#7):** `weapon_type` and `elemental_damage_type` are currently `String`s. They're fixed vocabularies → migrate to enums/registries (append-only once persisted in saved `.tres`). The family list below is the canonical `weapon_type` vocabulary.
+
+## Cross-cutting principles ([WORKSHOP])
+
+- **No accuracy, no crit % (Law #1).** The wiki is full of "crit chance / accuracy / dodge" — all dead. The named replacement: a **charge system / mid-battle decisions** plus the elemental **combinatrix** ([elemental-system.md](elemental-system.md)) as the deterministic stand-in for "big hits." Every "% chance to X" below is reframed as a deterministic trigger (a charge, a state, a position) or cut.
+- **Scaling is a stat blend.** The wiki says each weapon scales from a mix of **Speed / Skill / Strength**. ⚠️ *Drift to resolve:* the implemented `scaling_stat` enum is `STR / LDR / WIL / MHP` (no Spd/Skill) and takes **one** stat, not a blend. Reconcile when the statline firms up — add Spd/Skill, or express a blend at the resolution layer. **[OPEN]**
+- **Weapon triangle — purpose [OPEN].** A triangle is wanted, but with accuracy gone, *what does it decide?* Leading candidate (from `Main info` + scratchpad): it governs **blocking** cost/effectiveness, not hit chance (going against it might risk weapon-breaking). Tied to the block thread below.
+- **Build / weight gate (captured idea).** From a dev note (FE Engage's "build"): a weapon is usable **without penalty** until a unit's build/weight threshold, penalized past it — a deterministic mobility/weight curve, not a hard lock. **[captured, unplaced]**
+- **The 5th-tier power spike.** Each weapon's upgrade tree has a deliberate **5th-tier spike** — a customization payoff, not steady leveling (fits [progression.md](progression.md)'s go-wide model). Tree contents = economy, deferred.
+
+## ⚠ Surfaced thread — "blocking / guard" (no doc, no code yet)
+
+Recurs across `Main info` + `Precombat Popup` + scratchpad: **adjacent units can block once per engagement**, gated by weapon type & range, paid from a stat (DEF/health), mitigated/worsened by the weapon triangle, and possibly **stopping elemental effects** from landing. Ranged weapons (carbines) might block melee at high weapon-break risk. Per the dev (#32 era-check): **big maybe — revisit after elemental + Will land**; it may fold into Will, be a squad option, or seed a separate "abilities" system. Captured so the families can hint at it; **not a commitment.**
+
+## The seven weapon families (identities — [WORKSHOP])
+
+Each family = a fantasy + a role + a **signature class mechanic** (the wiki's per-family toggle), stated **de-randomized**.
+
+| Family (`weapon_type`) | Identity | Signature mechanic (de-RNG'd) |
+|---|---|---|
+| **Chainsword** | The mechanist's baseline blade — steady melee. | **Revved** — toggle: trade damage/speed for deterministic **dismemberment pressure** (a maim threshold; ties to [will-and-death.md](will-and-death.md)). |
+| **Drill** *(aka War Auger)* | Heavy, terrain-shaping bruiser. | **Burrow** — erect defensive or obstructive **terrain modifications** ([terrain.md](terrain.md)); the melee terrain-engineer. |
+| **Springspear** | Reach + the shock-combo enabler. | **Impale / Vault** — spring it into a **ranged** weapon (overworld action); winding back in costs time. The classic combinatrix shock partner. |
+| **Carbine** | Pressure-rifle ranged DPS. | **Headshot** — reframed from "+crit %" to a **charged precision shot** (deterministic). Per-weapon range bands (1–2 / 2–3). |
+| **Bludgeon** *(aka Kinetic Mace)* | Control via forced movement. | **Pummel** — **knock units a few tiles** (deterministic shove; pairs with terrain hazards / pit edges). |
+| **Chemical Spitter** | Close-range elemental applicator + support. | **Bio-hazard** — high front-loaded close damage; the **status-delivery** family (fire/ice/shock/corrode/heal variants → [elemental-system.md](elemental-system.md)). |
+| **Prosthetic** | The augmentation weapon (an *arm*, not a held tool). | **Inhuman** — **no STR scaling**; replaces STR with a static, upgradeable value; weapon-breakable only while equipped. The mechanist↔alchemist axis ([progression.md](progression.md)); the involuntary door from limb-loss ([will-and-death.md](will-and-death.md)). |
+
+*(Per-weapon flavor — The Broadburner, The Aegis, The Burn Notice, the Salve, etc. — is **content, deferred.** The named weapons in the wiki `Weapon List` are a flavor bank to draw from when authoring `.tres`, not a spec.)*
+
+## Locked vs open
+
+- **Locked-ish:** the policy/pattern architecture; the seven family identities + their signature-mechanic *fantasy*; no-accuracy/no-crit.
+- **Open (long-horizon):** all numbers; the scaling-stat blend (Spd/Skill vs the current enum); the weapon triangle's exact role; blocking; upgrade trees (economy); which families get built past the current three.
+
+## Sources & cross-refs
+
+Wiki: `Economy/Items/Weapons/{Main info, Weapon List, Upgrade System}`, `Code/Headers/Enums`. Code: `WeaponData`, `WeaponCatalog`, `AttackPattern`. See [elemental-system.md](elemental-system.md), [progression.md](progression.md), [will-and-death.md](will-and-death.md), [terrain.md](terrain.md); issues #7 (enums), #25 (ranges).

--- a/docs/design/wiki-triage.md
+++ b/docs/design/wiki-triage.md
@@ -1,0 +1,52 @@
+# Wiki Triage Ledger
+
+**Status: TRIAGE COMPLETE 2026-06-17** (issue #32). The exported Google Drive wiki (`C:\Iosis\Drive Wiki`, 152 `.docx`) has **no recoverable dates** — classified by content + dev confirmation. This is the durable record of what's distilled, discarded, and deferred, so the wiki never has to be re-triaged from scratch.
+
+## How to read this
+- **DISTILLED** — survivors already captured in `docs/design/`; the wiki doc is now reference-only.
+- **DISCARD** — GameMaker-era / superseded; **leave in the wiki as archive, never import**.
+- **DEFER** — live but future-milestone; revisit when that milestone arrives.
+
+## DISTILLED → `docs/design/`
+
+| Wiki source | Lives in |
+|---|---|
+| Elemental Combinatrix, Aristotelian Elements, Rune-Based Algorithms (element set) | `elemental-system.md`, `elemental-interactions.md` |
+| Alchemy, Rune Creation, Runestone, Philosopher's Stone (mechanics) | `alchemy-kit.md` |
+| The Art of Not Dying; Death, Damage Modifiers, Character-specific stats (downed/Will) | `will-and-death.md` |
+| Squads | `squad-system.md` |
+| Classes, Upgrade System (growth), Start (economy-as-lever) | `progression.md` |
+| Damage Calculation Algorithms (deterministic-preview intent) | `resolution-pipeline.md` (now Law #2) |
+| Economy/Items/Weapons/{Main info, Weapon List} | **`weapons.md`** (identities/philosophy; balance deferred) |
+| Systems Mechanics/Terrain Modification | **`terrain.md`** |
+| Gameplay Philosophies, Intended Player Behavior, Home | **`philosophy.md`** |
+
+## DISCARD (confirmed 2026-06-17) — GameMaker-era, archive in place
+- `Code/Headers/**` — GMIDL (Game Maker Interface Definition Language) + `base/` stdlib stubs.
+- `Code/Bug tracking/**` — GML crash logs (`obj_*`).
+- `Code/{Demo Goals, TODO}` — GameMaker-era working notes.
+- `Code/Algorithms/Damage Calculation Algorithms` — crit + pre-RNG "simulate every outcome" (intent survives as Law #2 / `resolution-pipeline.md`).
+- `Game Mechanics/Deprecated documents/**` — self-labeled; survivors already mined into `will-and-death` / `progression`.
+- **Rot to strip on contact, anywhere:** any `% chance` (crit / dodge / accuracy / "Avo"), **Action Points (AP)**, "battle statistics" framing — all dead under Law #1.
+
+## DEFER
+- **Story (`Story/**`, ~44 docs)** — narrative/lore, era-agnostic. → a **Milestone-B story pass** (its own `docs/story/` then). Gameplay leads; story bends to fit gameplay, not vice-versa (dev, 2026-06-17). May be *consulted* to ground gameplay (e.g. "what is a rune?").
+- **Economy / Overworld** (`Economy/{Jobs, Start, Scrap, Mounted Weapons}`, `Overworld/Mission Board`) — past basic engine work; Milestone B.
+- **Roguelike Mode** — *way* down the road.
+- **Battle transition animation** (grid expands 3×, FE-style zoom) — wanted, but **pure graphical spectacle → after core gameplay.**
+- **Battle-preview / combat UI** (`Precombat Informational Popup`, `Battle Preview`, `UI Suggestions`, `Unit Information`) — the Law #2 "preview honesty" UI. Not yet distilled; revisit alongside issues #2 / #3.
+
+## Ideas dispersed from the omnibus docs (`Scratchpad`, `Things we talked about TODAY`)
+Per dev request, design ideas were noted into the docs they relate to:
+- → `progression.md`: **randomness in *upgrades* (not combat) is allowed** under Law #1; optional job/class-lite layer; double-attack as a weapon property.
+- → `squad-system.md`: squad **archetypes by leader specialization** (a "defense squad," etc.).
+- → `weapons.md`: weapon-triangle-governs-blocking; build/weight gate; ranged-block-melee.
+- → `terrain.md`: atmosphere-as-diffusing-gas.
+- → `alchemy-kit.md`: player **rune-carving**; affinities can be *grown*, and unlisted units may use runes poorly (innate/untested affinities).
+- Pure plot beats (parents / dragons / philosopher / level ideas) → **deferred to the story pass.**
+
+## Surfaced undesigned mechanic
+- **Blocking / guard** — adjacent block once per engagement, weapon/range-gated, DEF-based, maybe stops elemental combos. Recurs in current-era docs; **absent from code and docs.** Dev: *"big maybe — handle elemental + Will first, then see where it fits"* (Will? a squad option? a separate abilities system?). Captured in [weapons.md](weapons.md).
+
+## Method (reproducible)
+Text was bulk-extracted from every `.docx` (a docx is a zip; `word/document.xml` → strip tags) and tagged for era-signals (crit/AP/GML) + topics. Re-run anytime if the wiki changes.


### PR DESCRIPTION
Per #32. Triage of all 152 wiki docs found the design-session systems (elemental, will, alchemy, squads, progression, resolution) were **already distilled** — this PR covers the long tail the dev greenlit.

### New docs
- **`weapons.md`** — the 7 weapon-family identities + the rules weapons obey (no crit/accuracy → charge system; the `WeaponData` policy / `AttackPattern` geometry split). Balance numbers deliberately deferred. Feeds #7 (weapon_type enum) and #25 (ranges).
- **`terrain.md`** — terrain-state catalog (ground / atmosphere / object layers), de-RNG'd; cross-references the elemental docs (terrain owns persistent state, elemental owns reactions).
- **`philosophy.md`** — a short gameplay-axioms "north star" behind the three Laws.
- **`wiki-triage.md`** — durable triage ledger: distilled / discard (GameMaker-era) / defer (story, economy, roguelike, battle-zoom).

### Notes added (captured scratchpad ideas)
- **`progression.md`** — randomness-in-upgrades-not-combat; optional job-lite layer; double-attack as a weapon property.
- **`squad-system.md`** — squad archetypes by leader specialization (future work).
- **`alchemy-kit.md`** — rune-carving UX; innate/untested affinities.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
