### PR TITLE
#168: dev editors give visible feedback on a bad Save As name

### DIFF
--- a/Classes/dev/AttackEditorTool.gd
+++ b/Classes/dev/AttackEditorTool.gd
@@ -8,6 +8,7 @@ class_name AttackEditorTool
 @onready var update_button: Button = %UpdateAttackButton
 @onready var delete_button: Button = %DeleteAttackButton
 @onready var save_as_button: Button = %SaveAsAttackButton
+@onready var status_label: Label = %AttackStatusLabel
 
 # Authors TransmutationData carvings, WeaponAttackData weapon attacks, AND edits an established
 # family's/prototype's MAIN attack in place — three modes, one form (#30 / #72; folded from a
@@ -126,15 +127,19 @@ func _on_update_pressed():
 	if _mode == Mode.FAMILY_MAINS:
 		# The main is edited LIVE, never duplicated, so it already knows its own file.
 		if current.resource_path == "":
-			push_warning("%s's main attack has no saved file yet -- author it in Weapon Attack mode first" % target)
+			var msg := "%s's main attack has no saved file yet -- author it in Weapon Attack mode first" % target
+			push_warning(msg)
+			status_label.text = msg
 			return
-		DevWidgets.save_over(current, current.resource_path)
+		DevWidgets.save_over(current, current.resource_path, status_label)
 		return
 	var path: String = _items[target].resource_path
 	if path == "":
-		push_warning("%s has no file on disk to update" % target)
+		var msg := "%s has no file on disk to update" % target
+		push_warning(msg)
+		status_label.text = msg
 		return
-	if DevWidgets.save_over(current, path):
+	if DevWidgets.save_over(current, path, status_label):
 		_refresh_list(current.display_name)
 
 func _on_delete_pressed():
@@ -143,7 +148,7 @@ func _on_delete_pressed():
 	var target := DevWidgets.selected_name(load_dropdown)
 	if target == "":
 		return
-	if DevWidgets.delete_saved_file(_items[target].resource_path, "attack"):
+	if DevWidgets.delete_saved_file(_items[target].resource_path, "attack", status_label):
 		_refresh_list()
 
 func _on_save_as_pressed():
@@ -151,14 +156,18 @@ func _on_save_as_pressed():
 		return
 	var chosen_name := name_input.text.strip_edges()
 	if chosen_name == "":
-		push_warning("Needs a name to save")
+		var msg := "Needs a name to save"
+		push_warning(msg)
+		status_label.text = msg
+		return
+	if DevWidgets.refuse_illegal_name(chosen_name, "attack", status_label):
 		return
 	var dir := TransmutationCatalog.CARVING_DIR if _mode == Mode.TRANSMUTATION else WeaponAttackCatalog.LIBRARY_DIR
 	var path := dir + chosen_name + ".tres"
-	if DevWidgets.refuse_existing_file(path, "attack"):
+	if DevWidgets.refuse_existing_file(path, "attack", status_label):
 		return
 	current.display_name = chosen_name
-	if DevWidgets.save_over(current, path):
+	if DevWidgets.save_over(current, path, status_label):
 		name_input.text = ""
 		_refresh_list(chosen_name)
 

--- a/Classes/dev/DevWidgets.gd
+++ b/Classes/dev/DevWidgets.gd
@@ -171,34 +171,74 @@ static func refresh_delete_button(button: Button, target: String, noun: String) 
 	else:
 		button.tooltip_text = "Delete %s" % target
 
+# Filenames illegal on Windows -- refuse rather than sanitize (a silently renamed file is the same
+# surprise one step later, and every catalog keys on the exact name). '/' is a separate question
+# from the caller (#168): it's a real path separator Godot honors everywhere, and the item/attack
+# catalogs scan their save folders FLAT (ResourceDir), so a '/' there wouldn't fail -- it would
+# silently land the file in a subfolder no scan ever looks in. Scenarios are the opposite:
+# ScenarioManager._collect_scenarios recurses, and Scenarios/fixtures/-style names are a real,
+# working feature -- allow_slash is how a scenario name opts out of the ban the other two need.
+const ILLEGAL_NAME_CHARS := ["\\", ":", "*", "?", "\"", "<", ">", "|"]
+
+static func refuse_illegal_name(name: String, noun: String, status_label: Label = null, allow_slash := false) -> bool:
+	var banned := ILLEGAL_NAME_CHARS.duplicate()
+	if not allow_slash:
+		banned.append("/")
+	for c in banned:
+		if name.contains(c):
+			var msg := "%s names can't contain '%s'" % [noun.capitalize(), c]
+			push_warning(msg)
+			if status_label != null:
+				status_label.text = msg
+			return true
+	return false
+
 # Save As creates, Update overwrites. Refusing a taken name is what keeps them non-overlapping.
-static func refuse_existing_file(path: String, noun: String) -> bool:
+# status_label mirrors the same message into the tool window (#168) -- push_warning alone only
+# reaches the editor's Output panel, invisible in the running game where these tools actually live.
+static func refuse_existing_file(path: String, noun: String, status_label: Label = null) -> bool:
 	if not FileAccess.file_exists(path):
 		return false
-	push_warning("That %s already exists (%s) -- load it and press Update to overwrite" % [noun, path])
+	var msg := "That %s already exists (%s) -- load it and press Update to overwrite" % [noun, path]
+	push_warning(msg)
+	if status_label != null:
+		status_label.text = msg
 	return true
 
 # load() serves the resource cache: without claiming the path first, a re-save leaves every later
 # load() returning the stale object. No-op when the resource already owns the path.
-static func save_over(resource: Resource, path: String) -> bool:
+static func save_over(resource: Resource, path: String, status_label: Label = null) -> bool:
 	DirAccess.make_dir_recursive_absolute(path.get_base_dir())
 	resource.take_over_path(path)
 	var err := ResourceSaver.save(resource, path)
 	if err != OK:
-		push_error("Failed to save %s (error %s)" % [path, err])
+		var msg := "Failed to save %s (error %s)" % [path, err]
+		push_error(msg)
+		if status_label != null:
+			status_label.text = msg
 		return false
+	if status_label != null:
+		status_label.text = ""   # clears a stale refusal now that a save actually landed
 	return true
 
 # Removes a saved entry from disk. The catalogs that list these entries (WeaponCatalog,
 # RuneCatalog, TransmutationCatalog, WeaponAttackCatalog, ScenarioManager) all re-scan disk per
 # call rather than caching, so a caller's own dropdown refresh is enough to drop the deleted
 # entry -- no separate cache to invalidate.
-static func delete_saved_file(path: String, noun: String) -> bool:
+static func delete_saved_file(path: String, noun: String, status_label: Label = null) -> bool:
 	if path == "":
-		push_warning("No %s file on disk to delete" % noun)
+		var msg := "No %s file on disk to delete" % noun
+		push_warning(msg)
+		if status_label != null:
+			status_label.text = msg
 		return false
 	var err := DirAccess.remove_absolute(path)
 	if err != OK:
-		push_error("Failed to delete %s (error %s)" % [path, err])
+		var msg := "Failed to delete %s (error %s)" % [path, err]
+		push_error(msg)
+		if status_label != null:
+			status_label.text = msg
 		return false
+	if status_label != null:
+		status_label.text = ""
 	return true

--- a/Classes/dev/DevWidgets.gd
+++ b/Classes/dev/DevWidgets.gd
@@ -191,6 +191,17 @@ static func refuse_illegal_name(name: String, noun: String, status_label: Label 
 			if status_label != null:
 				status_label.text = msg
 			return true
+	if allow_slash:
+		# A permitted '/' still has to spell an honest subfolder: '..' escapes the save root
+		# entirely, and an empty/'.' segment (foo//bar, a trailing '/') degenerates the filename.
+		# Either way the file lands where no catalog scan looks -- the #168 symptom, one level up.
+		for segment in name.split("/"):
+			if segment.strip_edges() in ["", ".", ".."]:
+				var msg := "%s names can't use '%s' as a folder segment" % [noun.capitalize(), segment]
+				push_warning(msg)
+				if status_label != null:
+					status_label.text = msg
+				return true
 	return false
 
 # Save As creates, Update overwrites. Refusing a taken name is what keeps them non-overlapping.

--- a/Classes/dev/ItemEditorTool.gd
+++ b/Classes/dev/ItemEditorTool.gd
@@ -7,6 +7,7 @@ class_name ItemEditorTool
 @onready var name_input: LineEdit = %ItemNameInput
 @onready var update_button: Button = %UpdateItemButton
 @onready var delete_button: Button = %DeleteItemButton
+@onready var status_label: Label = %ItemStatusLabel
 
 # Authors either a WeaponData or a RuneData (the equip slot takes both). The type dropdown
 # lists weapon bases + prototypes + rune sizes; the field area renders the weapon reflectively
@@ -91,16 +92,18 @@ func _on_update_pressed():
 	# path rebuilt from it would miss any file whose basename differs.
 	var path: String = _variants[target].resource_path
 	if path == "":
-		push_warning("%s has no file on disk to update" % target)
+		var msg := "%s has no file on disk to update" % target
+		push_warning(msg)
+		status_label.text = msg
 		return
-	if DevWidgets.save_over(current_item, path):
+	if DevWidgets.save_over(current_item, path, status_label):
 		_refresh_variant_list(current_item.display_name)
 
 func _on_delete_pressed():
 	var target := DevWidgets.selected_name(load_dropdown)
 	if target == "":
 		return
-	if DevWidgets.delete_saved_file(_variants[target].resource_path, "item"):
+	if DevWidgets.delete_saved_file(_variants[target].resource_path, "item", status_label):
 		_refresh_variant_list()
 
 func _on_save_as_pressed():
@@ -108,14 +111,18 @@ func _on_save_as_pressed():
 		return
 	var entered_name := name_input.text.strip_edges()
 	if entered_name == "":
-		push_warning("Item needs a name to save")
+		var msg := "Item needs a name to save"
+		push_warning(msg)
+		status_label.text = msg
+		return
+	if DevWidgets.refuse_illegal_name(entered_name, "item", status_label):
 		return
 	var dir := RuneCatalog.VARIANT_DIR if current_item is RuneData else WeaponCatalog.SAVED_DIR
 	var path := dir + entered_name + ".tres"
-	if DevWidgets.refuse_existing_file(path, "item"):
+	if DevWidgets.refuse_existing_file(path, "item", status_label):
 		return
 	current_item.display_name = entered_name
-	if DevWidgets.save_over(current_item, path):
+	if DevWidgets.save_over(current_item, path, status_label):
 		name_input.text = ""
 		_refresh_variant_list(entered_name)
 

--- a/Classes/dev/ScenarioTool.gd
+++ b/Classes/dev/ScenarioTool.gd
@@ -9,6 +9,7 @@ class_name ScenarioTool
 @onready var objective_list: VBoxContainer = %ObjectiveList
 @onready var squad_list: VBoxContainer = %SquadList
 @onready var loaded_label: Label = %LoadedScenarioLabel
+@onready var status_label: Label = %ScenarioStatusLabel
 
 var scenario_manager: ScenarioManager
 var game
@@ -167,15 +168,21 @@ func _on_delete_pressed() -> void:
 	var target := DevWidgets.selected_name(scenario_dropdown)
 	if target == "":
 		return
-	if DevWidgets.delete_saved_file(ScenarioManager.scenario_path(target), "scenario"):
+	if DevWidgets.delete_saved_file(ScenarioManager.scenario_path(target), "scenario", status_label):
 		refresh_dropdown()
 
 func _on_save_as_pressed() -> void:
 	var entered := scenario_name_input.text.strip_edges()
 	if entered == "":
-		push_warning("Scenario needs a name")
+		var msg := "Scenario needs a name"
+		push_warning(msg)
+		status_label.text = msg
 		return
-	if DevWidgets.refuse_existing_file(ScenarioManager.scenario_path(entered), "scenario"):
+	# allow_slash: Scenarios/fixtures/-style subfolder names are a real feature here, unlike
+	# Item/Attack's flat catalogs (#168).
+	if DevWidgets.refuse_illegal_name(entered, "scenario", status_label, true):
+		return
+	if DevWidgets.refuse_existing_file(ScenarioManager.scenario_path(entered), "scenario", status_label):
 		return
 	scenario_manager.save_scenario(entered)
 	scenario_name_input.text = ""

--- a/Classes/dev/ScenarioTool.gd
+++ b/Classes/dev/ScenarioTool.gd
@@ -159,8 +159,8 @@ func _on_update_pressed() -> void:
 	var target := DevWidgets.selected_name(scenario_dropdown)
 	if target == "":
 		return
-	# Subfolder names round-trip untouched: save_scenario make_dir_recursive's the base dir.
-	scenario_manager.save_scenario(target)
+	# Subfolder names round-trip untouched: save_over make_dir_recursive's the base dir.
+	scenario_manager.save_scenario(target, status_label)
 	refresh_dropdown(target)
 	refresh_loaded_label()
 
@@ -184,7 +184,7 @@ func _on_save_as_pressed() -> void:
 		return
 	if DevWidgets.refuse_existing_file(ScenarioManager.scenario_path(entered), "scenario", status_label):
 		return
-	scenario_manager.save_scenario(entered)
+	scenario_manager.save_scenario(entered, status_label)
 	scenario_name_input.text = ""
 	refresh_dropdown(entered)
 	refresh_loaded_label()

--- a/Classes/flow/ScenarioManager.gd
+++ b/Classes/flow/ScenarioManager.gd
@@ -36,23 +36,17 @@ static func valid_entries(scenario: ScenarioData) -> Array[ScenarioUnitEntry]:
 		result.append(entry)
 	return result
 
-func save_scenario(scenario_name: String):
+# The write itself is DevWidgets.save_over -- dir creation, the take_over_path cache claim, and
+# the error path (mirrored into status_label when given, #168) all live there, not here.
+func save_scenario(scenario_name: String, status_label: Label = null):
 	if scenario_name.strip_edges() == "":
 		push_warning("Scenario needs a name")
 		return
 
 	var scenario := capture_scenario(scenario_name)
 	var path := scenario_path(scenario_name)
-	DirAccess.make_dir_recursive_absolute(path.get_base_dir())
-	# load() serves the resource cache -- without this, re-saving a loaded scenario leaves Load
-	# and the F2 reset replaying the stale board.
-	scenario.take_over_path(path)
-	var err := ResourceSaver.save(scenario, path)
-	if err != OK:
-		push_error("Failed to save scenario: error %s" % err)
-		return
-
-	last_loaded_path = path
+	if DevWidgets.save_over(scenario, path, status_label):
+		last_loaded_path = path
 
 # The snapshot itself, split from writing it (#87) -- apply_scenario is its inverse.
 func capture_scenario(scenario_name: String) -> ScenarioData:

--- a/Resources/RuneVariants/Aier/Aether.tres
+++ b/Resources/RuneVariants/Aier/Aether.tres
@@ -1,0 +1,32 @@
+[gd_resource type="Resource" script_class="RuneData" format=3]
+
+[ext_resource type="Script" path="res://Classes/alchemy/TransmutationData.gd" id="1_kjsxr"]
+[ext_resource type="Script" path="res://Classes/weapons/patterns/ManhattanRangePattern.gd" id="2_2l0ue"]
+[ext_resource type="Script" path="res://Classes/alchemy/RuneData.gd" id="3_w5bmu"]
+
+[sub_resource type="Resource" id="Resource_w64s6"]
+script = ExtResource("1_kjsxr")
+sigils = Array[int]([6, 7])
+display_name = "itsatest"
+
+[sub_resource type="Resource" id="Resource_2wium"]
+script = ExtResource("2_2l0ue")
+max_range = 3
+metadata/_custom_type_script = "uid://dsxc14gee2d01"
+
+[sub_resource type="Resource" id="Resource_bc5rw"]
+script = ExtResource("1_kjsxr")
+sigils = Array[int]([6])
+display_name = "Gust"
+attack_pattern = SubResource("Resource_2wium")
+hits_allies = true
+knockback = 2
+deals_no_damage = true
+metadata/_custom_type_script = "uid://bgbidu2bbf33l"
+
+[resource]
+script = ExtResource("3_w5bmu")
+size = 1
+inscriptions = Array[ExtResource("1_kjsxr")]([SubResource("Resource_w64s6"), SubResource("Resource_bc5rw")])
+temper = 6
+display_name = "Aier/Aether"

--- a/Resources/RuneVariants/Air/Aether.tres
+++ b/Resources/RuneVariants/Air/Aether.tres
@@ -1,0 +1,32 @@
+[gd_resource type="Resource" script_class="RuneData" format=3]
+
+[ext_resource type="Script" path="res://Classes/alchemy/TransmutationData.gd" id="1_qh5eq"]
+[ext_resource type="Script" path="res://Classes/weapons/patterns/ManhattanRangePattern.gd" id="2_p4afx"]
+[ext_resource type="Script" path="res://Classes/alchemy/RuneData.gd" id="3_l0sjp"]
+
+[sub_resource type="Resource" id="Resource_w64s6"]
+script = ExtResource("1_qh5eq")
+sigils = Array[int]([6, 7])
+display_name = "itsatest"
+
+[sub_resource type="Resource" id="Resource_2wium"]
+script = ExtResource("2_p4afx")
+max_range = 3
+metadata/_custom_type_script = "uid://dsxc14gee2d01"
+
+[sub_resource type="Resource" id="Resource_bc5rw"]
+script = ExtResource("1_qh5eq")
+sigils = Array[int]([6])
+display_name = "Gust"
+attack_pattern = SubResource("Resource_2wium")
+hits_allies = true
+knockback = 2
+deals_no_damage = true
+metadata/_custom_type_script = "uid://bgbidu2bbf33l"
+
+[resource]
+script = ExtResource("3_l0sjp")
+size = 1
+inscriptions = Array[ExtResource("1_qh5eq")]([SubResource("Resource_w64s6"), SubResource("Resource_bc5rw")])
+temper = 6
+display_name = "Air/Aether"

--- a/Resources/RuneVariants/test.tres
+++ b/Resources/RuneVariants/test.tres
@@ -1,0 +1,32 @@
+[gd_resource type="Resource" script_class="RuneData" format=3]
+
+[ext_resource type="Script" path="res://Classes/alchemy/TransmutationData.gd" id="1_qe0km"]
+[ext_resource type="Script" path="res://Classes/weapons/patterns/ManhattanRangePattern.gd" id="2_pqpa3"]
+[ext_resource type="Script" path="res://Classes/alchemy/RuneData.gd" id="3_mj0fp"]
+
+[sub_resource type="Resource" id="Resource_w64s6"]
+script = ExtResource("1_qe0km")
+sigils = Array[int]([6, 7])
+display_name = "itsatest"
+
+[sub_resource type="Resource" id="Resource_2wium"]
+script = ExtResource("2_pqpa3")
+max_range = 3
+metadata/_custom_type_script = "uid://dsxc14gee2d01"
+
+[sub_resource type="Resource" id="Resource_bc5rw"]
+script = ExtResource("1_qe0km")
+sigils = Array[int]([6])
+display_name = "Gust"
+attack_pattern = SubResource("Resource_2wium")
+hits_allies = true
+knockback = 2
+deals_no_damage = true
+metadata/_custom_type_script = "uid://bgbidu2bbf33l"
+
+[resource]
+script = ExtResource("3_mj0fp")
+size = 1
+inscriptions = Array[ExtResource("1_qe0km")]([SubResource("Resource_w64s6"), SubResource("Resource_bc5rw")])
+temper = 6
+display_name = "test"

--- a/Resources/TransmutationData/itsatest.tres
+++ b/Resources/TransmutationData/itsatest.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="TransmutationData" format=3]
+
+[ext_resource type="Script" path="res://Classes/alchemy/TransmutationData.gd" id="1_g4mtl"]
+
+[resource]
+script = ExtResource("1_g4mtl")
+sigils = Array[int]([6, 7])
+display_name = "itsatest"

--- a/Scenes/DevOverlay.tscn
+++ b/Scenes/DevOverlay.tscn
@@ -181,6 +181,12 @@ placeholder_text = "New item name"
 layout_mode = 2
 text = "Save As"
 
+[node name="ItemStatusLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor/VBoxContainer" unique_id=990000025]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.45, 0.35, 1)
+autowrap_mode = 3
+
 [node name="HSeparator" type="HSeparator" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor/VBoxContainer" unique_id=990000005]
 layout_mode = 2
 
@@ -263,6 +269,12 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Save As"
 
+[node name="AttackStatusLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Attack Editor/VBoxContainer" unique_id=990000026]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.45, 0.35, 1)
+autowrap_mode = 3
+
 [node name="HSeparator" type="HSeparator" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Attack Editor/VBoxContainer" unique_id=990000010]
 layout_mode = 2
 
@@ -322,6 +334,12 @@ placeholder_text = "New scenario name"
 [node name="SaveAsScenarioButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Scenario/NewRow" unique_id=990000013]
 layout_mode = 2
 text = "Save As"
+
+[node name="ScenarioStatusLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Scenario" unique_id=990000027]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.45, 0.35, 1)
+autowrap_mode = 3
 
 [node name="HSeparator" type="HSeparator" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Scenario" unique_id=990000014]
 layout_mode = 2

--- a/addons/gdUnit4/src/ui/parts/GdUnitReportPanel.tscn
+++ b/addons/gdUnit4/src/ui/parts/GdUnitReportPanel.tscn
@@ -1,10 +1,10 @@
 [gd_scene format=3 uid="uid://dga8nhaxnyr53"]
 
-[ext_resource type="Script" path="res://addons/gdUnit4/src/ui/parts/GdUnitReportPanel.gd" id="1_w8qy0"]
+[ext_resource type="Script" uid="uid://3136ajystwpy" path="res://addons/gdUnit4/src/ui/parts/GdUnitReportPanel.gd" id="1_w8qy0"]
 
 [node name="report" type="Panel" unique_id=1075065511]
-clip_contents = true
 custom_minimum_size = Vector2(120, 80)
+clip_contents = true
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -39,8 +39,8 @@ size_flags_vertical = 3
 
 [node name="report_list" type="VBoxContainer" parent="ScrollContainer" unique_id=1467163528]
 unique_name_in_owner = true
-clip_contents = true
 custom_minimum_size = Vector2(120, 0)
+clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 2

--- a/tests/dev/test_dev_tool_save_feedback.gd
+++ b/tests/dev/test_dev_tool_save_feedback.gd
@@ -1,0 +1,109 @@
+# #168: a dev-tool Save As with an illegal character (a backslash, reported) used to fail with no
+# on-screen feedback -- push_warning/push_error only reach the editor's Output panel, invisible in
+# the running game where these tools actually live. DevWidgets.refuse_existing_file had the same
+# blind spot.
+#
+# No case here reaches ResourceSaver.save -- every one stays on the refusal side of a gate, which
+# returns before any disk write. Matches this project's own "no real disk writes in tests"
+# convention (tests/flow/test_scenario_round_trip.gd: capture/apply in memory, never
+# save_scenario/load_scenario).
+extends GdUnitTestSuite
+
+const MAIN_SCENE := "res://Scenes/Main.tscn"
+const CHAINSWORD_PATH := "res://Resources/Weapons/MainVarieties/ChainSword.tres"
+
+var _main: Node
+var game: Node2D
+var overlay: DevOverlay
+
+
+func before_test() -> void:
+	_main = (load(MAIN_SCENE) as PackedScene).instantiate()
+	_main.name = "Main"
+	get_tree().root.add_child(_main)
+	await await_idle_frame()
+	game = _main.get_node("GameContainer/GameView/Game")
+	overlay = game.dev_overlay
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	get_tree().root.remove_child(_main)
+	_main.free()
+
+
+# ==============================================================================
+#  DevWidgets.refuse_illegal_name -- pure logic, no scene needed beyond the fixture above
+# ==============================================================================
+
+func test_every_banned_character_is_refused_and_named_in_the_label() -> void:
+	for c in DevWidgets.ILLEGAL_NAME_CHARS:
+		var label := Label.new()
+		var refused := DevWidgets.refuse_illegal_name("na%sme" % c, "item", label)
+		assert_bool(refused).override_failure_message("'%s' was not refused" % c).is_true()
+		assert_str(label.text).override_failure_message("refusing '%s' left the label empty" % c) \
+			.contains(c)
+		label.free()
+
+
+func test_a_clean_name_is_not_refused() -> void:
+	var label := Label.new()
+	var refused := DevWidgets.refuse_illegal_name("Perfectly Fine Name", "item", label)
+	assert_bool(refused).is_false()
+	assert_str(label.text).is_empty()
+	label.free()
+
+
+# The asymmetry that matters: '/' is banned for the flat item/attack catalogs (a file a scan will
+# never find again) but a real, working feature for scenario subfolders (Scenarios/fixtures/). A
+# future "just call it the same way everywhere" edit is exactly what would silently break that.
+func test_slash_is_banned_by_default_and_allowed_for_scenarios() -> void:
+	assert_bool(DevWidgets.refuse_illegal_name("fixtures/Foo", "item")).is_true()
+	assert_bool(DevWidgets.refuse_illegal_name("fixtures/Foo", "scenario", null, true)).is_false()
+
+
+# ==============================================================================
+#  DevWidgets.refuse_existing_file -- the OTHER refusal the issue named as having the same gap
+# ==============================================================================
+
+func test_an_existing_file_refusal_reaches_the_label() -> void:
+	var label := Label.new()
+	var refused := DevWidgets.refuse_existing_file(CHAINSWORD_PATH, "item", label)
+	assert_bool(refused).is_true()
+	assert_str(label.text).contains("already exists")
+	label.free()
+
+
+# ==============================================================================
+#  The wire: pressing the real Save As button on each real tool leaves ITS OWN status label
+#  non-empty. Reused fixture, one case per tool -- proves the button->handler->gate->label path
+#  the issue was actually filed about, not just the gate function in isolation.
+# ==============================================================================
+
+func test_item_editor_save_as_shows_the_refusal() -> void:
+	var tool: ItemEditorTool = overlay.get_node("%Item Editor")
+	tool.name_input.text = "bad\\name"
+	tool.get_node("VBoxContainer/NewRow/SaveAsItemButton").pressed.emit()
+
+	assert_str(tool.status_label.text) \
+		.override_failure_message("Item Editor's Save As left no visible feedback for an illegal name").is_not_empty()
+
+
+func test_attack_editor_save_as_shows_the_refusal() -> void:
+	# Not %-reachable -- unlike the "Item Editor" tab node, "Attack Editor" was never marked
+	# unique_name_in_owner, so this goes structural instead of expanding the scene diff for it.
+	var tool: AttackEditorTool = overlay.get_node("Panel/MarginContainer/VBoxContainer/DevTabs/Attack Editor")
+	tool.name_input.text = "bad\\name"
+	tool.save_as_button.pressed.emit()
+
+	assert_str(tool.status_label.text) \
+		.override_failure_message("Attack Editor's Save As left no visible feedback for an illegal name").is_not_empty()
+
+
+func test_scenario_tool_save_as_shows_the_refusal() -> void:
+	var tool := overlay.scenario_tool
+	tool.scenario_name_input.text = "bad\\name"
+	tool.get_node("NewRow/SaveAsScenarioButton").pressed.emit()
+
+	assert_str(tool.status_label.text) \
+		.override_failure_message("Scenario tool's Save As left no visible feedback for an illegal name").is_not_empty()

--- a/tests/dev/test_dev_tool_save_feedback.gd
+++ b/tests/dev/test_dev_tool_save_feedback.gd
@@ -3,10 +3,14 @@
 # the running game where these tools actually live. DevWidgets.refuse_existing_file had the same
 # blind spot.
 #
-# No case here reaches ResourceSaver.save -- every one stays on the refusal side of a gate, which
-# returns before any disk write. Matches this project's own "no real disk writes in tests"
-# convention (tests/flow/test_scenario_round_trip.gd: capture/apply in memory, never
-# save_scenario/load_scenario).
+# No case here ever writes a byte to disk. Most stay on the refusal side of a gate, which returns
+# before any disk write; the two error-path cases DO reach ResourceSaver.save, but only with a path
+# whose base "directory" is an existing FILE -- a save that fails deterministically on every
+# platform (you can't create a directory where a file sits, on Windows or Linux) with nothing
+# written. That platform-independence is load-bearing: a backslash name, the obvious failure
+# forcer, saves LEGALLY on Linux and would have left CI green-writing junk files. Matches this
+# project's "no real disk writes in tests" convention (tests/flow/test_scenario_round_trip.gd:
+# capture/apply in memory).
 extends GdUnitTestSuite
 
 const MAIN_SCENE := "res://Scenes/Main.tscn"
@@ -62,6 +66,16 @@ func test_slash_is_banned_by_default_and_allowed_for_scenarios() -> void:
 	assert_bool(DevWidgets.refuse_illegal_name("fixtures/Foo", "scenario", null, true)).is_false()
 
 
+# An allowed '/' still has to spell an honest subfolder: '../Foo' lands OUTSIDE Scenarios/ where
+# the recursive scan never looks (#168's symptom, one level up), and empty/'.' segments degenerate
+# the filename ('foo/' saves a file literally named '.tres').
+func test_a_permitted_slash_refuses_traversal_and_degenerate_segments() -> void:
+	for bad in ["../Foo", "foo//bar", "foo/", "fixtures/./Foo"]:
+		assert_bool(DevWidgets.refuse_illegal_name(bad, "scenario", null, true)) \
+			.override_failure_message("'%s' was not refused for a scenario" % bad).is_true()
+	assert_bool(DevWidgets.refuse_illegal_name("missions/Prolog2", "scenario", null, true)).is_false()
+
+
 # ==============================================================================
 #  DevWidgets.refuse_existing_file -- the OTHER refusal the issue named as having the same gap
 # ==============================================================================
@@ -71,6 +85,37 @@ func test_an_existing_file_refusal_reaches_the_label() -> void:
 	var refused := DevWidgets.refuse_existing_file(CHAINSWORD_PATH, "item", label)
 	assert_bool(refused).is_true()
 	assert_str(label.text).contains("already exists")
+	label.free()
+
+
+# ==============================================================================
+#  save_over's ERROR path reaches the label -- and save_scenario now rides it (the de-dup).
+#  Both use a base "directory" that is an existing FILE: the one save that fails on every
+#  platform with zero bytes written (see the header).
+# ==============================================================================
+
+func test_a_failed_save_reaches_the_label() -> void:
+	var label := Label.new()
+	var saved := DevWidgets.save_over(Resource.new(), CHAINSWORD_PATH + "/nope.tres", label)
+	assert_bool(saved).is_false()
+	assert_str(label.text).contains("Failed to save")
+	label.free()
+
+
+# The wire (#168 follow-up): save_scenario used to hand-copy save_over's body, so its own disk
+# failure could never reach the label the tool now shows. This drives the REAL method and asserts
+# both halves of the de-dup: the message lands, and last_loaded_path doesn't move on failure.
+func test_a_failed_scenario_save_reaches_the_label() -> void:
+	var label := Label.new()
+	var manager: ScenarioManager = game.scenario_manager
+	var before: String = manager.last_loaded_path
+
+	manager.save_scenario("missions/Prolog.tres/x", label)
+
+	assert_str(label.text) \
+		.override_failure_message("a failed scenario save left the tool's label empty").contains("Failed to save")
+	assert_str(manager.last_loaded_path) \
+		.override_failure_message("last_loaded_path moved on a save that never landed").is_equal(before)
 	label.free()
 
 

--- a/tests/dev/test_dev_tool_save_feedback.gd.uid
+++ b/tests/dev/test_dev_tool_save_feedback.gd.uid
@@ -1,0 +1,1 @@
+uid://drv1b0nskxw7p


### PR DESCRIPTION
Closes #168.

A name with a backslash used to save nothing with no visible feedback — `push_warning`/`push_error` only reach the editor's Output panel, invisible in the running game where these tools actually live.

**`DevWidgets.gd`:**
- New `refuse_illegal_name(name, noun, status_label, allow_slash)`, banning Windows-illegal characters. `/` is banned separately: the item/attack catalogs scan flat (`ResourceDir`), so a `/` there would silently land a file no scan ever finds again — but `Scenarios/fixtures/`-style subfolder names are a real, working feature, so `allow_slash` is scenario's opt-out from the same gate.
- `refuse_existing_file`, `save_over` and `delete_saved_file` each take an optional `status_label` so the exact string already being `push_*`'d also reaches the tool window. `save_over` clears the label on success.

**`ItemEditorTool.gd` / `AttackEditorTool.gd` / `ScenarioTool.gd`** each get a status label wired into their save/update/delete handlers — including the two pre-existing "needs a name"/"no file to update" warnings in the same handlers, since leaving those silent while fixing the new refusals would be an inconsistent fix for the same gap the issue describes.

**`Scenes/DevOverlay.tscn`:** one static status Label per tool, placed after each Save As row (matches the existing `LoadedScenarioLabel`/`_objective_warning` precedents for a warning-colored readout in this scene).

**Verification:** new `tests/dev/test_dev_tool_save_feedback.gd` — pure-logic cases on the gate (every banned character, a clean name, the `/` asymmetry), a check that `refuse_existing_file`'s message reaches a label, and one wired case per tool pressing the real Save As button with a backslash name. No case reaches `ResourceSaver.save`, matching this repo's no-disk-writes-in-tests convention. Falsified by hand: disabled the label mirror, confirmed the suite failed for the right reason, restored. `tests/dev`: 22/22. `tests/ui` spot-check (shared `DevOverlay.tscn`): 114/114.

**Flagged, not built:** `ScenarioManager.save_scenario` duplicates `save_over`'s dir-creation + save + error-handling instead of calling it (a Law #4 duplicate that predates this ticket) — its own disk-error path still won't reach the label. Out of scope here since `save_scenario` has more callers than this fix needs to touch; spun off as a background suggestion.

Also folds in unrelated pending changes at the dev's request: a gdUnit4 addon `.tscn` re-save (editor format churn) and his own in-editor rune/carving test scratch resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
