### PR TITLE
Anchor the action-queue panel to the right viewport edge (#160)

### DIFF
--- a/Classes/ui/queue/SquadActionQueueControl.gd
+++ b/Classes/ui/queue/SquadActionQueueControl.gd
@@ -1,6 +1,12 @@
 extends Control
 class_name SquadActionQueueControl
 
+# The action-queue panel: renders a squad's plan as sectioned rows (via ActionQueueDisplayEntry)
+# with drag-reorder for attacks and the Execute button. Layout invariant (#160): the scene ROOT
+# is full-rect with mouse_filter IGNORE — never STOP, or it eats every board click — and
+# BackgroundPanel is anchored to the RIGHT edge so the dock follows a window resize; don't let
+# an editor resave quietly restore absolute offsets.
+
 @onready var sections_box: VBoxContainer = $BackgroundPanel/MarginContainer/VBox/OuterScroll/SectionsBox
 @onready var execute_button: Button = $BackgroundPanel/MarginContainer/VBox/ExecuteButton
 

--- a/Scenes/SquadActionQueueControl.tscn
+++ b/Scenes/SquadActionQueueControl.tscn
@@ -20,20 +20,26 @@ border_color = Color(0, 0, 0, 1)
 
 [node name="SquadActionQueueControl" type="Control" unique_id=1755236960]
 visible = false
-custom_minimum_size = Vector2(128, 0)
 layout_mode = 3
-anchors_preset = 0
-offset_right = 128.0
-offset_bottom = 40.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
 script = ExtResource("1_voyyq")
 
 [node name="BackgroundPanel" type="Panel" parent="." unique_id=1567639531]
 custom_minimum_size = Vector2(50, 50)
-layout_mode = 0
-offset_left = 1000.0
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -152.0
 offset_top = 25.0
-offset_right = 1145.0
+offset_right = -7.0
 offset_bottom = 525.0
+grow_horizontal = 0
 theme_override_styles/panel = SubResource("StyleBoxFlat_voyyq")
 
 [node name="MarginContainer" type="MarginContainer" parent="BackgroundPanel" unique_id=250797685]

--- a/tests/ui/test_queue_panel_docking.gd
+++ b/tests/ui/test_queue_panel_docking.gd
@@ -1,0 +1,66 @@
+# The action-queue panel's dock (#160), on the real scene: the panel sits against the RIGHT
+# viewport edge, FOLLOWS that edge when the viewport resizes (the co-dev's Mac report — the
+# shipped scene pinned it at absolute x=1000 offsets, the #132 sharp-edge class), and the
+# full-rect scene root stays click-transparent — a root with mouse_filter STOP would eat every
+# board click while every content-level suite stayed green (#131's lesson shape).
+extends GdUnitTestSuite
+
+const MAIN_SCENE := "res://Scenes/Main.tscn"
+
+# The panel's authored gap to the right edge (offset_right = -7 in the scene).
+const EDGE_MARGIN := 7.0
+
+var _main: Node
+var game: Node2D
+
+
+func before_test() -> void:
+	_main = (load(MAIN_SCENE) as PackedScene).instantiate()
+	_main.name = "Main"
+	get_tree().root.add_child(_main)
+	await await_idle_frame()
+	game = _main.get_node("GameContainer/GameView/Game")
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	get_tree().root.remove_child(_main)
+	_main.free()
+
+
+func _panel_right_edge() -> float:
+	var panel: Panel = game.squad_action_queue_control.get_node("BackgroundPanel")
+	return panel.get_global_rect().end.x
+
+
+func test_the_panel_docks_to_the_right_edge() -> void:
+	var viewport: SubViewport = _main.get_node("GameContainer/GameView")
+	assert_float(_panel_right_edge()).is_equal_approx(viewport.size.x - EDGE_MARGIN, 0.5)
+
+
+func test_the_dock_follows_a_viewport_resize() -> void:
+	# The reported bug: resize the window bigger and the panel stays put. A window resize reaches
+	# the game as GameContainer resizing (SubViewportContainer stretch is ON, which is what sizes
+	# GameView) — drive that directly and the dock must follow.
+	var container: SubViewportContainer = _main.get_node("GameContainer")
+	var viewport: SubViewport = _main.get_node("GameContainer/GameView")
+	container.size = Vector2(1600, 900)
+	await await_idle_frame()
+	await await_idle_frame()
+
+	# Fixture sanity: if stretch stopped propagating, this case would otherwise pass vacuously.
+	assert_int(viewport.size.x) \
+		.override_failure_message("fixture assumption broke: resizing GameContainer did not resize GameView (still %d wide)" % viewport.size.x) \
+		.is_equal(1600)
+	assert_float(_panel_right_edge()) \
+		.override_failure_message("the queue panel did not follow the right edge: panel ends at %.0f of %d" % [_panel_right_edge(), viewport.size.x]) \
+		.is_equal_approx(1600.0 - EDGE_MARGIN, 0.5)
+
+
+func test_the_full_rect_root_never_eats_board_clicks() -> void:
+	# The one subtle consequence of the fix: the root became full-rect so its child can anchor to
+	# the viewport edge, and a full-rect Control with the default STOP filter would swallow every
+	# click meant for the board underneath — silently, with all content suites green.
+	assert_int(game.squad_action_queue_control.mouse_filter) \
+		.override_failure_message("the queue panel's full-rect root is not click-transparent — every board click under it is being eaten") \
+		.is_equal(Control.MOUSE_FILTER_IGNORE)

--- a/tests/ui/test_queue_panel_docking.gd.uid
+++ b/tests/ui/test_queue_panel_docking.gd.uid
@@ -1,0 +1,1 @@
+uid://cpd4os83lwjdr


### PR DESCRIPTION
Fixes #160 — the co-dev's Mac report: resizing the window bigger left the queue panel floating mid-screen.

**Cause:** exactly the sharp-edge class the issue suspected. `BackgroundPanel` was pinned at absolute offsets (`x 1000..1145` — the right edge of the 1152-wide *base* window) with top-left anchors; nothing tracked the viewport. The left-docked inspect panel already anchors correctly — this was the one stray.

**Fix (scene values):** the panel is now top-right anchored (identical on-screen rect at base size, 7px edge margin), and the scene root became full-rect so the child can anchor to the viewport — with `mouse_filter = IGNORE`, because a full-rect STOP root under UILayer would silently eat every board click (the `ActionMenuController._backdrop` trap from the #132 notes). A short header comment in the script states the invariant so an editor resave can't quietly undo it.

**Verification:** new `tests/ui/test_queue_panel_docking.gd` pins the dock position, the resize (drives `GameContainer.size` — what a real window resize does to the SubViewport, confirmed working headless), and the click-transparent root. Falsified against the shipped scene: *"panel ends at 1145 of 1600"* — the reported symptom, reproduced and then fixed. `ui` area 128/128.

Worth one in-game resize on your end to confirm on real glass, but the mechanism is the engine's own anchor layout — the same one the inspect panel has always used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
