### PR TITLE
Add /scratchpad-sweep command + catalog slash commands in SHORTCUTS.md

### DIFF
--- a/.claude/commands/scratchpad-sweep.md
+++ b/.claude/commands/scratchpad-sweep.md
@@ -1,0 +1,36 @@
+---
+description: Sweep the Iosis idea inbox — read docs/SCRATCHPAD.md, file each Inbox idea where it belongs (a design doc, a proposed issue, or the defer pile), log it, and leave the Inbox empty
+---
+
+You are **sweeping the scratchpad** — the user's raw idea inbox at `docs/SCRATCHPAD.md`. Work from `C:\Iosis\Godoiosis`.
+
+## 1. Read the inbox and the procedure
+
+Read **`docs/SCRATCHPAD.md`** in full. It contains both the current **📥 Inbox** entries and the authoritative **sweep procedure** (the numbered steps under "How Claude processes this"). That doc is the source of truth — follow its steps exactly; the rest of this file just restates the guardrails so they aren't missed.
+
+If the Inbox is empty, say so and stop — nothing to sweep.
+
+If `$ARGUMENTS` is given, treat it as a scope hint (a specific idea, or an area like `weapons` / `story`) and sweep only matching entries; otherwise sweep the whole Inbox, top to bottom.
+
+## 2. For each idea, file it — grounded in the repo, not theory
+
+Same rigor as `/agent-queue`: read the design docs and real source an idea touches before deciding where it goes. For each bullet:
+
+1. **Understand it.** If filing it wrong would be worse than asking, **ask the user** — don't guess at intent.
+2. **Pick its home:** a `docs/design/*.md` section (most ideas), a **proposed** GitHub issue (actionable work — propose and get a yes *before* creating; never spam the tracker), or the **defer pile** (record in the relevant doc's open/deferred section or `wiki-triage.md` with the reason).
+3. **Apply it, honoring the contract & laws:**
+   - Docs are yours to edit directly. Mark each idea as a **captured idea, not a locked decision** — match the "Captured ideas" convention in `progression.md` / `alchemy-kit.md` — *unless* it's tagged `[DECIDED]` or the user says otherwise.
+   - **Gameplay code stays user-typed.** A code idea becomes a walkthrough or an issue — never a direct edit to `Classes/`, `Scenes/`, `game.gd`.
+   - Don't bake **fluid** systems (runes, weapon specifics, elemental tuning) as locked; respect the certainty map and the three Laws (no randomness; queue never lies; AI uses the player API).
+   - `[Q]` items: answer/research, record the answer where useful, then file like anything else.
+4. **Log it.** Move the bullet from **📥 Inbox** to **🗂 Dispersed** as `- <gist> → <destination> (YYYY-MM-DD)`. **Never silently delete a user's idea** — the log is the audit trail.
+
+Leave the **Inbox empty** when done. Anything you genuinely can't file without the user stays in the Inbox under a `**needs you:**` note.
+
+## 3. Provenance (only if you create or comment on an issue)
+
+If an idea becomes a GitHub issue or a comment, follow the `/agent-queue` rules: author the body with the **Write tool** (UTF-8), post via `gh ... --body-file` (never an inline non-ASCII arg — PS 5.1 mojibakes it), lead with `🤖 Claude says:`, end with `— Claude (Opus 4.8) · <today's date>`, and set the `agent/*` labels. Editing `docs/` needs none of this.
+
+## 4. Commit and report
+
+Commit the touched docs (this file plus any design docs you filed into) the way the repo's other docs are committed — branch off `main`, push, open a PR for the user to merge; don't commit straight to `main`. Then report a short **per-idea** summary: where each idea went, and anything still waiting on the user.

--- a/docs/SHORTCUTS.md
+++ b/docs/SHORTCUTS.md
@@ -1,6 +1,6 @@
 # Iosis — Keys & Shortcuts
 
-Quick reference for controls and dev-tool shortcuts. Keep this updated as new bindings are added (they live in Project Settings → Input Map, prefixed `cam_*` / `dev_*`). This is the canonical list — tab tooltips in the dev window should mirror it, not replace it.
+Quick reference for controls, dev-tool shortcuts, and Claude workflow commands. Keep this updated as new bindings are added (in-game ones live in Project Settings → Input Map, prefixed `cam_*` / `dev_*`). This is the canonical list — tab tooltips in the dev window should mirror it, not replace it.
 
 ## Gameplay
 | Key | Action |
@@ -19,6 +19,14 @@ Quick reference for controls and dev-tool shortcuts. Keep this updated as new bi
 | Left-click a unit | (DEV_MODE) Edit that unit in the Unit Editor |
 | Left-drag | (DEV_MODE, Tile Brush active) Paint the selected tile |
 | Right-click | (DEV_MODE, Tile Brush active) Erase a tile |
+
+## Claude slash commands
+Typed into the **Claude Code chat** (not in-game). Each lives as a file in [`.claude/commands/`](../.claude/commands/) — the filename *is* the command name, and the file is the instructions Claude follows when you run it. Anything after the command is passed in as an argument to scope the run.
+
+| Command | What it does |
+|---------|--------------|
+| `/agent-queue` | Scan the open GitHub issues labeled `agent/claude` and advance each one a step — draft a fix walkthrough, do `tests/`/`docs/` work directly, or flag a decision — then flip it to `agent/human`. Add issue numbers (e.g. `/agent-queue 23 25`) to work only those. |
+| `/scratchpad-sweep` | Read [`docs/SCRATCHPAD.md`](SCRATCHPAD.md), file each **Inbox** idea into the right design doc / a proposed issue / the defer pile, log where it went, and leave the Inbox empty. Add an area or idea (e.g. `/scratchpad-sweep weapons`) to sweep just those. |
 
 ## Notes
 - The dev tools open as a **separate OS window** (draggable to a second monitor). See `CLAUDE.md` → "Dev tools = separate OS window" for the architecture.


### PR DESCRIPTION
## What

- **New `/scratchpad-sweep` command** (`.claude/commands/scratchpad-sweep.md`) — the slash-command companion to the idea inbox added in #39. It reads `docs/SCRATCHPAD.md`, runs the sweep procedure documented there (the doc stays the single source of truth), and restates only the guardrails inline: gameplay-code ideas become walkthroughs not edits, ideas land as *captured* (not locked) unless tagged `[DECIDED]`, new issues are proposed before creation with full provenance, every handled idea is logged to **Dispersed**, and the Inbox is left empty.
- **`SHORTCUTS.md` now lists the Claude slash commands** — a new "Claude slash commands" section documents both `/agent-queue` and `/scratchpad-sweep` (what each does + how to scope it with an argument), and the intro is broadened to mention workflow commands alongside in-game keys.

## Why

The user liked the proposed sweep command and asked to (a) make it real and (b) catalog the slash commands in the shortcut doc so they're discoverable, not just tribal knowledge.

## Notes

- Docs/scaffolding only — no gameplay code touched.
- `/scratchpad-sweep` defers its detailed steps to `docs/SCRATCHPAD.md` to avoid two copies of the procedure drifting apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
