### PR TITLE
#146: zero executed test cases is a FAILURE, not a clean pass

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,20 @@ jobs:
             exit "$proc"
           fi
 
+          # ...AND THE VERDICT ONLY MEANS ANYTHING IF TESTS ACTUALLY RAN (#146). A suite that
+          # fails to LOAD runs zero tests, and gdUnit4 honestly reports "Exit code: 0" because
+          # nothing failed -- nothing ran. Without this, a parse error in a widely-depended-on
+          # production class drops every suite that touches it and CI still goes green.
+          # Mirrors the same guard in tests/run_tests.ps1 -- keep the two in step.
+          cases=$(grep -oE 'Executed test cases[[:space:]]*:[[:space:]]*\([0-9]+/[0-9]+\)' gdunit.log \
+                  | tail -1 | grep -oE '\([0-9]+' | grep -oE '[0-9]+' || true)
+
+          if [ -z "$cases" ] || [ "$cases" -eq 0 ]; then
+            echo "::error::ZERO test cases executed -- a suite failed to load, or the target matched nothing (#146)."
+            if [ "$proc" -eq 0 ]; then exit 1; fi
+            exit "$proc"
+          fi
+
           if [ "$proc" -ne "$verdict" ]; then
             echo "::warning::Engine crashed during shutdown after all tests ran and were counted (issue #93). Results are unaffected; reporting gdUnit4's verdict ($verdict), not the process exit ($proc)."
           fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,7 +37,7 @@ powershell -File tests\run_tests.ps1 res://tests/squad   # explicit path (back-c
 >
 > **Observation, 2026-07-27 (Unit.gd review session):** three consecutive full runs measured **19.5s / 19.9s / 20.9s** at 610–612 cases, hours after the 158s reading above and on the same machine. The session had just run `godot --headless --import` (to register a new `class_name`), and the speed persisted across later runs that did *not* re-import — a data point for the `.godot`-cache suspect. **The 153–158s figures above stand**: the slow behaviour keeps recurring and the fast state has not been shown to last. Treat this as "try an import pass before you accept a 2.5-minute loop", not as a new baseline.
 
-**Exit codes (from gdUnit4's `report_exit_code`):** `0` = clean pass · `100` = test failures **or** caught engine errors (e.g. a `push_error`/runtime error during a test) · `101` = passed but **orphan nodes** were detected. Treat anything non-zero as "fix it" — see orphan-node hygiene below.
+**Exit codes (from gdUnit4's `report_exit_code`):** `0` = clean pass · `100` = test failures **or** caught engine errors (e.g. a `push_error`/runtime error during a test) · `101` = passed but **orphan nodes** were detected. Treat anything non-zero as "fix it" — see orphan-node hygiene below. **And note `0` can lie too**: gdUnit4 reports it when zero tests ran, which is why the runner has a separate zero-cases guard (next block).
 
 > **The runner reports gdUnit4's verdict, not the process exit code** (changed 2026-07-29, [#93](https://github.com/Phaazoid/Godoiosis/issues/93)). Godot can die with an access violation *while tearing the engine down* — after every test has run and been counted — which made a clean pass report failure. `run_tests.ps1` now parses gdUnit4's own `Exit code: N` line and exits with that, printing a loud yellow NOTE when the process disagreed. This is strictly **more** truthful than trusting the process, in both directions:
 >
@@ -48,8 +48,24 @@ powershell -File tests\run_tests.ps1 res://tests/squad   # explicit path (back-c
 > | real test failure | 100 | **100** | the failures themselves |
 > | real failure + teardown crash | `-1073741819` | **100** | the failures themselves |
 > | crash *before* gdUnit4 reports | non-zero | **non-zero** | red "never reported a verdict" |
+> | **suite fails to LOAD** (parse error in a class it uses) | 105 | **non-zero** | red "ZERO test cases executed" |
 >
-> The last row is the safety property: a run that dies mid-flight produces no verdict line, and **no verdict is treated as failure** — the fix cannot swallow a genuine crash. Verified against all four cases, including a deliberate `OS.crash()` mid-suite.
+> The last two rows are the safety properties, and they are two different doors into the same room. A run that dies mid-flight produces no verdict line, and **no verdict is treated as failure**. A run whose suites never loaded produces a verdict of `0` that is *honest but meaningless* — nothing failed because nothing ran — so **zero executed cases is also treated as failure** ([#146](https://github.com/Phaazoid/Godoiosis/issues/146), fixed 2026-08-09). Together they mean the #93 override can only ever apply when its own premise holds: that every test really did run and get counted.
+>
+> **Why cases-executed and not the segfault exit code:** a #93 teardown crash happens *after* reporting, so it always prints `Executed test cases : (N/N)` with N > 0; a load failure never gets there. That discriminator is platform-independent, which matters because CI has to make the same call in bash.
+>
+> **Falsifying these guards** — do this rather than trusting the table, it is how #146 was found in the first place:
+>
+> ```
+> # 1. break a production class some suite depends on
+> #    append this line to Classes/ui/ModalCard.gd:   func _x( -> void:
+> powershell -File tests\run_tests.ps1 res://tests/ui/test_modal_card_scaffold.gd
+> #    -> MUST exit non-zero. Before #146 it exited 0 with "No test cases found" + "Exit code: 0".
+> # 2. put it back
+> git checkout -- Classes/ui/ModalCard.gd
+> ```
+>
+> Note a parse error in a **test** file behaves differently and was always caught: the run dies before any verdict is printed, so the no-verdict guard fires. The hole was specifically *test file fine, production dependency broken*.
 >
 > **CI carries the same logic** (`.github/workflows/tests.yml`), because it invokes Godot directly rather than through this script. The full-tree run happens not to trigger the crash today, but that masking is incidental — it depends on how many suites are loaded and shifts whenever anyone adds one. Keep the two in step: if you change the verdict rule here, change it there.
 

--- a/tests/run_tests.ps1
+++ b/tests/run_tests.ps1
@@ -101,6 +101,28 @@ if ($null -eq $verdict) {
 	exit $procCode
 }
 
+# ...AND THE VERDICT ONLY MEANS ANYTHING IF TESTS ACTUALLY RAN (#146). A suite that fails to
+# LOAD -- a parse error in a production class it depends on -- takes zero tests with it, and
+# gdUnit4 then honestly reports "No test cases found" + "Exit code: 0", because nothing failed:
+# nothing ran. The override above would discard the real non-zero process exit and call that a
+# clean pass, which is how a broken `Unit`/`SquadManager`/`game.gd` could redden nothing at all.
+#
+# The #93 override's whole premise is "every test already ran and was counted" -- so REQUIRE
+# that rather than assume it. Cases-executed is the discriminator because a #93 teardown crash
+# happens AFTER reporting (so N > 0), while a load failure never gets there (no line, or 0).
+# Chosen over matching the segfault exit code because this has to hold in bash for CI too.
+$casesRan = $null
+foreach ($line in $transcript) {
+	if ($line -match 'Executed test cases\s*:\s*\((\d+)/(\d+)\)') { $casesRan = [int]$Matches[1] }
+}
+
+if ($null -eq $casesRan -or $casesRan -eq 0) {
+	Write-Host ("Elapsed {0:N1}s  (gdUnit4 verdict {1}; process exit {2})" -f $sw.Elapsed.TotalSeconds, $verdict, $procCode) -ForegroundColor Cyan
+	Write-Error "ZERO test cases executed -- a suite failed to load, or the target matched nothing. Treating as FAILURE (#146)."
+	if ($procCode -eq 0) { exit 1 }
+	exit $procCode
+}
+
 if ($procCode -ne $verdict) {
 	Write-Host ("Elapsed {0:N1}s  (gdUnit4 verdict {1}; process exited {2})" -f $sw.Elapsed.TotalSeconds, $verdict, $procCode) -ForegroundColor Cyan
 	Write-Host "NOTE: the engine crashed while shutting down, after all tests had run and been counted (#93)." -ForegroundColor Yellow


### PR DESCRIPTION
Closes #146.

A parse error in a production class takes every dependent suite out of the run. gdUnit4 then runs zero tests and honestly reports `Exit code: 0` — nothing failed, because nothing ran — and `run_tests.ps1`'s #93 workaround discarded the real non-zero process exit and called it green.

Reproduced unchanged before the fix:

```
No test cases found, abort test run!
Exit code: 0
Elapsed 3.7s  (gdUnit4 verdict 0; process exited 105)
=== runner exit 0 ===          <- the bug
```

## Why it happened

Not "gdUnit4 is wrong" — the **#93 workaround meeting a case it was never scoped for.** It trusts gdUnit4's verdict over the process exit because Godot can segfault during teardown *after* every test ran. Its premise is that every test already ran and was counted. It never checked that. Now it does.

Two distinct abort paths in `GdUnitTestCIRunner.gd`, and only one was covered:

| path | prints | caught before? |
|---|---|---|
| script errors during discovery (`:384-390`) | "Abnormal exit with 105", **no verdict line** | yes — the existing no-verdict guard |
| no test cases found (`:392-396`) | "No test cases found", **`Exit code: 0`** | **no** — this is #146 |

## Why cases-executed, and not the segfault exit code

- A **#93** teardown crash happens *after* reporting, so it always prints `Executed test cases : (N/N)` with N > 0.
- A **load failure** never gets there — no line at all, or zero.

That cleanly separates the two, and it is **platform-independent**, which matters because CI has to make the same call in bash. Matching `-1073741819` / `139` would have needed two different rules.

## What is still not detectable — stated, not glossed

A suite that fails to load is never *discovered*, so it never enters the `(N/M)` totals at all. So a **partial** load failure — some suites run, one doesn't — still cannot be seen from these counts. The zero case is what is reliably detectable, and it is the case #146 filed. Worth knowing before anyone assumes this guard is broader than it is.

(Measured along the way: breaking a widely-depended-on class and running a whole area cascaded into a segfault with no verdict, so the *existing* guard caught it. That was luck — it depended on the cascade being violent enough to crash the engine.)

## Verification

**Falsified against #146's own bug — the gate.** Broke `Classes/ui/ModalCard.gd`, ran the modal suite:

```
No test cases found, abort test run!
Exit code: 0                                    <- gdUnit4, honest but meaningless
ZERO test cases executed -- a suite failed to load ... (#146)
=== RUNNER EXIT: 105 ===                        <- was 0 before this commit
```

| check | result |
|---|---|
| the bug, reintroduced | runner **105** (was **0**) ✔ |
| not merely always-red — full suite, clean tree | **1062/1062, runner exit 0** ✔ |
| the #93 override's own path | **not verified live** — see below |

**The #93 override was not exercised.** It only runs when the process exit disagrees with the verdict, and #93 would not reproduce on demand today: two attempts with its documented 4-line trigger — a lone suite, then a 2-suite area, the shapes it is *least* masked in — both exited cleanly on 4.7.1. So that path is verified **by inspection only**: the diff is a pure insertion above an untouched block, and the new guard provably parsed `casesRan > 0` on every healthy run, because it never fired. Saying so rather than implying it was tested.

If that inspection is wrong, the failure direction is the safe one: a genuine #93 run would be reported as a failure instead of passed — loud, not silent.

**Side observation, deliberately not a claim:** #93 not reproducing may just be the usual masking (it is known to hide as suite count changes), or 4.7.1 may have fixed it. Two clean runs is not evidence either way. Worth a look before anyone acts on it.

## Known duplication

The rule now exists twice — PowerShell in `tests/run_tests.ps1`, bash in `.github/workflows/tests.yml` — because the workflow invokes Godot directly rather than through the script. That is a Law #4 duplicate. Declaring it rather than pretending otherwise: the two must be kept in step, which `tests/README.md` already says of the verdict rule and now says of this one. Collapsing them would mean the workflow calling a shared script, which is its own change.

## Docs

`tests/README.md` gains the #146 row in the exit-code table, an explicit note that **`0` can lie too**, and the falsification procedure so this guard can be re-proven by hand rather than trusted:

```
# append `func _x( -> void:` to Classes/ui/ModalCard.gd
powershell -File tests\run_tests.ps1 res://tests/ui/test_modal_card_scaffold.gd
#   -> MUST exit non-zero
git checkout -- Classes/ui/ModalCard.gd
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
