### PR TITLE
Add test tiers to run_tests.ps1; correct the suite-runtime record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ Most scripts are reached by `class_name` (global), so folders are for humans nav
 ## Sharp edges (each of these has already bitten once)
 
 - **Grant/copy an equippable via `copy_equippable()`, never a bare `duplicate(true)`** (revised #59 — this used to say the opposite). `RuneData` still wants a full deep copy (its base implementation), but `WeaponInstance` overrides it to keep `template` a SHARED reference while its own `space_1/2/3` copy shallowly — a generic `duplicate(true)` would deep-copy the template too and silently fork a weapon off its family.
+- **gdUnit4's `Total execution time` line is not wall clock and inflates badly** — it read `1min 55s` for a 573-case run right after a cache clear, then `12s` for the identical run warm. Trust `run_tests.ps1`'s own stopwatched `Elapsed` line instead. The suite takes **~20s** full / **~7s** for `run_tests.ps1 fast` / ~3-5s per area; a belief that it took "about two minutes" came straight from this bad number (corrected 2026-07-24). Re-measure before ever acting on "the tests are getting slow".
 - `.tres` files omit properties at default values — an "empty-looking" resource may just be unsaved-at-defaults.
 - UI rule: **scene for static, code for dynamic.** Fixed controls live in `.tscn`; data-shaped UI (editor fields, stat rows) is generated.
 - Plain `Panel`s report 0×0 minimum size for absolutely-positioned children inside containers.

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,15 +9,27 @@ Pins the **settled** systems (the squad spec) as executable invariants so they d
 One command (PowerShell), from anywhere in the repo:
 
 ```
-powershell -File tests\run_tests.ps1                     # whole tests/ tree
-powershell -File tests\run_tests.ps1 res://tests/squad   # one folder or suite
+powershell -File tests\run_tests.ps1                     # full tree            ~20s
+powershell -File tests\run_tests.ps1 fast                # the fast tier        ~7s
+powershell -File tests\run_tests.ps1 weapons items       # one or more areas    ~3-5s each
+powershell -File tests\run_tests.ps1 res://tests/squad   # explicit path (back-compat)
 ```
+
+**Tiers** (added 2026-07-24) are named in `run_tests.ps1`'s `$Tiers` table — edit it there, it's the only definition:
+
+- **`fast`** = `law` + `rules` + `stats` + `unit` + `util` — 149 cases. The invariant core: the Law guards (action-registry completeness, AI action coverage, damage floor, DEF mitigation) plus the pure rule/math layers. This is the "did I break something cross-cutting" check for the inner loop, **not** a substitute for the full run before a commit.
+- **`full`** = the whole tree (the default).
+- Anything else is treated as an **area** — a folder name under `tests/`. A typo'd area is a hard error, deliberately: gdUnit4 treats an unmatched `-a` path as "zero suites" and still **exits 0**, which reads as a clean pass.
+
+`-a` is repeatable (`GdUnitTestCIRunner.add_test_suite` appends), which is what makes multi-area runs work.
 
 `run_tests.ps1` runs Godot headless against gdUnit4 and returns the suite's exit code. It defaults to `C:\Godot\Godot_v4.6-stable_win64.exe\Godot_v4.6-stable_win64_console.exe`; override with `$env:GODOT_BIN`. The raw command it runs:
 
 ```
 <godot-console-exe> --path . --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd -a res://tests --ignoreHeadlessMode
 ```
+
+> **⚠ Ignore gdUnit4's `Total execution time` line — it is not wall clock and inflates badly.** It printed `1min 55s` for a 573-case run immediately after a cache clear, then `12s` for the *identical* run warm. `run_tests.ps1` prints its own stopwatched `Elapsed` line; trust that one. (This mismeasurement is why the suite was believed to take ~2 minutes; it takes ~20 seconds. Cost is ~0.035s/case warm, so suite size is not a looming problem.)
 
 **Exit codes (from gdUnit4's `report_exit_code`):** `0` = clean pass · `100` = test failures **or** caught engine errors (e.g. a `push_error`/runtime error during a test) · `101` = passed but **orphan nodes** were detected. Treat anything non-zero as "fix it" — see orphan-node hygiene below.
 
@@ -53,6 +65,7 @@ powershell -File tests\run_tests.ps1 res://tests/squad   # one folder or suite
 - **`--remote-debug` needs a real port** (1–65535); `tcp://127.0.0.1:0` is rejected in 4.6, so we don't pass it.
 - **Orphan-node hygiene = the exit code.** gdUnit4 counts "orphan nodes" (`root.get_orphan_node_ids()` — any `Node` not in the SceneTree) sampled *during* each test, and returns `101` if any remain. So a fixture that `Node.new()`s something must keep it **in the tree** or `auto_free` it. The big trap here: `SquadManager` creates `Squad` nodes as *its own* children, so if the manager itself is orphaned (not in the tree) every squad it makes is an orphan too. `make_manager` therefore stands the manager up **inside the tree** (see fixtures below). Counterpart: `queue_free()` only works for in-tree nodes, which is a second reason to keep the graph in-tree.
 - **RefCounted reference cycles leak** (no GC). A volley's `AttackAction.volley` array references every sibling including itself, so a volley is a self-referential cycle that never frees — the volley suite breaks it in `after_test` (`attack.volley = empty`). See findings; this is a real (small) gameplay leak too.
+- **`tests/flow/test_scenario_load_integrity.gd` segfaults on SHUTDOWN when run alone** (exit `-1073741819` = `0xC0000005` access violation). All 7 cases pass — `0 errors, 0 failures, 0 orphans` — and *then* the process dies tearing down. It is **masked in the full run** (which exits 0), so it went unnoticed until per-area runs existed; found 2026-07-24 while adding tiers. Tracked as [#93](https://github.com/Phaazoid/Godoiosis/issues/93). Until fixed, `run_tests.ps1 flow` reports failure despite a clean pass — read the summary line, not just the exit code, for that one area.
 - **A failure truncates the REST of that suite file, silently.** Observed 2026-07-15 (#56): fixing one failing assertion in `test_ai_tactics.gd` revealed a second, previously-unrun test in the same file with the identical bug — the run before the fix reported "9 test cases" for that suite when the file has more; only after the fix did the remaining tests execute. So a suite's printed test count is not proof the whole file ran — if you fix a failure, **always re-run** rather than trusting the fix from reasoning alone, and don't assume "only 1 failure reported" means "only 1 test in this file is affected."
 - **Content-scan catalogs can key off a name that changes.** `WeaponAttackCatalog` (and similar folder-scan catalogs) use `display_name` as the registry key, falling back to the resource's filename when `display_name` is unset. Authoring a real `display_name` for a previously-unnamed attack changes its catalog key — a test asserting the old filename-derived key breaks (happened 2026-07-22: Springspear's main attack, "Springspear" → "Stab"). Expect this to recur as the remaining weapon families get real content.
 

--- a/tests/run_tests.ps1
+++ b/tests/run_tests.ps1
@@ -1,8 +1,30 @@
 # One-command headless gdUnit4 runner for Iosis.
-# Usage:   powershell -File tests\run_tests.ps1 [res://path]
-#   (default runs the whole tests/ tree; pass a folder/suite to narrow)
+#
+# Usage:
+#   powershell -File tests\run_tests.ps1                   # full tree (default)
+#   powershell -File tests\run_tests.ps1 fast              # the fast tier -- inner-loop check
+#   powershell -File tests\run_tests.ps1 weapons items     # one or more areas (folders under tests/)
+#   powershell -File tests\run_tests.ps1 res://tests/ai    # explicit res:// path (back-compat)
+#
+# WHY TIERS EXIST -- measured 2026-07-24 over 573 cases / 79 suites (report_173):
+# cost is ~0.10s per test case plus ~0.75s per suite FILE, and it is near-UNIFORM. The
+# cheapest possible test (comparing two const arrays, no scene) costs 0.078s; the most
+# expensive (loading every scenario off disk) costs 0.221s -- only 2.9x apart. That means
+# there are no slow suites to quarantine: the only lever is running FEWER tests. Roughly
+# half the full run's wall clock is fixed overhead, so a tier saves on both axes.
+#
 # Override the engine with $env:GODOT_BIN if your Godot lives elsewhere.
-param([string]$TestPath = "res://tests")
+
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Targets)
+
+# Named tiers -> folder names under tests/. An EMPTY list means "the whole tree".
+# `fast` is the invariant core: the Law guards (registry completeness, AI action coverage,
+# damage floor, DEF mitigation) plus the pure rule/math layers. It is the "did I break
+# something cross-cutting" check, NOT a substitute for the full run before a commit.
+$Tiers = @{
+	'full' = @()
+	'fast' = @('law', 'rules', 'stats', 'unit', 'util')
+}
 
 $bin = $env:GODOT_BIN
 if (-not $bin) { $bin = "C:\Godot\Godot_v4.6-stable_win64.exe\Godot_v4.6-stable_win64_console.exe" }
@@ -12,5 +34,49 @@ if (-not (Test-Path $bin)) {
 }
 
 $root = Split-Path $PSScriptRoot -Parent
-& $bin --path $root --headless -s "res://addons/gdUnit4/bin/GdUnitCmdTool.gd" -a $TestPath --ignoreHeadlessMode
-exit $LASTEXITCODE
+if (-not $Targets -or $Targets.Count -eq 0) { $Targets = @('full') }
+
+$folders = New-Object System.Collections.Generic.List[string]
+$explicit = New-Object System.Collections.Generic.List[string]
+$wholeTree = $false
+
+foreach ($t in $Targets) {
+	if ($t -like 'res://*') { $explicit.Add($t); continue }
+	if ($Tiers.ContainsKey($t)) {
+		if ($Tiers[$t].Count -eq 0) { $wholeTree = $true }
+		else { foreach ($f in $Tiers[$t]) { $folders.Add($f) } }
+		continue
+	}
+	$folders.Add($t)
+}
+
+# Fail loudly on a typo'd area rather than silently running nothing -- gdUnit4 treats an
+# unknown -a path as "zero suites matched" and still exits 0, which reads as a clean pass.
+$known = Get-ChildItem -Path $PSScriptRoot -Directory | Select-Object -ExpandProperty Name
+foreach ($f in $folders) {
+	if ($known -notcontains $f) {
+		Write-Error "Unknown test area '$f'. Tiers: $($Tiers.Keys -join ', '). Areas: $($known -join ', ')."
+		exit 1
+	}
+}
+
+$paths = New-Object System.Collections.Generic.List[string]
+if ($wholeTree) {
+	$paths.Add('res://tests')
+} else {
+	foreach ($f in ($folders | Select-Object -Unique)) { $paths.Add("res://tests/$f") }
+	foreach ($e in $explicit) { $paths.Add($e) }
+}
+
+# -a appends (GdUnitTestCIRunner.add_test_suite -> _included_tests.append), so it repeats.
+$argv = @('--path', $root, '--headless', '-s', 'res://addons/gdUnit4/bin/GdUnitCmdTool.gd')
+foreach ($p in $paths) { $argv += @('-a', $p) }
+$argv += '--ignoreHeadlessMode'
+
+Write-Host "Running: $($paths -join '  ')" -ForegroundColor Cyan
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+& $bin @argv
+$code = $LASTEXITCODE
+$sw.Stop()
+Write-Host ("Elapsed {0:N1}s  (exit {1})" -f $sw.Elapsed.TotalSeconds, $code) -ForegroundColor Cyan
+exit $code


### PR DESCRIPTION
## Tiers

```
run_tests.ps1                    full tree                              ~20s
run_tests.ps1 fast               law+rules+stats+unit+util (149 cases)   ~7s
run_tests.ps1 weapons items      one or more areas                      ~3-5s each
run_tests.ps1 res://tests/ai     explicit path (unchanged)
```

`-a` is repeatable (`GdUnitTestCIRunner.add_test_suite` appends), so multi-area runs need only one Godot invocation. **A typo'd area is now a hard error** listing the valid ones — gdUnit4 treats an unmatched `-a` path as "zero suites" and still **exits 0**, which reads as a clean pass.

`fast` is the invariant core: the Law guards (action-registry completeness, AI action coverage, damage floor, DEF mitigation) plus the pure rule/math layers.

## The premise was wrong, and that's the more useful finding

This work was motivated by "the suite is getting slow — about two minutes." **It isn't.** That number came from gdUnit4's own `Total execution time` line, which is not wall clock and inflates badly: it printed `1min 55s` for a 573-case run immediately after a cache clear, then `12s` for the *identical* run warm.

Measured with a stopwatch around the process: **~20s for all 573 cases** (~0.035s/case). Even 1500 cases would land near 50s. The runner now prints its own `Elapsed` line, and both `CLAUDE.md` and `tests/README.md` record the correction so the bad number doesn't get re-derived into future advice.

The tiers are still worth having for the inner loop — 7s beats 20s when iterating — but the urgency was an artifact.

## Bonus: per-area runs exposed a real crash

`tests/flow/test_scenario_load_integrity.gd` passes all 7 cases and **then segfaults on shutdown** (`0xC0000005`), reproduced 4/4. The full run masks it (exits 0), so it had gone unnoticed. Filed as #93 with an isolation table; documented in the README gotchas.

No test or gameplay code changed. Suite still **573/573**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)