### PR TITLE
docs: scratchpad sweep 2026-07-14 (Duplex Breech + telemetry #53)

### DIFF
--- a/docs/SCRATCHPAD.md
+++ b/docs/SCRATCHPAD.md
@@ -36,9 +36,10 @@ Then report a short per-idea summary: where each went, and anything that needs t
 
 ## 📥 Inbox (drop ideas here)
 
-*(empty — swept 2026-07-08)*
-
 ## 🗂 Dispersed (log)
+
+- Double-barreled gun: every other shot a different effect (per-barrel mods or authored cycle) → weapon-mod-ideas.md #31 "Duplex Breech" [CB] keystone sketch (2026-07-14)
+- Far-future data-driven balance metrics (beta telemetry: collect/analyze what's strong/weak) → issue #53 (P2-someday, the #52 far-future pattern; Play API #46 named as the natural substrate) (2026-07-14)
 
 - Revved Chainsword chews through Cover terrain over a turn → weapons.md (Captured ideas) + terrain.md ("Attack the map") (2026-06-17)
 - Range-dependent damage / sweet-spot patterns (carbine harder at range, shotgun up close, Springspear AoE center tile) → weapons.md (Captured ideas); relates to issue #25 (2026-06-17)

--- a/docs/design/weapon-mod-ideas.md
+++ b/docs/design/weapon-mod-ideas.md
@@ -44,6 +44,7 @@
 28. **Volatile Core** [∀] — big power spike; drawback: the wielder's tile gains FIRE on use (previewed, positioning tax).
 29. **Aegis Suite** [∀] — guard stance alt-action: forgo attacking to block for adjacent allies this pass (weapon-tied squad blocking).
 30. **Rune Socket** [∀] — the weapon carries a size-1 rune; attacks channel it if the wielder has the aura. ⚠ **Fence-crosser:** bridges into alchemy's monopoly — grill before authoring (it's the mechanist-alchemist bridge as an item, which is exactly why it's tempting *and* dangerous).
+31. **Duplex Breech** [CB] — double-barrel conversion: shots **alternate barrels deterministically** (odd/even shot counter — Law #1 clean), and each barrel carries its own effect — either each takes its own size-1 infusion/mod ("modified separately": two effect channels in one weapon) or two authored effects that simply cycle. Law #2: the queue previews *which barrel* every planned shot fires. Prototype cousin: a named double-barreled gun with two pre-authored alternating effects. *(Scratchpad capture 2026-07-14; keystone placement is a sketch.)*
 
 ## Prototypes (named prebuilts — unique effect, one size-1 space)
 


### PR DESCRIPTION
Scratchpad sweep (2026-07-14) — two inbox ideas filed, inbox left empty:

- **Double-barreled gun / alternating shot effects** → captured in `docs/design/weapon-mod-ideas.md` as #31 **Duplex Breech** [CB] (keystone sketch: deterministic barrel alternation, per-barrel mod channels or authored cycle, Law #2 barrel preview, prototype cousin noted). Captured idea, not locked.
- **Far-future data-driven balance metrics (beta telemetry)** → issue #53 (P2-someday / type-feature / agent-human, the #52 far-future pattern).

Only the two swept docs are in this PR; the ratification-day design-doc edits in the working tree are deliberately not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
