### PR TITLE
Upgrade engine to Godot 4.7.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,15 +19,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: godot-bin/
-          key: godot-4.6-stable-linux-x86_64
+          key: godot-4.7.1-stable-linux-x86_64
 
-      - name: Download Godot 4.6
+      - name: Download Godot 4.7.1
         if: steps.cache-godot.outputs.cache-hit != 'true'
         run: |
-          wget -q https://github.com/godotengine/godot/releases/download/4.6-stable/Godot_v4.6-stable_linux.x86_64.zip
-          unzip -q Godot_v4.6-stable_linux.x86_64.zip
+          wget -q https://github.com/godotengine/godot/releases/download/4.7.1-stable/Godot_v4.7.1-stable_linux.x86_64.zip
+          unzip -q Godot_v4.7.1-stable_linux.x86_64.zip
           mkdir godot-bin
-          mv Godot_v4.6-stable_linux.x86_64 godot-bin/godot
+          mv Godot_v4.7.1-stable_linux.x86_64 godot-bin/godot
 
       - name: Ensure Godot is executable
         run: chmod +x godot-bin/godot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Iosis — Project Guide
 
-Tactical RPG (Fire Emblem-influenced), Godot 4.6, GDScript. Solo hobbyist developer.
+Tactical RPG (Fire Emblem-influenced), Godot 4.7, GDScript. Solo hobbyist developer.
 
 ## Collaboration contract (read first)
 

--- a/KIMI.md
+++ b/KIMI.md
@@ -4,7 +4,7 @@ My (Kimi's) own memory for this project. Created 2026-07-29. Companion to `CLAUD
 
 ## What this is
 
-- **Iosis**: tactical RPG (Fire Emblem-influenced), Godot 4.6, GDScript, solo hobbyist dev (the owner, "Dmanz" / GitHub `Phaazoid`).
+- **Iosis**: tactical RPG (Fire Emblem-influenced), Godot 4.7, GDScript, solo hobbyist dev (the owner, "Dmanz" / GitHub `Phaazoid`).
 - Repo root: `C:\Iosis\Godoiosis` (git repo, GitHub: Phaazoid/Godoiosis). Work is tracked in GitHub Issues with `agent/claude` / `agent/human` labels.
 - `CLAUDE.md` (~71 KB) is the single canon doc: collaboration contract, design laws, architecture map, sharp edges, known debt. `docs/build-log.md` has build history; `docs/design/` has design docs with "Canon checked through #NN" markers; `docs/SCRATCHPAD.md` is the idea inbox.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -17,7 +17,7 @@ is being repeated far more often than anyone intended — usually via a signal f
 ## How to re-measure
 
 ```bash
-"C:/Godot/Godot_v4.6-stable_win64.exe/Godot_v4.6-stable_win64_console.exe" --headless --path "C:/Iosis/Godoiosis" --script res://tools/profile_group_move.gd
+"C:/Godot/Godot_v4.7.1-stable_win64/Godot_v4.7.1-stable_win64_console.exe" --headless --path "C:/Iosis/Godoiosis" --script res://tools/profile_group_move.gd
 ```
 
 `tools/profile_group_move.gd` boots the real `Main.tscn`, loads Castle Assault, and times the

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Iosis"
 run/main_scene="uid://cxiu0yvwwxlgo"
-config/features=PackedStringArray("4.6", "Mobile")
+config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"
 
 [display]

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,7 +23,7 @@ powershell -File tests\run_tests.ps1 res://tests/squad   # explicit path (back-c
 
 `-a` is repeatable (`GdUnitTestCIRunner.add_test_suite` appends), which is what makes multi-area runs work.
 
-`run_tests.ps1` runs Godot headless against gdUnit4 and returns the suite's exit code. It defaults to `C:\Godot\Godot_v4.6-stable_win64.exe\Godot_v4.6-stable_win64_console.exe`; override with `$env:GODOT_BIN`. The raw command it runs:
+`run_tests.ps1` runs Godot headless against gdUnit4 and returns the suite's exit code. It defaults to `C:\Godot\Godot_v4.7.1-stable_win64\Godot_v4.7.1-stable_win64_console.exe`; override with `$env:GODOT_BIN`. The raw command it runs:
 
 ```
 <godot-console-exe> --path . --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd -a res://tests --ignoreHeadlessMode

--- a/tests/run_tests.ps1
+++ b/tests/run_tests.ps1
@@ -27,9 +27,9 @@ $Tiers = @{
 }
 
 $bin = $env:GODOT_BIN
-if (-not $bin) { $bin = "C:\Godot\Godot_v4.6-stable_win64.exe\Godot_v4.6-stable_win64_console.exe" }
+if (-not $bin) { $bin = "C:\Godot\Godot_v4.7.1-stable_win64\Godot_v4.7.1-stable_win64_console.exe" }
 if (-not (Test-Path $bin)) {
-	Write-Error "Godot not found at '$bin'. Set `$env:GODOT_BIN to your Godot 4.6 console exe."
+	Write-Error "Godot not found at '$bin'. Set `$env:GODOT_BIN to your Godot 4.7 console exe."
 	exit 1
 }
 


### PR DESCRIPTION
Moves the engine from Godot 4.6 to **4.7.1** (released 14 July 2026).

Worth saying plainly: nothing in 4.7 helps Iosis — its headline features are HDR output, AreaLight3D, MeshLibrary and mobile/XR export. This buys currency, not capability. The argument for doing it now rather than after the demo is that upgrade cost scales with the project, and this landed at 11 `.tscn` / 78 `.tres`.

## What changed

Seven files — the four places the engine version is pinned, plus two live instruction sites found by a canon sweep:

| file | change |
|---|---|
| `project.godot` | `config/features` 4.6 → 4.7 (written by the importer) |
| `tests/run_tests.ps1` | default binary path + the "set GODOT_BIN" message |
| `.github/workflows/tests.yml` | cache key, step name, download URL, binary name |
| `CLAUDE.md` / `KIMI.md` | project line |
| `docs/performance.md` | the profiler command someone would actually run |
| `tests/README.md` | the stated runner default |

Dated historical records are deliberately **not** touched — `docs/BACKLOG.md`'s run log, `tests/README.md`'s 2026-06-16 status line, and all 13 `docs/session-prompts/` files record what was true when written.

**The importer rewrote only the features line — zero `.tscn`/`.tres` churn**, so there is no converter-churn commit.

## Breaking-change surface, measured against the code

Most of 4.7's list misses this project entirely: no `is_class()` call sites, no custom `draw_line`, **no shaders at all**, no audio, Windows-only export, and the one `RichTextLabel` only sets `.text`. Three items were real:

- **Typed-return inheritance on overrides** — the compile-time risk across 260 scripts and a heavy virtual-override architecture. Import pass: exit 0, zero parse errors.
- **Control anchor/offset resolution** — covered by `test_modal_card_scaffold.gd`, which asserts viewport-fill and panel-centering geometry for all four modals (the guard #132 left behind). All pass.
- **Input device-ID renumbering** — see below.

## The input device-ID question

4.7 changed keyboard/mouse device IDs from `0` to `InputEvent.DEVICE_ID_KEYBOARD` (measured: **16**), and the importer did **not** rewrite the saved input map, which still carries `"device":0` on F1, F2 and the arrow-key camera halves. If `InputMap` filtered on device, those bindings would go dead silently — no error, the key just stops working, and invisible to all 1062 tests.

Probed directly on both engines with a throwaway script. Under 4.7.1, `InputMap` still matches **every** one of those bindings, alongside the `device: -1` control group (WASD, Space, F3). Left as authored rather than rewritten to `-1`, since the engine treats them as equivalent and a rewrite would be churn.

## Verification

| gate | result |
|---|---|
| `--headless --import` on 4.7.1 | exit 0, **zero** script/parse errors across 260 scripts |
| Full suite on 4.7.1 | **1062/1062**, 0 failures, 0 orphans, exit 0 |
| `fast` tier, no `GODOT_BIN` override | 222/222, exit 0 — proves the new hardcoded default resolves |
| UI suite (modal geometry, click path, dev keys) | 107/107, exit 0 |
| Input-map device probe | every binding matches |
| In-game visual check | confirmed by the dev |
| Linux CI | this PR |
| Export | pending — 4.7.1 templates installing |

## gdUnit4 stays on 6.2.0-rc1 — deliberately

The plan called for bumping to 6.2.x alongside the engine, as a separate first commit to isolate the variable. That isolation immediately earned its keep and the bump was **abandoned**.

gdUnit4 6.2.0 stable **fixed orphan detection**. Same engine, same tests, minutes apart:

| gdUnit4 | orphans | verdict |
|---|---|---|
| 6.2.0-rc1 | 0 | 0 — SUCCESS |
| 6.2.0 stable | **376** | **101 — WARNING** |

`report_exit_code()` is byte-identical in both, so the rule did not change — the counting did. Because it returns `WARNING(101)` for *any* orphan, and both `run_tests.ps1` and `tests.yml` exit on gdUnit4's verdict, the bump reddens a fully-passing suite with zero test failures.

Those are very likely **real leaks rc1 was blind to**, concentrated in the three full-game-scene suites (`test_game_scene_smoke` 256, `test_game_scene_without_dev_overlay` 30, `test_scenario_round_trip` 12). Filed separately — it is independent of this upgrade and does not belong in its diff.

## Rollback

`git checkout main` and launch the 4.6 binary, which is still installed at `C:\Godot\Godot_v4.6-stable_win64.exe\`. No half-migrated state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
