### PR TITLE
Tuning-value sweep: no test may break when a named knob moves

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -89,6 +89,12 @@ powershell -File tests\run_tests.ps1 res://tests/squad   # explicit path (back-c
 
 7. **Run it:** `powershell -File tests\run_tests.ps1 res://tests/<your-folder>`. On a large run, redirect to a file and search it (`... *> out.txt`) rather than trusting a truncated terminal capture. Always re-run after fixing a failure — see the truncation gotcha below.
 
+8. **The tuning razor (dev rule, 2026-08-10 — #118 and the sweep that followed): a test may not break when a NAMED tunable constant moves; it may break when a function body changes.** *"I don't want any tests that test what these values are, only that they work."* In practice:
+   - **Never hard-code a knob's current value** into an expectation, an input whose *meaning* is its position relative to a threshold, or a tick/loop count. Read the constant (`Squad.MEMBER_LDR_COST`, `Stats.DEX_MOV_MID_MAX + 1`, `TerrainStateManager.STATE_DURATIONS[state]`), derive the expectation from it, or assert a relationship (`is_greater`, before-vs-after) instead of a number. `contains(str(CONST))` is the pattern for status strings.
+   - **A fixture that inherits a tunable default is a trap** — author the knob-dependent input explicitly (the cohesion suite's `FIXTURE_COH`), or derive it (`2 * Squad.MEMBER_LDR_COST`). Where a case's premise depends on a knob relationship, **assert the premise** so a retune fails loudly as a fixture problem, not silently as a phantom mechanism bug.
+   - **What stays literal:** values in function *bodies* (band rung heights, the MOV floor of 1) — retuning those means editing the mechanism, where a red test is ordinary regression semantics — and authored fixture content a test constructs itself.
+   - Verified by **retune matrix** (2026-08-10): `CON_DEF_FACTOR`, `STATE_DURATIONS`, `MEMBER_LDR_COST`, and the band thresholds were each moved and the full suite stayed green. `JOBLESS_MOV_BASE` is the known exception: the AI/cohesion **board-geometry fixtures** are authored relative to global mobility (what's "out of reach" at MOV 4 isn't at MOV 6), so a mobility retune legitimately demands a fixture pass — the same pass the game's real scenario boards would need.
+
 ## Gotchas (learned the hard way — don't re-discover)
 
 - **Use the `_console.exe`** Godot build on Windows, or you capture no stdout.

--- a/tests/items/test_armor_equip.gd
+++ b/tests/items/test_armor_equip.gd
@@ -7,6 +7,13 @@ extends GdUnitTestSuite
 const H := preload("res://tests/support/squad_fixtures.gd")
 
 
+# What a worn piece pays out on this unit's body, through the stat doctrine -- never a literal
+# (2026-08-10 sweep: the payout rides CON_DEF_FACTOR, which is playtest-tunable; this file's
+# cases are about the SLOT mechanics, so a factor retune must not touch them).
+func _payout(def_power: int, unit: Unit) -> int:
+	return Stats.armor_def(def_power, unit.get_effective_stat(Stats.Stat.CON))
+
+
 func _vest(def_power: int = 2) -> ArmorData:
 	var armor := ArmorData.new()
 	armor.display_name = "Test Vest"
@@ -77,7 +84,8 @@ func test_a_unit_wears_armor_and_wields_a_weapon_at_once() -> void:
 
 	assert_object(unit.get_equipped_weapon()).is_same(weapon)
 	assert_object(unit.worn_armor).is_same(unit.inventory[1])
-	assert_int(unit.get_effective_def()).is_equal(2)
+	assert_int(unit.get_effective_def()).is_equal(_payout(2, unit))
+	assert_int(unit.get_effective_def()).is_greater(0)   # premise: the vest pays out at all
 
 
 # --- the gate lives at the one chokepoint ---
@@ -123,7 +131,7 @@ func test_tossing_worn_armor_stops_granting_def() -> void:
 	var unit: Unit = H.spawn_unit(self, Team.Faction.PLAYER, Vector2i.ZERO, {}, false)
 	unit.add_item(_vest())
 	unit.wear_armor(0)
-	assert_int(unit.get_effective_def()).is_equal(2)
+	assert_int(unit.get_effective_def()).is_equal(_payout(2, unit))
 
 	unit.remove_item(0)
 	assert_object(unit.worn_armor).is_null()
@@ -139,7 +147,7 @@ func test_tossing_a_weapon_leaves_worn_armor_alone() -> void:
 
 	unit.remove_item(0)
 	assert_object(unit.worn_armor).is_not_null()
-	assert_int(unit.get_effective_def()).is_equal(2)
+	assert_int(unit.get_effective_def()).is_equal(_payout(2, unit))
 
 
 func test_swapping_armor_replaces_rather_than_stacks() -> void:
@@ -150,4 +158,4 @@ func test_swapping_armor_replaces_rather_than_stacks() -> void:
 	unit.wear_armor(1)
 
 	assert_object(unit.worn_armor).is_same(unit.inventory[1])
-	assert_int(unit.get_effective_def()).is_equal(4)   # the second piece only, never 2 + 4
+	assert_int(unit.get_effective_def()).is_equal(_payout(4, unit))   # the second piece only, never both

--- a/tests/law/test_def_mitigation.gd
+++ b/tests/law/test_def_mitigation.gd
@@ -52,14 +52,18 @@ func _attack(attacker: Unit, target: Unit) -> AttackAction:
 func test_def_subtracts_from_damage() -> void:
 	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.STR: 4})
 	var target := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.MHP: 20, Stats.Stat.CON: 5})
-	target.worn_armor = _make_armor(4)   # DEF 4 at CON 5 (armor_def(4,5) == 4)
+	target.worn_armor = _make_armor(4)
 
 	var attack := _attack(attacker, target)   # base 10 (power 6 + STR 4)
 	var plan := ResolvedPlan.new()
 	plan.attacks.append(attack)
 	PlanResolver.resolve(plan)
 
-	assert_int(attack.resolved.damage).is_equal(6)   # 10 - 4 DEF
+	# Expected DEF through the readout seam, never a literal (2026-08-10 sweep): the armor term
+	# rides CON_DEF_FACTOR, which is playtest-tunable. Readout == subtraction is this file's own
+	# doctrine (see the header + test_def_breakdown_total_is_what_the_resolver_subtracts).
+	assert_int(attack.resolved.damage).is_equal(10 - target.get_effective_def())
+	assert_int(target.get_effective_def()).is_greater(0)   # premise: the piece pays out at all
 
 
 func test_naked_target_takes_full_damage() -> void:
@@ -92,6 +96,9 @@ func test_def_never_drives_damage_below_zero() -> void:
 	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.STR: 4})
 	var target := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.MHP: 20, Stats.Stat.CON: 5})
 	target.worn_armor = _make_armor(40)   # DEF far above the incoming hit
+	# The premise stated rather than assumed: if a factor retune ever drops this below the base 10,
+	# this fails HERE as a fixture problem, not below as a phantom mechanism bug.
+	assert_int(target.get_effective_def()).is_greater_equal(10)
 
 	var attack := _attack(attacker, target)
 	var plan := ResolvedPlan.new()
@@ -128,7 +135,7 @@ func test_cover_stacks_with_armor() -> void:
 	plan.attacks.append(attack)
 	PlanResolver.resolve(plan, ReactionCatalog.get_all(), board)
 
-	assert_int(attack.resolved.damage).is_equal(10 - 4 - Terrain.COVER_DEF)
+	assert_int(attack.resolved.damage).is_equal(10 - target.get_effective_def() - Terrain.COVER_DEF)
 
 
 func test_cover_only_shelters_the_covered_cell() -> void:
@@ -170,10 +177,14 @@ func test_def_breakdown_itemizes_armor_and_cover() -> void:
 	target.worn_armor = _make_armor(4)
 	var board := _board_with_cover(Vector2i(1, 0))
 
+	# The armor term derived independently through the stat doctrine (Stats.armor_def), so this
+	# case genuinely cross-checks the breakdown rather than echoing get_effective_def back at
+	# itself -- and no literal rides CON_DEF_FACTOR (playtest-tunable, 2026-08-10 sweep).
+	var armor_term: int = Stats.armor_def(4, target.get_effective_stat(Stats.Stat.CON))
 	var def := RulesService.def_breakdown(target, Vector2i(1, 0), board)
-	assert_int(def["armor"]).is_equal(4)
+	assert_int(def["armor"]).is_equal(armor_term)
 	assert_int(def["cover"]).is_equal(Terrain.COVER_DEF)
-	assert_int(def["total"]).is_equal(4 + Terrain.COVER_DEF)
+	assert_int(def["total"]).is_equal(armor_term + Terrain.COVER_DEF)
 
 
 func test_def_breakdown_without_a_board_is_armor_only() -> void:
@@ -183,7 +194,7 @@ func test_def_breakdown_without_a_board_is_armor_only() -> void:
 
 	var def := RulesService.def_breakdown(target, Vector2i(1, 0), null)
 	assert_int(def["cover"]).is_equal(0)
-	assert_int(def["total"]).is_equal(4)
+	assert_int(def["total"]).is_equal(Stats.armor_def(4, target.get_effective_stat(Stats.Stat.CON)))
 
 
 func test_def_breakdown_total_is_what_the_resolver_subtracts() -> void:

--- a/tests/squad/test_squad_shape.gd
+++ b/tests/squad/test_squad_shape.gd
@@ -53,21 +53,31 @@ func test_squad_range_follows_leader_reassignment() -> void:
 	assert_object(squad.leader).is_same(heir)
 	assert_int(squad.get_max_squad_range()).is_equal(4)
 
-func test_max_size_follows_the_ratified_rungs() -> void:
-	# eLDR 0-1 loner · 2-3 pair · 4-5 trio · 6-7 four · 8-9 five · 10-11 six (PER 5 -> band 0).
-	assert_int(_leader_with_ldr(1, Vector2i(0, 0)).squad.max_size()).is_equal(1)
-	assert_int(_leader_with_ldr(3, Vector2i(4, 0)).squad.max_size()).is_equal(2)
-	assert_int(_leader_with_ldr(5, Vector2i(8, 0)).squad.max_size()).is_equal(3)
-	assert_int(_leader_with_ldr(7, Vector2i(12, 0)).squad.max_size()).is_equal(4)
-	assert_int(_leader_with_ldr(9, Vector2i(16, 0)).squad.max_size()).is_equal(5)
-	assert_int(_leader_with_ldr(11, Vector2i(20, 0)).squad.max_size()).is_equal(6)
+func test_max_size_follows_the_capacity_rungs() -> void:
+	# capacity = leader + floor(eLDR / MEMBER_LDR_COST), probed across six rungs. Expected values
+	# derive from the constant (2026-08-10 sweep -- MEMBER_LDR_COST is playtest-tunable, and the
+	# same symbolic form test_derived_stat_chain already uses): the shape being pinned is that
+	# capacity STEPS with LDR, at whatever the cost is that day. Default PER -> band 0.
+	for ldr in [1, 3, 5, 7, 9, 11]:
+		var leader := _leader_with_ldr(ldr, Vector2i(ldr * 2, 0))
+		assert_int(leader.squad.max_size()) \
+			.override_failure_message("capacity at LDR %d does not follow the ladder" % ldr) \
+			.is_equal(1 + ldr / Squad.MEMBER_LDR_COST)
 
 func test_per_band_shifts_capacity_across_rung_boundaries() -> void:
-	# The PER shadow with teeth: LDR 5 + PER 9 -> eLDR 6 -> four; LDR 4 + PER 2 -> eLDR 3 -> pair.
-	var sharp := H.spawn_solo(self, _sm, ENEMY, Vector2i(0, 4), {Stats.Stat.LDR: 5, Stats.Stat.PER: 9})
-	assert_int(sharp.squad.max_size()).is_equal(4)
-	var dull := H.spawn_solo(self, _sm, ENEMY, Vector2i(4, 4), {Stats.Stat.LDR: 4, Stats.Stat.PER: 2})
-	assert_int(dull.squad.max_size()).is_equal(2)
+	# The PER shadow with teeth: a band edge in PER moves eLDR, and eLDR moves capacity. Expected
+	# derives from the band + the cost, so it pins the WIRE (PER reaches capacity), not the numbers.
+	var high_per: int = Stats.BAND_MID_MAX + 2
+	var sharp := H.spawn_solo(self, _sm, ENEMY, Vector2i(0, 4), {Stats.Stat.LDR: 5, Stats.Stat.PER: high_per})
+	assert_int(sharp.squad.max_size()) \
+		.is_equal(1 + (5 + Stats.per_ldr_band(high_per)) / Squad.MEMBER_LDR_COST)
+	# The guaranteed-visible direction: LDR sitting exactly on a rung multiple, dull PER dragging
+	# eLDR one below it. floor((2c-1)/c) < 2 for every cost >= 1, so this drop survives ANY retune;
+	# the upward twin does not (a +1 shift only crosses a boundary at some costs), hence this side.
+	var rung_ldr: int = 2 * Squad.MEMBER_LDR_COST
+	var plain := _leader_with_ldr(rung_ldr, Vector2i(8, 4))
+	var dull := H.spawn_solo(self, _sm, ENEMY, Vector2i(12, 4), {Stats.Stat.LDR: rung_ldr, Stats.Stat.PER: 0})
+	assert_int(dull.squad.max_size()).is_less(plain.squad.max_size())
 
 func test_negative_effective_ldr_clamps_to_loner() -> void:
 	# LDR 0 + PER 2 -> eLDR -1; capacity floors at "just yourself", never negative.
@@ -75,8 +85,10 @@ func test_negative_effective_ldr_clamps_to_loner() -> void:
 	assert_int(husk.squad.max_size()).is_equal(1)
 
 func test_join_predicate_refuses_at_capacity() -> void:
-	# eLDR 4 leader -> trio cap. Fill it via direct joins; the PREDICATE refuses the fourth.
-	var leader := _leader_with_ldr(4, Vector2i(0, 0))
+	# Capacity authored AS two-members-beyond-the-leader (LDR = 2 x the cost), so the fill below
+	# and the refusal stay aligned with the knob at any retune (2026-08-10 sweep). The PREDICATE
+	# refuses the member past capacity; direct joins stay permissive.
+	var leader := _leader_with_ldr(2 * Squad.MEMBER_LDR_COST, Vector2i(0, 0))
 	var m1 := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0))
 	var m2 := H.spawn_solo(self, _sm, ENEMY, Vector2i(0, 1))
 	var late := H.spawn_solo(self, _sm, ENEMY, Vector2i(2, 0))
@@ -86,8 +98,9 @@ func test_join_predicate_refuses_at_capacity() -> void:
 	assert_bool(_sm.can_join_squad(late, leader.squad)).is_false() # 3/3 -> full
 
 func test_loner_cannot_form_a_squad() -> void:
-	# The ratified 0-1 rung: capacity 0 members means the create option greys out entirely.
-	var loner := _leader_with_ldr(1, Vector2i(0, 0))
+	# The bottom rung: capacity 0 members means the create option greys out entirely. LDR authored
+	# one short of the first member's cost, so the rung holds at any retune.
+	var loner := _leader_with_ldr(Squad.MEMBER_LDR_COST - 1, Vector2i(0, 0))
 	var buddy := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0))
 	assert_bool(_sm.can_squad_up(buddy, loner.squad)).is_false()
 	assert_bool(_sm.can_create_any_squad(loner)).is_false()

--- a/tests/stats/test_armor_seam.gd
+++ b/tests/stats/test_armor_seam.gd
@@ -18,13 +18,17 @@ func test_naked_unit_has_zero_def_regardless_of_con() -> void:
 	assert_int(unit.get_effective_def()).is_equal(0)
 
 func test_worn_armor_scales_with_con() -> void:
+	# The Unit-side wiring: the worn piece and the wearer's CON reach get_effective_def through
+	# Stats.armor_def. Expected via that same doctrine function, never a literal (2026-08-10
+	# sweep: CON_DEF_FACTOR is playtest-tunable), and the scaling claim itself is the comparison.
 	var average := H.spawn_unit(self, Team.Faction.ENEMY, Vector2i(0, 0), {Stats.Stat.CON: 5})
 	average.worn_armor = _make_armor(10)
-	assert_int(average.get_effective_def()).is_equal(10)   # printed value on the default body
+	assert_int(average.get_effective_def()).is_equal(Stats.armor_def(10, 5))
 
 	var sturdy := H.spawn_unit(self, Team.Faction.ENEMY, Vector2i(1, 0), {Stats.Stat.CON: 8})
 	sturdy.worn_armor = _make_armor(10)
-	assert_int(sturdy.get_effective_def()).is_equal(16)
+	assert_int(sturdy.get_effective_def()).is_equal(Stats.armor_def(10, 8))
+	assert_int(sturdy.get_effective_def()).is_greater(average.get_effective_def())
 
 func test_flat_def_does_not_scale_with_con() -> void:
 	# The un-scaled term: identical on every body, so a CON-gated piece can pay out without
@@ -38,9 +42,11 @@ func test_flat_def_does_not_scale_with_con() -> void:
 	assert_int(sturdy.get_effective_def()).is_equal(3)
 
 func test_flat_and_scaled_terms_sum() -> void:
+	# flat + scaled, expected off the scaled term alone (2026-08-10 sweep: no literal may ride
+	# CON_DEF_FACTOR) -- the claim is the SUM, so only the +2 is this case's own.
 	var unit := H.spawn_unit(self, Team.Faction.ENEMY, Vector2i(0, 0), {Stats.Stat.CON: 5})
 	unit.worn_armor = _make_armor(10, {}, 2)
-	assert_int(unit.get_effective_def()).is_equal(12)
+	assert_int(unit.get_effective_def()).is_equal(Stats.armor_def(10, 5) + 2)
 
 func test_zero_con_still_earns_the_flat_term_only() -> void:
 	# The "multiplier with no base" doctrine holds for the SCALED half: CON 0 zeroes it

--- a/tests/stats/test_gear_stat_modifiers.gd
+++ b/tests/stats/test_gear_stat_modifiers.gd
@@ -42,18 +42,23 @@ func test_gear_is_derived_and_stores_nothing() -> void:
 
 
 func test_a_dex_tax_can_cost_a_point_of_mov() -> void:
-	# DEX 6 sits one point into the high MOV rung (dex_mov_band: 6-8 = +1), so a -1 tax drops
-	# the wearer back to the mid rung. The tax reaching a DERIVED readout is the whole point.
-	var nimble: Unit = H.spawn_unit(self, Team.Faction.ENEMY, Vector2i(0, 0), {Stats.Stat.DEX: 6})
+	# DEX authored one point past the rung threshold (2026-08-10 sweep -- the threshold is
+	# playtest-tunable, so the POSITION is authored, never the number), so a -1 tax drops the
+	# wearer back a rung. The tax reaching a DERIVED readout is the whole point.
+	var nimble: Unit = H.spawn_unit(self, Team.Faction.ENEMY, Vector2i(0, 0),
+		{Stats.Stat.DEX: Stats.DEX_MOV_MID_MAX + 1})
 	var before := nimble.get_mov()
 	nimble.worn_armor = _taxing_armor(Stats.Stat.DEX, -1)
 	assert_int(nimble.get_mov()).is_equal(before - 1)
 
 
 func test_a_dex_tax_inside_a_band_costs_no_mov() -> void:
-	# Bands are coarse ON PURPOSE (stats.md) -- default DEX 5 taxed to 4 stays in the same rung,
+	# Bands are coarse ON PURPOSE (stats.md) -- a top-of-rung DEX taxed one stays in its rung,
 	# so the same armor is free for one unit and costly for another. That jaggedness is a goal.
-	var average: Unit = H.spawn_unit(self, Team.Faction.ENEMY, Vector2i(0, 0), {Stats.Stat.DEX: 5})
+	# Premise: the rung really is at least two wide, or this case is measuring nothing.
+	assert_int(Stats.dex_mov_band(Stats.DEX_MOV_MID_MAX - 1)).is_equal(Stats.dex_mov_band(Stats.DEX_MOV_MID_MAX))
+	var average: Unit = H.spawn_unit(self, Team.Faction.ENEMY, Vector2i(0, 0),
+		{Stats.Stat.DEX: Stats.DEX_MOV_MID_MAX})
 	var before := average.get_mov()
 	average.worn_armor = _taxing_armor(Stats.Stat.DEX, -1)
 	assert_int(average.get_mov()).is_equal(before)
@@ -85,7 +90,10 @@ func test_gear_tax_composes_with_a_temporary_effect() -> void:
 func test_a_taxing_armor_still_pays_its_def() -> void:
 	var unit: Unit = H.spawn_unit(self, Team.Faction.ENEMY, Vector2i(0, 0), {Stats.Stat.CON: 5, Stats.Stat.DEX: 6})
 	unit.worn_armor = _taxing_armor(Stats.Stat.DEX, -1, 4)
-	assert_int(unit.get_effective_def()).is_equal(4)
+	# Expected DEF via the doctrine function (2026-08-10 sweep -- CON_DEF_FACTOR is playtest-
+	# tunable); this case's own claim is only that the tax doesn't eat the payout.
+	assert_int(unit.get_effective_def()).is_equal(Stats.armor_def(4, unit.get_effective_stat(Stats.Stat.CON)))
+	assert_int(unit.get_effective_def()).is_greater(0)
 	assert_int(unit.get_effective_stat(Stats.Stat.DEX)).is_equal(5)
 
 

--- a/tests/stats/test_mov.gd
+++ b/tests/stats/test_mov.gd
@@ -23,9 +23,15 @@ func test_default_unit_moves_at_jobless_base() -> void:
 	assert_int(_mov(_make_instance({}))).is_equal(UnitInstance.JOBLESS_MOV_BASE)
 
 func test_dex_band_rungs_reach_mov() -> void:
-	assert_int(_mov(_make_instance({Stats.Stat.DEX: 3}))).is_equal(3)   # low rung
-	assert_int(_mov(_make_instance({Stats.Stat.DEX: 6}))).is_equal(5)   # one point of investment
-	assert_int(_mov(_make_instance({Stats.Stat.DEX: 9}))).is_equal(6)   # the earned top rung
+	# Inputs through the named thresholds, expected off the base (2026-08-10 sweep): both are
+	# playtest-tunable and retuning either must not turn this red. The rung deltas stay literal --
+	# they are the band's shape, pinned by test_stat_bands.
+	assert_int(_mov(_make_instance({Stats.Stat.DEX: Stats.BAND_LOW_MAX}))) \
+		.is_equal(UnitInstance.JOBLESS_MOV_BASE - 1)   # low rung
+	assert_int(_mov(_make_instance({Stats.Stat.DEX: Stats.DEX_MOV_MID_MAX + 1}))) \
+		.is_equal(UnitInstance.JOBLESS_MOV_BASE + 1)   # one point of investment
+	assert_int(_mov(_make_instance({Stats.Stat.DEX: Stats.DEX_MOV_HIGH_MAX + 1}))) \
+		.is_equal(UnitInstance.JOBLESS_MOV_BASE + 2)   # the earned top rung
 
 func test_con_does_not_touch_mov() -> void:
 	# Doctrine correction 2026-07-27: weight is gear-only and feeds nothing, so a high-CON
@@ -33,18 +39,28 @@ func test_con_does_not_touch_mov() -> void:
 	assert_int(_mov(_make_instance({Stats.Stat.CON: 8}))).is_equal(UnitInstance.JOBLESS_MOV_BASE)
 	assert_int(_mov(_make_instance({Stats.Stat.CON: 20}))).is_equal(UnitInstance.JOBLESS_MOV_BASE)
 
+# The throttle threads assert the RELATIONSHIP, not a finished number (2026-08-10 sweep): the
+# dragged DEX is read back off the real chain and the pre-throttle MOV rebuilt from it, so the only
+# thing each case can fail on is its own stage -- the halve-up -- and no knob retune reaches it.
+func _unthrottled_mov(inst: UnitInstance) -> int:
+	return UnitInstance.JOBLESS_MOV_BASE + Stats.dex_mov_band(inst.get_effective_stat(Stats.Stat.DEX))
+
 func test_one_empty_leg_halves_final_mov() -> void:
-	# The full thread, default unit: leg empties -> eff DEX ceil(5/2)=3 -> band -1 -> 3,
-	# then the throttle halves it rounded up -> 2. Both effects stack deliberately.
+	# The full thread, default unit: leg empties -> the DEX mean drags -> the band drops,
+	# then the throttle halves the result rounded up. Both effects stack deliberately.
 	var inst := _make_instance({})
 	inst.limbs[UnitInstance.LimbSlot.LEG_L].state = UnitInstance.LimbState.EMPTY
-	assert_int(_mov(inst)).is_equal(2)
+	assert_int(_mov(inst)).is_equal(ceili(_unthrottled_mov(inst) / 2.0))
+	# The premise -- the drag really reached the band, or the halve-up above proved nothing new.
+	assert_int(_unthrottled_mov(inst)).is_less(UnitInstance.JOBLESS_MOV_BASE)
 
 func test_one_empty_leg_on_a_sprinter() -> void:
-	# DEX 12: eff DEX ceil(12/2)=6 -> band +1 -> 5 -> halved up -> 3. Fast, but limping.
+	# A high-DEX unit limps too, from its own higher baseline. Fast, but limping.
 	var inst := _make_instance({Stats.Stat.DEX: 12})
 	inst.limbs[UnitInstance.LimbSlot.LEG_R].state = UnitInstance.LimbState.EMPTY
-	assert_int(_mov(inst)).is_equal(3)
+	assert_int(_mov(inst)).is_equal(ceili(_unthrottled_mov(inst) / 2.0))
+	# Premise: the sprinter keeps a band edge over the default even dragged.
+	assert_int(_unthrottled_mov(inst)).is_greater(UnitInstance.JOBLESS_MOV_BASE - 1)
 
 func test_both_legs_empty_pins_mov_to_one() -> void:
 	# Categorical (dev ruling): overrides base, band, weight — even a DEX-12 sprinter crawls.
@@ -54,10 +70,12 @@ func test_both_legs_empty_pins_mov_to_one() -> void:
 	assert_int(_mov(inst)).is_equal(1)
 
 func test_prosthetic_leg_lifts_the_throttle() -> void:
-	# A fitted prosthetic is a functional leg: no halving; its stat feeds the DEX mean.
-	var inst := _make_instance({Stats.Stat.DEX: 5})
+	# A fitted prosthetic is a functional leg: no halving; its stat feeds the DEX mean. A
+	# default-stat prosthetic on a default unit rides the defaults-land-on-0 guarantee
+	# (test_stat_bands), so the expectation is the bare base whatever the numbers are.
+	var inst := _make_instance({Stats.Stat.DEX: Stats.STAT_DEFAULTS[Stats.Stat.DEX]})
 	inst.limbs[UnitInstance.LimbSlot.LEG_L].state = UnitInstance.LimbState.PROSTHETIC
-	inst.limbs[UnitInstance.LimbSlot.LEG_L].prosthetic_stat = 5
+	inst.limbs[UnitInstance.LimbSlot.LEG_L].prosthetic_stat = Stats.STAT_DEFAULTS[Stats.Stat.DEX]
 	assert_int(_mov(inst)).is_equal(UnitInstance.JOBLESS_MOV_BASE)
 
 func test_mov_never_drops_below_one() -> void:

--- a/tests/stats/test_stat_bands.gd
+++ b/tests/stats/test_stat_bands.gd
@@ -1,26 +1,31 @@
 # The band doctrine as executable spec (docs/design/stats.md, #55): every input stat
 # casts a small, coarse, bounded shadow. Pure functions — rung values, both boundaries,
 # and the invariant that makes the whole session behavior-neutral: DEFAULTS LAND ON 0.
+#
+# Boundaries are probed THROUGH the named threshold constants, never as literals (2026-08-10
+# sweep): the thresholds are playtest-tunable, and retuning one must not turn this suite red.
+# The rung HEIGHTS stay literal on purpose — they live in the band function bodies, not in named
+# knobs, so they are the mechanism's shape and pinning them is this file's job.
 extends GdUnitTestSuite
 
 func test_dex_mov_band_rungs() -> void:
-	# Retuned 2026-07-15 (jobs.md): default (5) TOPS its rung — one DEX point buys +1, four buy +2.
+	# Retuned 2026-07-15 (jobs.md): the default TOPS its rung — one DEX point buys +1.
 	assert_int(Stats.dex_mov_band(0)).is_equal(-1)
-	assert_int(Stats.dex_mov_band(3)).is_equal(-1)   # top of low rung
-	assert_int(Stats.dex_mov_band(4)).is_equal(0)    # bottom of mid rung
-	assert_int(Stats.dex_mov_band(5)).is_equal(0)    # the default — last point of the free rung
-	assert_int(Stats.dex_mov_band(6)).is_equal(1)    # one point of investment jumps a rung
-	assert_int(Stats.dex_mov_band(8)).is_equal(1)
-	assert_int(Stats.dex_mov_band(9)).is_equal(2)    # four points above default: hard but doable
-	assert_int(Stats.dex_mov_band(12)).is_equal(2)
+	assert_int(Stats.dex_mov_band(Stats.BAND_LOW_MAX)).is_equal(-1)        # top of low rung
+	assert_int(Stats.dex_mov_band(Stats.BAND_LOW_MAX + 1)).is_equal(0)     # bottom of mid rung
+	assert_int(Stats.dex_mov_band(Stats.DEX_MOV_MID_MAX)).is_equal(0)      # last point of the free rung
+	assert_int(Stats.dex_mov_band(Stats.DEX_MOV_MID_MAX + 1)).is_equal(1)  # one point of investment jumps a rung
+	assert_int(Stats.dex_mov_band(Stats.DEX_MOV_HIGH_MAX)).is_equal(1)
+	assert_int(Stats.dex_mov_band(Stats.DEX_MOV_HIGH_MAX + 1)).is_equal(2) # the earned top rung
+	assert_int(Stats.dex_mov_band(Stats.DEX_MOV_HIGH_MAX + 4)).is_equal(2) # ...and it caps there
 
 func test_con_mhp_band_rungs() -> void:
 	assert_int(Stats.con_mhp_band(0)).is_equal(-2)
-	assert_int(Stats.con_mhp_band(3)).is_equal(-2)
-	assert_int(Stats.con_mhp_band(4)).is_equal(0)
-	assert_int(Stats.con_mhp_band(7)).is_equal(0)
-	assert_int(Stats.con_mhp_band(8)).is_equal(2)
-	assert_int(Stats.con_mhp_band(12)).is_equal(2)
+	assert_int(Stats.con_mhp_band(Stats.BAND_LOW_MAX)).is_equal(-2)
+	assert_int(Stats.con_mhp_band(Stats.BAND_LOW_MAX + 1)).is_equal(0)
+	assert_int(Stats.con_mhp_band(Stats.BAND_MID_MAX)).is_equal(0)
+	assert_int(Stats.con_mhp_band(Stats.BAND_MID_MAX + 1)).is_equal(2)
+	assert_int(Stats.con_mhp_band(Stats.BAND_MID_MAX + 5)).is_equal(2)
 
 func test_con_mhp_band_extremes_within_doctrine() -> void:
 	# stats.md: extremes no more than 4-5 MHP apart end to end.
@@ -29,25 +34,33 @@ func test_con_mhp_band_extremes_within_doctrine() -> void:
 
 func test_per_ldr_band_rungs() -> void:
 	assert_int(Stats.per_ldr_band(0)).is_equal(-1)
-	assert_int(Stats.per_ldr_band(3)).is_equal(-1)
-	assert_int(Stats.per_ldr_band(4)).is_equal(0)
-	assert_int(Stats.per_ldr_band(7)).is_equal(0)
-	assert_int(Stats.per_ldr_band(8)).is_equal(1)
-	assert_int(Stats.per_ldr_band(12)).is_equal(1)
+	assert_int(Stats.per_ldr_band(Stats.BAND_LOW_MAX)).is_equal(-1)
+	assert_int(Stats.per_ldr_band(Stats.BAND_LOW_MAX + 1)).is_equal(0)
+	assert_int(Stats.per_ldr_band(Stats.BAND_MID_MAX)).is_equal(0)
+	assert_int(Stats.per_ldr_band(Stats.BAND_MID_MAX + 1)).is_equal(1)
+	assert_int(Stats.per_ldr_band(Stats.BAND_MID_MAX + 5)).is_equal(1)
 
 func test_all_defaults_land_on_the_zero_rung() -> void:
-	# The no-behavior-shift guarantee: a default statline (5s) takes 0 from every band,
+	# The no-behavior-shift guarantee: a default statline takes 0 from every band,
 	# so pre-CON units, scenarios, and fixtures keep their exact numbers.
 	assert_int(Stats.dex_mov_band(Stats.STAT_DEFAULTS[Stats.Stat.DEX])).is_equal(0)
 	assert_int(Stats.con_mhp_band(Stats.STAT_DEFAULTS[Stats.Stat.CON])).is_equal(0)
 	assert_int(Stats.per_ldr_band(Stats.STAT_DEFAULTS[Stats.Stat.PER])).is_equal(0)
 
-func test_armor_def_multiplier_with_no_base() -> void:
-	# DEF x CON (stats.md): naked or zero-CON -> zero DEF; CON 5 wears armor as printed.
-	assert_int(Stats.armor_def(10, 5)).is_equal(10)   # default body = printed value
-	assert_int(Stats.armor_def(10, 8)).is_equal(16)
-	assert_int(Stats.armor_def(10, 2)).is_equal(4)
-	assert_int(Stats.armor_def(10, 0)).is_equal(0)    # CON 0 can't brace armor
-	assert_int(Stats.armor_def(0, 9)).is_equal(0)     # no gear, no DEF — regardless of CON
-	assert_int(Stats.armor_def(3, 4)).is_equal(2)     # 2.4 rounds down
-	assert_int(Stats.armor_def(7, 5)).is_equal(7)
+func test_armor_def_mechanism() -> void:
+	# DEF = flat + (power x CON x factor), stats.md. Value-free on CON_DEF_FACTOR (playtest-tunable):
+	# these pin the formula's SHAPE, so retuning the factor cannot turn them red.
+	assert_int(Stats.armor_def(10, 0)).is_equal(0)   # CON 0 can't brace armor
+	assert_int(Stats.armor_def(0, 9)).is_equal(0)    # no gear, no scaled DEF — regardless of CON
+	# The scaled term is monotone in CON: a tougher body never wears the same piece worse.
+	assert_int(Stats.armor_def(10, 8)).is_greater(Stats.armor_def(10, 2))
+	# More armor never pays out less on the same body.
+	assert_int(Stats.armor_def(10, 5)).is_greater_equal(Stats.armor_def(7, 5))
+
+func test_armor_def_flat_term_is_unscaled() -> void:
+	# The 2026-07-24 rule that created flat_def: a CON-gated piece pays its flat term out
+	# WITHOUT double-dipping CON. flat + scaled, never (flat + power) x scaled.
+	assert_int(Stats.armor_def(10, 8, 3)).is_equal(Stats.armor_def(10, 8) + 3)
+	# ...and it pays out even where the scaled term is zero.
+	assert_int(Stats.armor_def(0, 8, 3)).is_equal(3)
+	assert_int(Stats.armor_def(10, 0, 3)).is_equal(3)

--- a/tests/terrain/test_burnout.gd
+++ b/tests/terrain/test_burnout.gd
@@ -1,8 +1,13 @@
 # #50 burnout: a BURNING tile goes out after STATE_DURATIONS ticks. tick_states runs once per turn
 # cycle (TurnManager.round_completed); spreading/other elements are a later PR. Pure store, headless.
+#
+# Tick counts derive from STATE_DURATIONS, never a literal (2026-08-10 sweep): the duration is a
+# tuning dial, and retuning it must not turn this suite red. Each case walks to the last tick the
+# state should survive, asserts it held, then ticks once more -- a real boundary at any duration.
 extends GdUnitTestSuite
 
 const BURN_CELL := Vector2i(1, 0)
+const BURN_TICKS: int = TerrainStateManager.STATE_DURATIONS[Terrain.TileState.BURNING]
 
 func _ignite(tsm: TerrainStateManager, cell: Vector2i) -> void:
 	var effect := ResolvedCellEffect.new()
@@ -10,26 +15,26 @@ func _ignite(tsm: TerrainStateManager, cell: Vector2i) -> void:
 	effect.states_added.assign([Terrain.TileState.BURNING])
 	tsm.apply(effect)
 
-func test_burning_clears_after_three_ticks() -> void:
+func test_burning_clears_after_its_authored_duration() -> void:
 	var tsm: TerrainStateManager = auto_free(TerrainStateManager.new())
 	add_child(tsm)
 	_ignite(tsm, BURN_CELL)
 	assert_bool(tsm.has_state(BURN_CELL, Terrain.TileState.BURNING)).is_true()
-	tsm.tick_states()  # 3 -> 2
-	tsm.tick_states()  # 2 -> 1
-	assert_bool(tsm.has_state(BURN_CELL, Terrain.TileState.BURNING)).is_true()
-	tsm.tick_states()  # 1 -> 0 -> out
-	assert_bool(tsm.has_state(BURN_CELL, Terrain.TileState.BURNING)).is_false()
+	for _i in range(BURN_TICKS - 1):
+		tsm.tick_states()
+	assert_bool(tsm.has_state(BURN_CELL, Terrain.TileState.BURNING)).is_true()   # last authored tick
+	tsm.tick_states()
+	assert_bool(tsm.has_state(BURN_CELL, Terrain.TileState.BURNING)).is_false()  # ...and out
 
 func test_reigniting_resets_the_timer() -> void:
 	var tsm: TerrainStateManager = auto_free(TerrainStateManager.new())
 	add_child(tsm)
 	_ignite(tsm, BURN_CELL)
-	tsm.tick_states()  # 3 -> 2
-	tsm.tick_states()  # 2 -> 1
-	_ignite(tsm, BURN_CELL)  # restoked -> back to 3
-	tsm.tick_states()  # 3 -> 2
-	tsm.tick_states()  # 2 -> 1
+	for _i in range(BURN_TICKS - 1):
+		tsm.tick_states()   # down to the fire's final tick
+	_ignite(tsm, BURN_CELL)  # restoked -> back to full
+	for _i in range(BURN_TICKS - 1):
+		tsm.tick_states()   # a full countdown less one: only survivable on the reset timer
 	assert_bool(tsm.has_state(BURN_CELL, Terrain.TileState.BURNING)).is_true()
 
 func test_loaded_burning_tile_gets_a_fresh_timer() -> void:
@@ -42,8 +47,8 @@ func test_loaded_burning_tile_gets_a_fresh_timer() -> void:
 	var dst: TerrainStateManager = auto_free(TerrainStateManager.new())
 	add_child(dst)
 	dst.load_state_dict(src.to_state_dict())
-	dst.tick_states()
-	dst.tick_states()
-	assert_bool(dst.has_state(BURN_CELL, Terrain.TileState.BURNING)).is_true()
+	for _i in range(BURN_TICKS - 1):
+		dst.tick_states()
+	assert_bool(dst.has_state(BURN_CELL, Terrain.TileState.BURNING)).is_true()   # outlived the source's remainder
 	dst.tick_states()
 	assert_bool(dst.has_state(BURN_CELL, Terrain.TileState.BURNING)).is_false()

--- a/tests/terrain/test_ice.gd
+++ b/tests/terrain/test_ice.gd
@@ -120,10 +120,12 @@ func test_a_tileset_that_omits_the_walkable_flag_reads_unwalkable() -> void:
 	var board := BoardContext.new(grid, no_units, null)
 	assert_bool(board.is_walkable(Vector2i.ZERO)).is_false()
 
-func test_frozen_melts_after_three_ticks() -> void:
+func test_frozen_melts_after_its_authored_duration() -> void:
+	# Tick count off STATE_DURATIONS, not a literal (2026-08-10 sweep): the duration is a tuning
+	# dial. Walk to the last authored tick, assert the ice held, then one more melts it.
 	var tsm := _frozen_store()
-	tsm.tick_states()
-	tsm.tick_states()
+	for _i in range(TerrainStateManager.STATE_DURATIONS[Terrain.TileState.FROZEN] - 1):
+		tsm.tick_states()
 	assert_bool(tsm.has_state(WATER_CELL, Terrain.TileState.FROZEN)).is_true()
 	tsm.tick_states()
 	assert_bool(tsm.has_state(WATER_CELL, Terrain.TileState.FROZEN)).is_false()


### PR DESCRIPTION
The #118 rule — *"no tests that test what these values **are**, only that they work"* — applied to
the whole tree, at @Phaazoid's request.

## The razor (now canon in `tests/README.md` §8)

> **A test may not break when a NAMED tunable constant moves. It may break when a function body
> changes.** Retuning a `playtest-tunable` const is a one-line edit that must stay green; editing
> the mechanism is a code change, where a red test is ordinary regression semantics.

Rung heights, floors, and authored fixture content stay literal on purpose — pinning those pins the
mechanism's shape, which is a test's job.

## What the sweep found

Most of the suite was already right: weapons, crisis, will costs, intimidate, cover and tooltip
tests all read their constants symbolically; there are zero wall-clock waits anywhere; the cohesion
suite had even fixed this class in itself once (`STAT_DEFAULTS[COH]` 3→4). **Nine files failed the
razor**, each against a constant source marks `playtest-tunable`:

| File | Knob it baked in | Fix |
|---|---|---|
| `test_stat_bands` | band thresholds + `CON_DEF_FACTOR` | boundaries probed *through* the constants; armor_def cases became value-free properties — incl. the flat-term no-double-dip rule, **previously untested** |
| `test_mov` | `JOBLESS_MOV_BASE` + thresholds | expectations off the base; throttle threads assert the halve-up *relationship*, premise asserted |
| `test_squad_shape` | `MEMBER_LDR_COST` | ladder derives from the cost; fixtures author LDR *as* a multiple of it; PER-shift teeth moved to the low-band side (the only direction guaranteed visible at any cost) |
| `test_def_mitigation`, `test_armor_equip`, `test_armor_seam`, `test_gear_stat_modifiers` | `CON_DEF_FACTOR` arithmetic | expectations derive through `Stats.armor_def` / `get_effective_def` |
| `test_burnout`, `test_ice` | `STATE_DURATIONS` | tick counts derive from the dict; cases renamed duration-neutrally |

Three of the armor files never **named** the constant — they just baked its arithmetic. Grep could
not find them; the retune matrix did.

## Verification — both directions

**Retune matrix** (move the knob, full suite, expect green — the check that was impossible before):

| Knob | Probe | Result |
|---|---|---|
| `CON_DEF_FACTOR` | 0.2 → 0.3 | **1106/1106** (after fixing the 3 files it exposed) |
| `STATE_DURATIONS` | 3 → 5 / 4 (asymmetric) | **1106/1106** |
| `MEMBER_LDR_COST` | 2 → 3 | **1106/1106** |
| band thresholds | mid/high shifted +1 | **1106/1106** |
| `JOBLESS_MOV_BASE` | 4 → 6 | **honest exception** — see below |

`JOBLESS_MOV_BASE` breaks 6 AI/cohesion cases whose *boards* are authored relative to global
mobility ("out of reach" at MOV 4 isn't at MOV 6). That is a real design coupling, not a literal to
launder away: the jam suite's own premise assertion catches it loudly (*"fixture: the member CAN
follow — this jam no longer jams"*), and a mobility retune would demand the same look at the game's
real scenario boards. Documented in README §8 rather than papered over.

**Falsification** — five mechanism mutations, each confirmed red against its rewritten case, then
reverted: armor_def flat-term double-dip · terrain states never expire · capacity ignores the cost ·
band mid-threshold ignored · resolver computes DEF and throws it away.

Final clean run: **1106/1106, 62.4s.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
