### PR TITLE
Character editor: author the Resources/Units/ cast files in the dev tools (#179)

### DIFF
--- a/Classes/dev/CharacterEditorTool.gd
+++ b/Classes/dev/CharacterEditorTool.gd
@@ -1,0 +1,557 @@
+extends MarginContainer
+class_name CharacterEditorTool
+
+# Dev-only character editor (#179): authors the standalone UnitData files under Resources/Units/
+# -- the cast (#177). An authored save REFERENCES those files, so Update rewrites the character
+# in every mission that references it; the file IS the character. Load/Update/Delete/Save As
+# ride the Item Editor's pool chrome; Capture stages the live unit selected in the Unit Editor
+# tab as a new character. Kit slots stage catalog FILE resources, so saves write ExtResource
+# references (UnitData's own authoring guidance) and a path-less entry is called out as inline
+# rather than silently embedded.
+
+const KEEP_LABEL := "(keep current)"
+const PORTRAIT_DIR := "res://Art/Units/Portraits/"
+
+@onready var editor_container := %CharacterEditorVbox
+@onready var load_dropdown: OptionButton = %CharacterLoadDropdown
+@onready var name_input: LineEdit = %CharacterNameInput
+@onready var update_button: Button = %UpdateCharacterButton
+@onready var delete_button: Button = %DeleteCharacterButton
+@onready var status_label: Label = %CharacterStatusLabel
+
+var current: UnitData = null
+var _items := {}
+# Which catalog entry current was loaded from ("" = a New character). Load stages a COPY with no
+# resource_path, so nothing else records this -- and Update's load-gate needs it.
+var _loaded_name := ""
+
+func _ready():
+	_refresh_list()
+	_on_new_pressed()
+
+func _refresh_list(select_name := ""):
+	load_dropdown.clear()
+	_items = UnitCatalog.get_characters()
+	for k in _items:
+		load_dropdown.add_item(k)
+
+	# add_item auto-selects index 0 -- Update must never aim at an entry nobody picked.
+	load_dropdown.select(-1)
+	for i in load_dropdown.item_count:
+		if load_dropdown.get_item_text(i) == select_name:
+			load_dropdown.select(i)
+			break
+	_refresh_buttons()
+
+func _refresh_buttons():
+	DevWidgets.refresh_update_button(update_button, DevWidgets.selected_name(load_dropdown), "character", _update_block_reason())
+	DevWidgets.refresh_delete_button(delete_button, DevWidgets.selected_name(load_dropdown), "character")
+
+# "" = allowed. Update only overwrites the character that is actually LOADED (#166 shape) -- and
+# here an overwrite reaches every mission referencing the file, the blast radius that made the
+# gate a rule in the first place.
+func _update_block_reason() -> String:
+	var target := DevWidgets.selected_name(load_dropdown)
+	if target == "" or target == _loaded_name:
+		return ""
+	return "Load '%s' first -- Update overwrites it with whatever is in the editor" % target
+
+func _on_load_dropdown_item_selected(_index: int):
+	_refresh_buttons()
+
+func _on_new_pressed():
+	current = UnitData.new()
+	_loaded_name = ""
+	name_input.text = ""
+	status_label.text = ""
+	load_dropdown.select(-1)
+	_refresh_buttons()
+	populate()
+
+func _on_load_pressed():
+	var target := DevWidgets.selected_name(load_dropdown)
+	if target == "" or not _items.has(target):
+		return
+	# duplicate(true) deep-copies the typed dicts (staged edits can't write through the resource
+	# cache) while path'd sub-resources -- textures, catalog kit entries -- stay SHARED and
+	# re-save as ExtResource. Safe only while the form swaps whole slots and never edits an
+	# item's internals; re-verify if in-place item editing is ever added here.
+	var picked: UnitData = _items[target]
+	current = picked.duplicate(true)
+	_loaded_name = target
+	name_input.text = ""
+	_refresh_buttons()
+	status_label.text = _load_notes()
+	populate()
+
+# The spawn path silently drops aura held outside affinity (the Rebecca rule, enforced in
+# UnitInstance.initialize) -- surfaced at load instead, where it can actually be fixed.
+func _load_notes() -> String:
+	var outside: Array[String] = []
+	for element in current.base_aura:
+		if not current.base_affinity.has(element):
+			outside.append(Elemental.Element.keys()[element])
+	if outside.is_empty():
+		return ""
+	return "Aura in %s sits outside affinity and drops at spawn -- check the affinity box or zero it" % ", ".join(outside)
+
+func _on_update_pressed():
+	var target := DevWidgets.selected_name(load_dropdown)
+	if current == null or target == "":
+		return
+	# The handler is the real gate -- the disabled button is only its surface (#166 shape).
+	var reason := _update_block_reason()
+	if reason != "":
+		status_label.text = reason
+		return
+	# Overwrite the file the entry actually came from -- a path rebuilt from the dropdown key
+	# would miss any file whose basename differs from the display name.
+	var path: String = _items[target].resource_path
+	if path == "":
+		var msg := "%s has no file on disk to update" % target
+		push_warning(msg)
+		status_label.text = msg
+		return
+	_trim_kit()
+	if DevWidgets.save_over(current, path, status_label):
+		_loaded_name = current.display_name   # a rename moves the loaded identity with it
+		_refresh_list(current.display_name)
+		_note_missing_art()
+
+func _on_delete_pressed():
+	var target := DevWidgets.selected_name(load_dropdown)
+	if target == "":
+		return
+	DevWidgets.confirm_delete(self, "character '%s'" % target, func(): _delete_confirmed(target))
+
+func _delete_confirmed(target: String) -> void:
+	if not _items.has(target):
+		return   # catalog moved between the press and the Yes
+	if DevWidgets.delete_saved_file(_items[target].resource_path, "character", status_label):
+		if target == _loaded_name:
+			_loaded_name = ""
+		_refresh_list()
+
+func _on_save_as_pressed():
+	if current == null:
+		return
+	var entered_name := name_input.text.strip_edges()
+	if entered_name == "":
+		var msg := "Character needs a name to save"
+		push_warning(msg)
+		status_label.text = msg
+		return
+	if DevWidgets.refuse_illegal_name(entered_name, "character", status_label):
+		return
+	var path := UnitCatalog.CHARACTER_DIR + entered_name + ".tres"
+	if DevWidgets.refuse_existing_file(path, "character", status_label):
+		return
+	current.display_name = entered_name
+	_trim_kit()
+	if DevWidgets.save_over(current, path, status_label):
+		_loaded_name = entered_name   # save_over take_over_path'd it: the editor now holds this file
+		name_input.text = ""
+		_refresh_list(entered_name)
+		_note_missing_art()
+		populate()   # the display-name field changed underneath the form
+
+# Trailing empty slots are form scaffolding, not content -- trimmed so an all-empty kit reads as
+# NO kit (has_starting_kit checks emptiness) and files stay minimal. Only trailing nulls go, so
+# every equip/wear/prosthetic index keeps its meaning.
+func _trim_kit() -> void:
+	while not current.starting_inventory.is_empty() and current.starting_inventory.back() == null:
+		current.starting_inventory.pop_back()
+
+func _note_missing_art() -> void:
+	if current.map_sprite == null:
+		status_label.text = "Saved, but no map sprite is set -- the unit will be invisible on the board"
+
+# Stage the live unit selected in the Unit Editor tab (dev-mode click) as a character. Identity
+# comes off unit.unit_data; carried state rides ScenarioUnitEntry.capture_unit_state -- the one
+# compaction of a unit into a dense inventory + indices (Law #4) -- projected onto the kit block.
+# Staged only: name it and press Save As.
+func _on_capture_pressed():
+	var unit_editor: UnitEditorTool = get_node("%Unit Editor")
+	if not is_instance_valid(unit_editor.editing_unit):
+		status_label.text = "No unit selected -- click one on the board in dev mode first"
+		return
+	var unit: Unit = unit_editor.editing_unit
+
+	var data := UnitData.new()
+	var source: UnitData = unit.unit_data
+	data.display_name = source.display_name
+	data.portrait = source.portrait
+	data.map_sprite = source.map_sprite
+	data.move_sprite = source.move_sprite
+	data.downed_sprite = source.downed_sprite
+	data.faction = unit.get_faction()
+	data.innate_abilities = source.innate_abilities.duplicate()
+
+	var entry := ScenarioUnitEntry.new()
+	entry.capture_unit_state(unit)
+	data.base_stats = entry.stats
+	data.base_aura = entry.aura
+	data.base_affinity = entry.affinity
+	data.base_is_alkahest_affine = entry.is_alkahest_affine
+	data.starting_jobs = entry.jobs
+	data.starting_inventory = entry.inventory
+	data.starting_equipped_index = entry.equipped_index
+	data.starting_worn_index = entry.worn_armor_index
+	data.starting_proficiency = entry.weapon_proficiency
+	data.starting_prosthetics = entry.limb_prosthetic_items
+
+	current = data
+	_loaded_name = ""
+	load_dropdown.select(-1)
+	if name_input.text.strip_edges() == "":
+		name_input.text = data.display_name
+	_refresh_buttons()
+	status_label.text = _capture_notes(unit, entry)
+	populate()
+
+# What a character FILE cannot represent out of what the snapshot caught -- said out loud, never
+# silently dropped.
+func _capture_notes(unit: Unit, entry: ScenarioUnitEntry) -> String:
+	var notes: Array[String] = []
+	var carried := 0
+	for item in entry.inventory:
+		if item != null:
+			carried += 1
+	if carried > 0:
+		notes.append("%d carried item(s) embed inline on save; re-pick slots from the catalogs to reference Item Editor files" % carried)
+	if entry.inventory.size() > Unit.MAX_INVENTORY_SIZE:
+		notes.append("%d items exceed the %d-slot kit and drop at spawn" % [entry.inventory.size(), Unit.MAX_INVENTORY_SIZE])
+	if entry.equipped_index == -1 and _kit_has_weapon(entry.inventory):
+		notes.append("was unarmed, but a kit auto-equips the first weapon at spawn")
+	for limb_slot in entry.limb_states:
+		var state: UnitInstance.LimbState = entry.limb_states[limb_slot]
+		if state != UnitInstance.LimbState.NATURAL and not entry.limb_prosthetic_items.has(limb_slot):
+			notes.append("%s is %s -- a character file can't carry limb state, so it spawns whole" % [
+				UnitInstance.LimbSlot.keys()[limb_slot], UnitInstance.LimbState.keys()[state]])
+	var msg := "Captured %s -- name it and press Save As" % unit.get_unit_name()
+	if not notes.is_empty():
+		msg += ". Note: " + "; ".join(notes)
+	return msg
+
+func _kit_has_weapon(inventory: Array[EquippableData]) -> bool:
+	for item in inventory:
+		if item != null and not (item is ArmorData):
+			return true
+	return false
+
+# ==============================================================================
+#  The form
+# ==============================================================================
+
+func populate():
+	for child in editor_container.get_children():
+		editor_container.remove_child(child)
+		child.queue_free()
+	if current == null:
+		return
+	var edited := current
+	DevWidgets.add_lineedit(editor_container, "Display name", edited.display_name, func(s: String): edited.display_name = s)
+	DevWidgets.add_option(editor_container, "Faction", Team.Faction.keys(), Team.Faction.keys()[edited.faction],
+		func(s: String): edited.faction = Team.Faction[s])
+	_add_art_section()
+	_add_stats_section()
+	_add_affinity_section()
+	_add_abilities_section()
+	_add_jobs_section()
+	_add_kit_section()
+	_add_prosthetics_section()
+	_add_proficiency_section()
+
+# Map sprites come as idle/moving/downed triples off SpawnTool's one folder scan (Law #4);
+# portraits are this tool's own flat scan. "(keep current)" is a no-op, never a clear -- there
+# is no legitimate reason to author a sprite-less character.
+func _add_art_section() -> void:
+	var sprites := SpawnTool.build_sprite_catalog()
+	var current_sprite := KEEP_LABEL
+	for sprite_name in sprites:
+		if sprites[sprite_name]["idle"] == current.map_sprite:
+			current_sprite = sprite_name
+			break
+	var sprite_options: Array = [KEEP_LABEL]
+	sprite_options.append_array(sprites.keys())
+	DevWidgets.add_option(editor_container, "Map sprite", sprite_options, current_sprite,
+		func(label: String): _on_sprite_picked(sprites, label))
+
+	var portraits := _portrait_catalog()
+	var current_portrait := KEEP_LABEL
+	for portrait_name in portraits:
+		if portraits[portrait_name] == current.portrait:
+			current_portrait = portrait_name
+			break
+	var portrait_options: Array = [KEEP_LABEL]
+	portrait_options.append_array(portraits.keys())
+	DevWidgets.add_option(editor_container, "Portrait", portrait_options, current_portrait,
+		func(label: String): _on_portrait_picked(portraits, label))
+
+func _on_sprite_picked(sprites: Dictionary, label: String) -> void:
+	if not sprites.has(label):
+		return   # "(keep current)"
+	var triple: Dictionary = sprites[label]
+	current.map_sprite = triple["idle"]
+	current.move_sprite = triple["moving"]
+	current.downed_sprite = triple["downed"]
+
+func _on_portrait_picked(portraits: Dictionary, label: String) -> void:
+	if portraits.has(label):
+		current.portrait = portraits[label]
+
+func _portrait_catalog() -> Dictionary:
+	var portraits := {}
+	for file in ResourceDir.files_with_extension(PORTRAIT_DIR, ".png"):
+		portraits[file.get_basename()] = load(PORTRAIT_DIR + file)
+	return portraits
+
+# Sparse on purpose: a stat the dev never touches stays unauthored and keeps reading its default.
+func _add_stats_section() -> void:
+	DevWidgets.add_label(editor_container, "Base stats")
+	var grid := GridContainer.new()
+	grid.columns = 4
+	grid.add_theme_constant_override("h_separation", 12)
+	editor_container.add_child(grid)
+	for stat in Stats.STAT_DEFAULTS:
+		var key: Stats.Stat = stat
+		var label := Label.new()
+		label.text = Stats.Stat.keys()[key]
+		grid.add_child(label)
+		var spin := SpinBox.new()
+		spin.min_value = -999
+		spin.max_value = 999
+		spin.value = current.base_stats.get(key, Stats.STAT_DEFAULTS[key])
+		spin.value_changed.connect(func(v): current.base_stats[key] = int(v))
+		grid.add_child(spin)
+
+# The Unit Editor's affinity/aura row shape: the aura spinbox only exists while the affinity is
+# held, and unchecking erases the aura -- the Rebecca-rule guard, which is what makes the
+# illegal aura the shipped cast files carry unauthorable here.
+func _add_affinity_section() -> void:
+	DevWidgets.add_label(editor_container, "Affinity / Aura")
+	for element in Elemental.SIGIL_ELEMENTS:
+		var e: Elemental.Element = element
+		var row := HBoxContainer.new()
+		var box := CheckBox.new()
+		box.text = Elemental.Element.keys()[e]
+		box.button_pressed = current.base_affinity.has(e)
+		box.toggled.connect(func(pressed: bool): _on_affinity_toggled(e, pressed))
+		row.add_child(box)
+		if current.base_affinity.has(e):
+			var spin := SpinBox.new()
+			spin.min_value = -999
+			spin.max_value = 999
+			spin.value = current.base_aura.get(e, 0)
+			spin.tooltip_text = "Aura points"
+			spin.value_changed.connect(func(v): current.base_aura[e] = int(v))
+			row.add_child(spin)
+		editor_container.add_child(row)
+	DevWidgets.add_checkbox(editor_container, "Alkahest affine (hidden -- Isaac only)", current.base_is_alkahest_affine,
+		func(pressed: bool): current.base_is_alkahest_affine = pressed)
+
+func _on_affinity_toggled(element: Elemental.Element, pressed: bool) -> void:
+	if pressed:
+		if not current.base_affinity.has(element):
+			current.base_affinity.append(element)
+	else:
+		current.base_affinity.erase(element)
+		current.base_aura.erase(element)   # can't hold aura outside affinity -- Rebecca rule guard
+	populate()
+
+func _add_abilities_section() -> void:
+	DevWidgets.add_label(editor_container, "Innate abilities")
+	var abilities := AbilityCatalog.get_abilities()
+	if abilities.is_empty():
+		DevWidgets.add_label(editor_container, "  (none in Resources/Abilities/)")
+		return
+	for ability_name in abilities:
+		var ability: AbilityData = abilities[ability_name]
+		DevWidgets.add_checkbox(editor_container, ability_name, current.innate_abilities.has(ability),
+			func(pressed: bool): _on_ability_toggled(ability, pressed))
+
+func _on_ability_toggled(ability: AbilityData, pressed: bool) -> void:
+	if pressed:
+		if not current.innate_abilities.has(ability):
+			current.innate_abilities.append(ability)
+	else:
+		current.innate_abilities.erase(ability)
+
+func _add_jobs_section() -> void:
+	DevWidgets.add_label(editor_container, "Starting jobs")
+	var jobs := JobCatalog.get_editable()   # display_name -> JobData; the kit stores IDS
+	for job_name in jobs:
+		var job: JobData = jobs[job_name]
+		DevWidgets.add_checkbox(editor_container, job_name, current.starting_jobs.has(job.id),
+			func(pressed: bool): _on_job_toggled(job.id, pressed))
+
+func _on_job_toggled(id: String, pressed: bool) -> void:
+	if pressed:
+		if not current.starting_jobs.has(id):
+			current.starting_jobs.append(id)
+	else:
+		current.starting_jobs.erase(id)
+
+# The Unit Editor's weapons+armor+runes merge, CALLED rather than copied (Law #4) -- one answer
+# to "what can a dev put in a hand".
+func _equippable_catalog() -> Dictionary:
+	var unit_editor: UnitEditorTool = get_node("%Unit Editor")
+	return unit_editor._equippable_catalog()
+
+# The kit: what the character carries into any board, seeded through the gated doors at spawn
+# (#177). Slot picks stage the catalog FILE resource itself -- no copy -- so a save writes an
+# ExtResource reference and the spawn grants copy_equippable() copies off it.
+func _add_kit_section() -> void:
+	DevWidgets.add_label(editor_container, "Starting inventory (no Equip checked = auto-equip decides)")
+	var catalog := _equippable_catalog()
+	var keys: Array = catalog.keys()
+	var equip_group := ButtonGroup.new()
+	equip_group.allow_unpress = true
+
+	for i in range(Unit.MAX_INVENTORY_SIZE):
+		var slot_index := i
+		var slot_item: EquippableData = null
+		if slot_index < current.starting_inventory.size():
+			slot_item = current.starting_inventory[slot_index]
+
+		var row := HBoxContainer.new()
+		var label := Label.new()
+		label.text = "Slot %d" % (slot_index + 1)
+		label.custom_minimum_size = Vector2(60, 0)
+		row.add_child(label)
+
+		var picker := OptionButton.new()
+		picker.add_item("(empty)")
+		for k in keys:
+			picker.add_item(k)
+		var sel := 0
+		if slot_item != null:
+			for k_index in range(keys.size()):
+				if catalog[keys[k_index]] == slot_item:
+					sel = k_index + 1
+					break
+		picker.select(sel)
+		picker.item_selected.connect(func(opt_index: int): _on_slot_picked(slot_index, opt_index))
+		row.add_child(picker)
+
+		if slot_item != null and sel == 0:
+			# No catalog file backs this entry (a captured copy, or one inlined by hand) -- it
+			# embeds inside the character file on save. The Unit Editor's "holds:" honesty.
+			var held_label := Label.new()
+			held_label.text = "inline: %s" % slot_item.display_name
+			row.add_child(held_label)
+
+		var is_armor := slot_item is ArmorData
+		var equip_btn := CheckBox.new()
+		if is_armor:
+			equip_btn.text = "Wear"
+			equip_btn.button_pressed = slot_index == current.starting_worn_index
+			equip_btn.toggled.connect(func(pressed: bool): _on_worn_toggled(slot_index, pressed))
+		else:
+			equip_btn.text = "Equip"
+			equip_btn.button_group = equip_group
+			equip_btn.button_pressed = slot_item != null and slot_index == current.starting_equipped_index
+			equip_btn.toggled.connect(func(pressed: bool): _on_equip_toggled(slot_index, pressed))
+		equip_btn.disabled = slot_item == null
+		row.add_child(equip_btn)
+
+		editor_container.add_child(row)
+
+	for i in range(Unit.MAX_INVENTORY_SIZE, current.starting_inventory.size()):
+		var extra: EquippableData = current.starting_inventory[i]
+		if extra != null:
+			DevWidgets.add_label(editor_container, "  overflow: %s -- past the %d-slot cap, drops at spawn" % [extra.display_name, Unit.MAX_INVENTORY_SIZE])
+
+func _on_slot_picked(index: int, opt_index: int) -> void:
+	if current.starting_inventory.size() < Unit.MAX_INVENTORY_SIZE:
+		current.starting_inventory.resize(Unit.MAX_INVENTORY_SIZE)
+	var entry: EquippableData = null
+	if opt_index > 0:
+		var catalog := _equippable_catalog()
+		entry = catalog[catalog.keys()[opt_index - 1]]
+	current.starting_inventory[index] = entry
+	if current.starting_equipped_index == index:
+		current.starting_equipped_index = -1
+	if current.starting_worn_index == index:
+		current.starting_worn_index = -1
+	for slot in current.starting_prosthetics.keys():
+		if current.starting_prosthetics[slot] == index:
+			current.starting_prosthetics.erase(slot)   # the item that filled this limb just changed under it
+	populate()
+
+func _on_equip_toggled(index: int, pressed: bool) -> void:
+	if pressed:
+		current.starting_equipped_index = index
+	elif current.starting_equipped_index == index:
+		current.starting_equipped_index = -1   # unpressed: back to "auto-equip decides"
+
+func _on_worn_toggled(index: int, pressed: bool) -> void:
+	if pressed:
+		current.starting_worn_index = index
+	elif current.starting_worn_index == index:
+		current.starting_worn_index = -1
+	populate()
+
+# Which kit entry fills each limb -- candidates ride the same gate install_prosthetic enforces
+# (can_install_as_prosthetic), so the list can never offer an entry the spawn would refuse.
+func _add_prosthetics_section() -> void:
+	DevWidgets.add_label(editor_container, "Starting prosthetics")
+	var slot_names := UnitInstance.LimbSlot.keys()
+	for limb_slot in UnitInstance.LimbSlot.values():
+		var slot: UnitInstance.LimbSlot = limb_slot
+		var candidates: Array[int] = []
+		for i in range(current.starting_inventory.size()):
+			var item := current.starting_inventory[i] as WeaponInstance
+			if item != null and UnitInstance.can_install_as_prosthetic(slot, item):
+				candidates.append(i)
+
+		var row := HBoxContainer.new()
+		var label := Label.new()
+		label.text = slot_names[slot]
+		label.custom_minimum_size = Vector2(60, 0)
+		row.add_child(label)
+
+		var picker := OptionButton.new()
+		picker.add_item("(natural)")
+		for idx in candidates:
+			picker.add_item("Slot %d: %s" % [idx + 1, current.starting_inventory[idx].display_name])
+		var chosen: int = current.starting_prosthetics.get(slot, -1)
+		picker.select(candidates.find(chosen) + 1)   # -1 / not-found both land on 0
+		picker.item_selected.connect(func(opt_index: int): _on_prosthetic_picked(slot, opt_index, candidates))
+		row.add_child(picker)
+
+		editor_container.add_child(row)
+
+func _on_prosthetic_picked(slot: UnitInstance.LimbSlot, opt_index: int, candidates: Array[int]) -> void:
+	if opt_index > 0:
+		current.starting_prosthetics[slot] = candidates[opt_index - 1]
+	else:
+		current.starting_prosthetics.erase(slot)
+
+# Absent key = DEFAULT_PROFICIENCY (3, every mod space active) -- only a deliberate reduction is
+# worth authoring, so a value set back to 3 is erased rather than written.
+func _add_proficiency_section() -> void:
+	DevWidgets.add_label(editor_container, "Proficiency (0-3; 3 = default)")
+	var grid := GridContainer.new()
+	grid.columns = 4
+	grid.add_theme_constant_override("h_separation", 12)
+	editor_container.add_child(grid)
+	for weapon_type in WeaponData.WeaponType.values():
+		var family: WeaponData.WeaponType = weapon_type
+		if family == WeaponData.WeaponType.NONE:
+			continue
+		var label := Label.new()
+		label.text = WeaponData.WeaponType.keys()[family]
+		grid.add_child(label)
+		var spin := SpinBox.new()
+		spin.min_value = 0
+		spin.max_value = 3
+		spin.value = current.starting_proficiency.get(family, UnitInstance.DEFAULT_PROFICIENCY)
+		spin.value_changed.connect(func(v): _on_proficiency_changed(family, int(v)))
+		grid.add_child(spin)
+
+func _on_proficiency_changed(family: WeaponData.WeaponType, value: int) -> void:
+	if value == UnitInstance.DEFAULT_PROFICIENCY:
+		current.starting_proficiency.erase(family)
+	else:
+		current.starting_proficiency[family] = value

--- a/Classes/dev/CharacterEditorTool.gd.uid
+++ b/Classes/dev/CharacterEditorTool.gd.uid
@@ -1,0 +1,1 @@
+uid://csmaf1em1xek2

--- a/Classes/dev/DevOverlay.gd
+++ b/Classes/dev/DevOverlay.gd
@@ -4,14 +4,16 @@ class_name DevOverlay
 # The dev-tools window — a real OS window when unembedded (CLAUDE.md "Sharp edges": dev tools =
 # separate OS window; the game is wrapped in a SubViewport). Owns the DevTabs TabContainer and
 # wires each per-tool tab that needs external state (Spawn/Unit Editor/Scenario/Tile Brush) to the
-# live game + scenario manager; Item Editor and Attack Editor are self-sufficient (their own
-# _ready() does all setup) and need no wiring here.
+# live game + scenario manager; Item Editor, Attack Editor and Character are self-sufficient
+# (their own _ready() does all setup) and need no wiring here. The Unit Authoring tab is a plain
+# container holding the Spawn and Character sub-tabs (#179 -- top-level tabs stay few, dev call).
 
 @onready var scenario_manager: ScenarioManager = get_node("../GameContainer/GameView/Game/ScenarioManager")
 @onready var game = get_node("../GameContainer/GameView/Game")
 @onready var tile_brush: TileBrushTool = get_node("%Tile Brush")
 @onready var unit_editor: UnitEditorTool = get_node("%Unit Editor")
 @onready var spawn: SpawnTool = get_node("%Spawn")
+@onready var unit_authoring: MarginContainer = get_node("%Unit Authoring")
 @onready var scenario_tool: ScenarioTool = get_node("%Scenario")
 @onready var dev_mode_toggle: CheckButton = %DevModeToggle
 
@@ -26,13 +28,16 @@ func _ready() -> void:
 	close_requested.connect(_on_close_requested)
 	%DevTabs.tab_changed.connect(_on_tab_changed)
 	var tabs := %DevTabs
-	tabs.set_tab_tooltip(0, "Spawn units — configure here, then hover the board + Space to place.")
+	tabs.set_tab_tooltip(0, "Author units — Spawn places configured or cast units; Character edits the cast files.")
 	tabs.set_tab_tooltip(1, "Click a unit in dev mode to edit it here.")
-	tabs.set_tab_tooltip(2, "Author cast characters — the Resources/Units/ files authored saves reference. Update rewrites the character everywhere; Save As or Capture creates.")
-	tabs.set_tab_tooltip(3, "Author items — weapons and runes. Load a preset or start new, edit, name, save.")
-	tabs.set_tab_tooltip(4, "Author attacks — Transmutation, Weapon Attack, or Family Mains (edit an established family's main in place); toggle at top.")
-	tabs.set_tab_tooltip(5, "Save / load board scenarios. F2 resets the current one.")
-	tabs.set_tab_tooltip(6, "Paint the board — Terrain, Zones, or Tile States (fire/ice/cover); left-drag paints, right-click erases.")
+	tabs.set_tab_tooltip(2, "Author items — weapons and runes. Load a preset or start new, edit, name, save.")
+	tabs.set_tab_tooltip(3, "Author attacks — Transmutation, Weapon Attack, or Family Mains (edit an established family's main in place); toggle at top.")
+	tabs.set_tab_tooltip(4, "Save / load board scenarios. F2 resets the current one.")
+	tabs.set_tab_tooltip(5, "Paint the board — Terrain, Zones, or Tile States (fire/ice/cover); left-drag paints, right-click erases.")
+	var authoring_tabs: TabContainer = %AuthoringTabs
+	authoring_tabs.tab_changed.connect(_on_authoring_tab_changed)
+	authoring_tabs.set_tab_tooltip(0, "Spawn units — configure here, then hover the board + Space to place.")
+	authoring_tabs.set_tab_tooltip(1, "Author cast characters — the Resources/Units/ files authored saves reference. Update rewrites the character everywhere; Save As or Capture creates.")
 
 func _on_close_requested():
 	hide()
@@ -41,9 +46,8 @@ func _on_close_requested():
 
 func _on_tab_changed(_tab: int):
 	var current = %DevTabs.get_current_tab_control()
-	if current == spawn:
-		spawn.refresh_weapons()
-		spawn.refresh_characters()
+	if current == unit_authoring:
+		_refresh_spawn_pickers()
 	if current == unit_editor:
 		unit_editor.refresh_catalogs()
 	if current == scenario_tool:
@@ -51,6 +55,17 @@ func _on_tab_changed(_tab: int):
 	if current != tile_brush:
 		tile_brush.deactivate()
 	_update_zone_visibility()
+
+# The Spawn form's dropdowns go stale whenever authoring happens elsewhere, so they refresh at
+# BOTH doors into it: outer tab entry above, and the sub-tab switch here -- "save a character,
+# flip to Spawn, place it" never fires an outer tab change (#179).
+func _on_authoring_tab_changed(_tab: int) -> void:
+	if %AuthoringTabs.get_current_tab_control() == spawn:
+		_refresh_spawn_pickers()
+
+func _refresh_spawn_pickers() -> void:
+	spawn.refresh_weapons()
+	spawn.refresh_characters()
 
 # Zones are authoring scaffolding -- visible only while actively painting (this window up
 # AND the Tile Brush tab current), never during play.

--- a/Classes/dev/DevOverlay.gd
+++ b/Classes/dev/DevOverlay.gd
@@ -28,10 +28,11 @@ func _ready() -> void:
 	var tabs := %DevTabs
 	tabs.set_tab_tooltip(0, "Spawn units — configure here, then hover the board + Space to place.")
 	tabs.set_tab_tooltip(1, "Click a unit in dev mode to edit it here.")
-	tabs.set_tab_tooltip(2, "Author items — weapons and runes. Load a preset or start new, edit, name, save.")
-	tabs.set_tab_tooltip(3, "Author attacks — Transmutation, Weapon Attack, or Family Mains (edit an established family's main in place); toggle at top.")
-	tabs.set_tab_tooltip(4, "Save / load board scenarios. F2 resets the current one.")
-	tabs.set_tab_tooltip(5, "Paint the board — Terrain, Zones, or Tile States (fire/ice/cover); left-drag paints, right-click erases.")
+	tabs.set_tab_tooltip(2, "Author cast characters — the Resources/Units/ files authored saves reference. Update rewrites the character everywhere; Save As or Capture creates.")
+	tabs.set_tab_tooltip(3, "Author items — weapons and runes. Load a preset or start new, edit, name, save.")
+	tabs.set_tab_tooltip(4, "Author attacks — Transmutation, Weapon Attack, or Family Mains (edit an established family's main in place); toggle at top.")
+	tabs.set_tab_tooltip(5, "Save / load board scenarios. F2 resets the current one.")
+	tabs.set_tab_tooltip(6, "Paint the board — Terrain, Zones, or Tile States (fire/ice/cover); left-drag paints, right-click erases.")
 
 func _on_close_requested():
 	hide()
@@ -42,6 +43,7 @@ func _on_tab_changed(_tab: int):
 	var current = %DevTabs.get_current_tab_control()
 	if current == spawn:
 		spawn.refresh_weapons()
+		spawn.refresh_characters()
 	if current == unit_editor:
 		unit_editor.refresh_catalogs()
 	if current == scenario_tool:

--- a/Classes/dev/SpawnTool.gd
+++ b/Classes/dev/SpawnTool.gd
@@ -25,6 +25,7 @@ var _spawnable := {}
 # resource, so provenance survives and an authored save references it. null = the form flow.
 var _characters := {}
 var selected_character: UnitData = null
+var _character_dropdown: OptionButton = null
 
 func init(p_game):
 	game = p_game
@@ -49,20 +50,26 @@ func init(p_game):
 	%OtherCheckBox.button_group = faction_group
 	
 	refresh_weapons()
-	_build_sprite_catalog()
+	sprite_catalog = build_sprite_catalog()
 	var sprite_dropdown := %SpriteDropdown
 	for sprite_name in sprite_catalog:
 		sprite_dropdown.add_item(sprite_name)
 	_on_sprite_dropdown_item_selected(sprite_dropdown.selected)
 
-	# The cast picker (#177), scanned once per session like JobCatalog. "(custom)" keeps the
-	# form flow; a character spawns from its file with the faction radio as an override.
-	_characters = UnitCatalog.get_characters()
-	var character_options: Array = [CUSTOM_LABEL]
-	character_options.append_array(_characters.keys())
-	DevWidgets.add_option(self, "Character", character_options, CUSTOM_LABEL,
-		func(label: String): selected_character = null if label == CUSTOM_LABEL else _characters[label])
-	move_child(get_child(get_child_count() - 1), 0)
+	# The cast picker (#177). "(custom)" keeps the form flow; a character spawns from its file
+	# with the faction radio as an override. Built inline rather than DevWidgets.add_option so
+	# refresh_characters() can rebuild the list -- add_option's handler closes over a snapshot
+	# of its options array, which a rebuild would silently strand (#179).
+	var character_row := HBoxContainer.new()
+	var character_label := Label.new()
+	character_label.text = "Character"
+	character_row.add_child(character_label)
+	_character_dropdown = OptionButton.new()
+	_character_dropdown.item_selected.connect(_on_character_selected)
+	character_row.add_child(_character_dropdown)
+	add_child(character_row)
+	move_child(character_row, 0)
+	refresh_characters()
 
 func refresh_weapons():
 	var dropdown := %WeaponDropdown
@@ -77,6 +84,28 @@ func refresh_weapons():
 	if new_idx >= 0:
 		dropdown.select(new_idx)
 	_on_weapon_dropdown_item_selected(dropdown.selected)
+
+# Rebuild the cast dropdown from disk, keeping the selection -- called on entering this tab, so
+# a character authored in the Character tab appears without a restart (#179). Mirrors
+# refresh_weapons; a vanished selection falls back to "(custom)".
+func refresh_characters():
+	var prev_key := ""
+	if _character_dropdown.selected > 0 and _character_dropdown.selected - 1 < _characters.size():
+		prev_key = _characters.keys()[_character_dropdown.selected - 1]
+	_character_dropdown.clear()
+	_characters = UnitCatalog.get_characters()
+	_character_dropdown.add_item(CUSTOM_LABEL)
+	for character_name in _characters:
+		_character_dropdown.add_item(character_name)
+	var new_idx: int = _characters.keys().find(prev_key)
+	_character_dropdown.select(new_idx + 1 if new_idx >= 0 else 0)
+	_on_character_selected(_character_dropdown.selected)
+
+func _on_character_selected(index: int) -> void:
+	if index <= 0 or index - 1 >= _characters.size():
+		selected_character = null
+		return
+	selected_character = _characters[_characters.keys()[index - 1]]
 
 func _validate():
 	set_selected_faction()
@@ -165,8 +194,11 @@ func _on_sprite_dropdown_item_selected(index: int) -> void:
 func _on_unit_name_input_text_changed(new_text: String) -> void:
 	unit_name = new_text
 
-func _build_sprite_catalog() -> void:
+# The idle/moving/downed sprite triples under Art/Units/MapSprites/, keyed by base name.
+# Static and shared: the Character editor's art picker reads this same scan (#179, Law #4).
+static func build_sprite_catalog() -> Dictionary:
 	const SPRITE_DIR := "res://Art/Units/MapSprites/"
+	var catalog := {}
 	for file in ResourceDir.files_with_extension(SPRITE_DIR, ".png"):
 		if file.ends_with("_Moving.png"):
 			continue
@@ -178,4 +210,5 @@ func _build_sprite_catalog() -> void:
 		var moving: Texture2D = load(moving_path) if ResourceLoader.exists(moving_path) else idle
 		var downed_path := SPRITE_DIR + sprite_name + "_Downed.png"
 		var downed: Texture2D = load(downed_path) if ResourceLoader.exists(downed_path) else null
-		sprite_catalog[sprite_name] = {"idle": idle, "moving": moving, "downed": downed}
+		catalog[sprite_name] = {"idle": idle, "moving": moving, "downed": downed}
+	return catalog

--- a/Classes/jobs/AbilityCatalog.gd
+++ b/Classes/jobs/AbilityCatalog.gd
@@ -1,0 +1,12 @@
+extends Object
+class_name AbilityCatalog
+
+# Registry for authored AbilityData content under Resources/Abilities/ (#179): the character
+# editor's innate-abilities picker is the first thing to ENUMERATE abilities rather than
+# reference them file-by-file (JobData.ability_pool, ArmorData.granted_abilities). Uncached,
+# like every flat catalog outside hot paths.
+
+const ABILITY_DIR := "res://Resources/Abilities/"
+
+static func get_abilities() -> Dictionary:
+	return ResourceCatalog.by_name(ABILITY_DIR, AbilityData)

--- a/Classes/jobs/AbilityCatalog.gd.uid
+++ b/Classes/jobs/AbilityCatalog.gd.uid
@@ -1,0 +1,1 @@
+uid://bf5gq8f0y1lj3

--- a/Scenes/DevOverlay.tscn
+++ b/Scenes/DevOverlay.tscn
@@ -49,66 +49,76 @@ layout_mode = 2
 size_flags_vertical = 3
 current_tab = 0
 
-[node name="Spawn" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs" unique_id=1658763081]
+[node name="Unit Authoring" type="MarginContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs" unique_id=990000044]
+unique_name_in_owner = true
+layout_mode = 2
+metadata/_tab_index = 0
+
+[node name="AuthoringTabs" type="TabContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring" unique_id=990000045]
+unique_name_in_owner = true
+layout_mode = 2
+current_tab = 0
+
+[node name="Spawn" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs" unique_id=1658763081]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
 script = ExtResource("2_s2u0l")
 metadata/_tab_index = 0
 
-[node name="UnitNameInput" type="LineEdit" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn" unique_id=1543092952]
+[node name="UnitNameInput" type="LineEdit" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" unique_id=1543092952]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 25)
 layout_mode = 2
 text = "Soldier1"
 placeholder_text = "Name"
 
-[node name="FactionCheckBoxes" type="GridContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn" unique_id=1333475274]
+[node name="FactionCheckBoxes" type="GridContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" unique_id=1333475274]
 custom_minimum_size = Vector2(75, 25)
 layout_mode = 2
 columns = 3
 
-[node name="PlayerCheckBox" type="CheckBox" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/FactionCheckBoxes" unique_id=1276337252]
+[node name="PlayerCheckBox" type="CheckBox" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/FactionCheckBoxes" unique_id=1276337252]
 unique_name_in_owner = true
 layout_mode = 2
 button_pressed = true
 text = "Player"
 
-[node name="EnemyCheckBox" type="CheckBox" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/FactionCheckBoxes" unique_id=966222468]
+[node name="EnemyCheckBox" type="CheckBox" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/FactionCheckBoxes" unique_id=966222468]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Enemy"
 
-[node name="OtherCheckBox" type="CheckBox" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/FactionCheckBoxes" unique_id=1974080667]
+[node name="OtherCheckBox" type="CheckBox" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/FactionCheckBoxes" unique_id=1974080667]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Other"
 
-[node name="StatInput" type="GridContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn" unique_id=1722468506]
+[node name="StatInput" type="GridContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" unique_id=1722468506]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 25)
 layout_mode = 2
 columns = 4
 
-[node name="WeaponRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn" unique_id=824005631]
+[node name="WeaponRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" unique_id=824005631]
 layout_mode = 2
 
-[node name="WeaponLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/WeaponRow" unique_id=313839466]
+[node name="WeaponLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/WeaponRow" unique_id=313839466]
 layout_mode = 2
 text = "Weapon"
 
-[node name="WeaponDropdown" type="OptionButton" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/WeaponRow" unique_id=2013762213]
+[node name="WeaponDropdown" type="OptionButton" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/WeaponRow" unique_id=2013762213]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="SpriteRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn" unique_id=373928489]
+[node name="SpriteRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" unique_id=373928489]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/SpriteRow" unique_id=356273023]
+[node name="Label" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/SpriteRow" unique_id=356273023]
 layout_mode = 2
 text = "Unit Sprite"
 
-[node name="SpriteDropdown" type="OptionButton" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/SpriteRow" unique_id=1830821036]
+[node name="SpriteDropdown" type="OptionButton" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/SpriteRow" unique_id=1830821036]
 unique_name_in_owner = true
 layout_mode = 2
 
@@ -124,78 +134,78 @@ metadata/_tab_index = 1
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Character" type="MarginContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs" unique_id=990000028]
+[node name="Character" type="MarginContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs" unique_id=990000028]
 unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(200, 150)
 layout_mode = 2
 script = ExtResource("4_chr79")
-metadata/_tab_index = 2
+metadata/_tab_index = 1
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character" unique_id=990000029]
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character" unique_id=990000029]
 layout_mode = 2
 
-[node name="ExistingRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer" unique_id=990000030]
+[node name="ExistingRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer" unique_id=990000030]
 layout_mode = 2
 
-[node name="CharacterLoadDropdown" type="OptionButton" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow" unique_id=990000031]
+[node name="CharacterLoadDropdown" type="OptionButton" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/ExistingRow" unique_id=990000031]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="LoadCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow" unique_id=990000032]
+[node name="LoadCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/ExistingRow" unique_id=990000032]
 layout_mode = 2
 text = "Load"
 
-[node name="UpdateCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow" unique_id=990000033]
+[node name="UpdateCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/ExistingRow" unique_id=990000033]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Update"
 
-[node name="DeleteCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow" unique_id=990000034]
+[node name="DeleteCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/ExistingRow" unique_id=990000034]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Delete"
 
-[node name="NewRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer" unique_id=990000035]
+[node name="NewRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer" unique_id=990000035]
 layout_mode = 2
 
-[node name="NewButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow" unique_id=990000036]
+[node name="NewButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/NewRow" unique_id=990000036]
 layout_mode = 2
 text = "New"
 
-[node name="CharacterNameInput" type="LineEdit" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow" unique_id=990000037]
+[node name="CharacterNameInput" type="LineEdit" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/NewRow" unique_id=990000037]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "New character name"
 
-[node name="SaveAsCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow" unique_id=990000038]
+[node name="SaveAsCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/NewRow" unique_id=990000038]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Save As"
 
-[node name="CaptureCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow" unique_id=990000039]
+[node name="CaptureCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/NewRow" unique_id=990000039]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Stage the unit selected in the Unit Editor tab as a new character. Reads the LIVE unit -- staged edits not yet saved there are not captured."
 text = "Capture selected unit"
 
-[node name="CharacterStatusLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer" unique_id=990000040]
+[node name="CharacterStatusLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer" unique_id=990000040]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_color = Color(1, 0.45, 0.35, 1)
 autowrap_mode = 3
 
-[node name="HSeparator" type="HSeparator" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer" unique_id=990000041]
+[node name="HSeparator" type="HSeparator" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer" unique_id=990000041]
 layout_mode = 2
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer" unique_id=990000042]
+[node name="ScrollContainer" type="ScrollContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer" unique_id=990000042]
 layout_mode = 2
 size_flags_vertical = 3
 horizontal_scroll_mode = 0
 
-[node name="CharacterEditorVbox" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ScrollContainer" unique_id=990000043]
+[node name="CharacterEditorVbox" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/ScrollContainer" unique_id=990000043]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -206,7 +216,7 @@ visible = false
 custom_minimum_size = Vector2(200, 150)
 layout_mode = 2
 script = ExtResource("3_16gjg")
-metadata/_tab_index = 3
+metadata/_tab_index = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor" unique_id=382651101]
 layout_mode = 2
@@ -277,7 +287,7 @@ size_flags_horizontal = 3
 visible = false
 layout_mode = 2
 script = ExtResource("5_qihyv")
-metadata/_tab_index = 4
+metadata/_tab_index = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Attack Editor" unique_id=2053424278]
 layout_mode = 2
@@ -364,7 +374,7 @@ unique_name_in_owner = true
 visible = false
 layout_mode = 2
 script = ExtResource("2_1dnd3")
-metadata/_tab_index = 5
+metadata/_tab_index = 4
 
 [node name="LoadedScenarioLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Scenario" unique_id=990000021]
 unique_name_in_owner = true
@@ -458,7 +468,7 @@ unique_name_in_owner = true
 visible = false
 layout_mode = 2
 script = ExtResource("3_1dnd3")
-metadata/_tab_index = 6
+metadata/_tab_index = 5
 
 [node name="Panel" type="Panel" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Tile Brush" unique_id=1425842195]
 custom_minimum_size = Vector2(50, 50)
@@ -475,16 +485,16 @@ layout_mode = 2
 text = "Tile Brush on/off"
 
 [connection signal="toggled" from="Panel/MarginContainer/VBoxContainer/DevModeToggle" to="." method="_on_dev_mode_toggled"]
-[connection signal="text_changed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/UnitNameInput" to="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn" method="_on_unit_name_input_text_changed"]
-[connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/WeaponRow/WeaponDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn" method="_on_weapon_dropdown_item_selected"]
-[connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/SpriteRow/SpriteDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn" method="_on_sprite_dropdown_item_selected"]
-[connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow/CharacterLoadDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_load_dropdown_item_selected"]
-[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow/LoadCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_load_pressed"]
-[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow/UpdateCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_update_pressed"]
-[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow/DeleteCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_delete_pressed"]
-[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow/NewButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_new_pressed"]
-[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow/SaveAsCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_save_as_pressed"]
-[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow/CaptureCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_capture_pressed"]
+[connection signal="text_changed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/UnitNameInput" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" method="_on_unit_name_input_text_changed"]
+[connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/WeaponRow/WeaponDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" method="_on_weapon_dropdown_item_selected"]
+[connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/SpriteRow/SpriteDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" method="_on_sprite_dropdown_item_selected"]
+[connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/ExistingRow/CharacterLoadDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character" method="_on_load_dropdown_item_selected"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/ExistingRow/LoadCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character" method="_on_load_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/ExistingRow/UpdateCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character" method="_on_update_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/ExistingRow/DeleteCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character" method="_on_delete_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/NewRow/NewButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character" method="_on_new_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/NewRow/SaveAsCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character" method="_on_save_as_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character/VBoxContainer/NewRow/CaptureCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Character" method="_on_capture_pressed"]
 [connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor/VBoxContainer/ExistingRow/ItemLoadDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor" method="_on_load_dropdown_item_selected"]
 [connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor/VBoxContainer/ExistingRow/LoadItemButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor" method="_on_load_pressed"]
 [connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor/VBoxContainer/ExistingRow/UpdateItemButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor" method="_on_update_pressed"]

--- a/Scenes/DevOverlay.tscn
+++ b/Scenes/DevOverlay.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="Script" uid="uid://ddx3t4esgtshi" path="res://Classes/dev/SpawnTool.gd" id="2_s2u0l"]
 [ext_resource type="Script" uid="uid://dh3jl6n4f8qa8" path="res://Classes/dev/TileBrushTool.gd" id="3_1dnd3"]
 [ext_resource type="Script" uid="uid://fp1up4anr4xw" path="res://Classes/dev/ItemEditorTool.gd" id="3_16gjg"]
+[ext_resource type="Script" path="res://Classes/dev/CharacterEditorTool.gd" id="4_chr79"]
 [ext_resource type="Script" uid="uid://bgy2v6i3ovpuq" path="res://Classes/dev/AttackEditorTool.gd" id="5_qihyv"]
 [ext_resource type="ButtonGroup" uid="uid://6a8b7yuy02ce" path="res://Classes/dev/AttackTypeToggle.tres" id="6_p14e7"]
 
@@ -123,13 +124,89 @@ metadata/_tab_index = 1
 unique_name_in_owner = true
 layout_mode = 2
 
+[node name="Character" type="MarginContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs" unique_id=990000028]
+unique_name_in_owner = true
+visible = false
+custom_minimum_size = Vector2(200, 150)
+layout_mode = 2
+script = ExtResource("4_chr79")
+metadata/_tab_index = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character" unique_id=990000029]
+layout_mode = 2
+
+[node name="ExistingRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer" unique_id=990000030]
+layout_mode = 2
+
+[node name="CharacterLoadDropdown" type="OptionButton" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow" unique_id=990000031]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="LoadCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow" unique_id=990000032]
+layout_mode = 2
+text = "Load"
+
+[node name="UpdateCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow" unique_id=990000033]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Update"
+
+[node name="DeleteCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow" unique_id=990000034]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Delete"
+
+[node name="NewRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer" unique_id=990000035]
+layout_mode = 2
+
+[node name="NewButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow" unique_id=990000036]
+layout_mode = 2
+text = "New"
+
+[node name="CharacterNameInput" type="LineEdit" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow" unique_id=990000037]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "New character name"
+
+[node name="SaveAsCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow" unique_id=990000038]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Save As"
+
+[node name="CaptureCharacterButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow" unique_id=990000039]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Stage the unit selected in the Unit Editor tab as a new character. Reads the LIVE unit -- staged edits not yet saved there are not captured."
+text = "Capture selected unit"
+
+[node name="CharacterStatusLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer" unique_id=990000040]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.45, 0.35, 1)
+autowrap_mode = 3
+
+[node name="HSeparator" type="HSeparator" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer" unique_id=990000041]
+layout_mode = 2
+
+[node name="ScrollContainer" type="ScrollContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer" unique_id=990000042]
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+
+[node name="CharacterEditorVbox" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ScrollContainer" unique_id=990000043]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
 [node name="Item Editor" type="MarginContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs" unique_id=1368554550]
 unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(200, 150)
 layout_mode = 2
 script = ExtResource("3_16gjg")
-metadata/_tab_index = 2
+metadata/_tab_index = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor" unique_id=382651101]
 layout_mode = 2
@@ -200,7 +277,7 @@ size_flags_horizontal = 3
 visible = false
 layout_mode = 2
 script = ExtResource("5_qihyv")
-metadata/_tab_index = 3
+metadata/_tab_index = 4
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Attack Editor" unique_id=2053424278]
 layout_mode = 2
@@ -287,7 +364,7 @@ unique_name_in_owner = true
 visible = false
 layout_mode = 2
 script = ExtResource("2_1dnd3")
-metadata/_tab_index = 4
+metadata/_tab_index = 5
 
 [node name="LoadedScenarioLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Scenario" unique_id=990000021]
 unique_name_in_owner = true
@@ -381,7 +458,7 @@ unique_name_in_owner = true
 visible = false
 layout_mode = 2
 script = ExtResource("3_1dnd3")
-metadata/_tab_index = 5
+metadata/_tab_index = 6
 
 [node name="Panel" type="Panel" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Tile Brush" unique_id=1425842195]
 custom_minimum_size = Vector2(50, 50)
@@ -401,6 +478,13 @@ text = "Tile Brush on/off"
 [connection signal="text_changed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/UnitNameInput" to="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn" method="_on_unit_name_input_text_changed"]
 [connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/WeaponRow/WeaponDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn" method="_on_weapon_dropdown_item_selected"]
 [connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn/SpriteRow/SpriteDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Spawn" method="_on_sprite_dropdown_item_selected"]
+[connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow/CharacterLoadDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_load_dropdown_item_selected"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow/LoadCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_load_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow/UpdateCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_update_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/ExistingRow/DeleteCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_delete_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow/NewButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_new_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow/SaveAsCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_save_as_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Character/VBoxContainer/NewRow/CaptureCharacterButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Character" method="_on_capture_pressed"]
 [connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor/VBoxContainer/ExistingRow/ItemLoadDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor" method="_on_load_dropdown_item_selected"]
 [connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor/VBoxContainer/ExistingRow/LoadItemButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor" method="_on_load_pressed"]
 [connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor/VBoxContainer/ExistingRow/UpdateItemButton" to="Panel/MarginContainer/VBoxContainer/DevTabs/Item Editor" method="_on_update_pressed"]

--- a/tests/dev/test_character_editor.gd
+++ b/tests/dev/test_character_editor.gd
@@ -171,18 +171,31 @@ func test_capture_projects_the_live_unit() -> void:
 	assert_str(tool.status_label.text).contains("inline")
 
 # ==============================================================================
-#  The Spawn tab's dropdown refresh wire
+#  The Spawn form's dropdown refresh wires (both doors)
 # ==============================================================================
 
-func test_spawn_tab_entry_rebuilds_the_character_dropdown() -> void:
-	# A character authored here must reach the Spawn tab's cast picker without a restart. Drives
-	# the real tab-entry hook, not refresh_characters() directly -- the wire is the claim.
+func test_switching_to_the_spawn_subtab_rebuilds_the_character_dropdown() -> void:
+	# The inner door: save a character, flip Character -> Spawn, place it. No outer tab change
+	# ever fires on that path, so the sub-tab switch must carry its own refresh wire.
 	var spawn: SpawnTool = overlay.spawn
 	spawn._character_dropdown.clear()   # a stale list, as if the catalog changed underneath
 	assert_int(spawn._character_dropdown.item_count).is_equal(0)
 
+	var authoring_tabs: TabContainer = overlay.get_node("%AuthoringTabs")
+	authoring_tabs.current_tab = authoring_tabs.get_tab_idx_from_control(_tool())
+	authoring_tabs.current_tab = authoring_tabs.get_tab_idx_from_control(spawn)
+
+	assert_int(spawn._character_dropdown.item_count).is_equal(UnitCatalog.get_characters().size() + 1)
+
+func test_entering_the_authoring_tab_rebuilds_the_character_dropdown() -> void:
+	# The outer door: authoring can also happen entirely elsewhere (a scenario load, a delete),
+	# so entering Unit Authoring refreshes too. Drives the real tab-entry hook.
+	var spawn: SpawnTool = overlay.spawn
+	spawn._character_dropdown.clear()
+	assert_int(spawn._character_dropdown.item_count).is_equal(0)
+
 	var tabs: TabContainer = overlay.get_node("%DevTabs")
-	tabs.current_tab = tabs.get_tab_idx_from_control(_tool())
-	tabs.current_tab = tabs.get_tab_idx_from_control(spawn)
+	tabs.current_tab = tabs.get_tab_idx_from_control(overlay.unit_editor)
+	tabs.current_tab = tabs.get_tab_idx_from_control(overlay.unit_authoring)
 
 	assert_int(spawn._character_dropdown.item_count).is_equal(UnitCatalog.get_characters().size() + 1)

--- a/tests/dev/test_character_editor.gd
+++ b/tests/dev/test_character_editor.gd
@@ -1,0 +1,188 @@
+# The Character editor (#179): the dev tab that authors the Resources/Units/ cast files (#177).
+# Pins the pool chrome's guards (the Update load-gate, Save As refusals, New clearing the loaded
+# identity), the by-construction kit rule (a slot pick stages the catalog FILE, so saves write
+# ExtResource references), the Rebecca-rule aura guard, the capture projection off
+# ScenarioUnitEntry.capture_unit_state, and the Spawn-tab dropdown refresh wire.
+#
+# No case writes to disk: refusal cases return before any save, and the allowed Update
+# direction is asserted at reason level (a real press would re-save a tracked cast file).
+extends GdUnitTestSuite
+
+const MAIN_SCENE := "res://Scenes/Main.tscn"
+const H := preload("res://tests/support/squad_fixtures.gd")
+const GRASS_SOURCE := 0
+const GRASS_ATLAS := Vector2i(5, 0)
+
+var _main: Node
+var game: Node2D
+var overlay: DevOverlay
+
+func before_test() -> void:
+	_main = (load(MAIN_SCENE) as PackedScene).instantiate()
+	_main.name = "Main"
+	get_tree().root.add_child(_main)
+	await await_idle_frame()
+	game = _main.get_node("GameContainer/GameView/Game")
+	game.scenario_manager.clear_board()
+	game.game_state = game.GameState.IDLE
+	for x in range(8):
+		game.grid.set_cell(Vector2i(x, 0), GRASS_SOURCE, GRASS_ATLAS)
+	overlay = game.dev_overlay
+	await await_idle_frame()
+
+func after_test() -> void:
+	await await_idle_frame()
+	get_tree().root.remove_child(_main)
+	_main.free()
+
+func _tool() -> CharacterEditorTool:
+	return overlay.get_node("%Character")
+
+# ==============================================================================
+#  Update: the load gate
+# ==============================================================================
+
+func test_update_refuses_an_unloaded_character() -> void:
+	var tool := _tool()
+	assert_int(tool.load_dropdown.item_count).is_greater(0)   # empty catalog would make this vacuous
+	tool.load_dropdown.select(0)
+
+	tool.update_button.pressed.emit()
+
+	# The refusal wording, not just "some message": a gate-less Update would still write a label
+	# ("Saved, but no map sprite...") -- caught by this suite's own first falsification run.
+	assert_str(tool.status_label.text).contains("Load '")
+
+func test_update_allows_the_loaded_character_at_reason_level() -> void:
+	# Reason level only -- an actual allowed press would re-save a tracked cast file.
+	var tool := _tool()
+	assert_int(tool.load_dropdown.item_count).is_greater(0)
+	tool.load_dropdown.select(0)
+	tool._on_load_pressed()
+
+	assert_str(tool._update_block_reason()).is_empty()
+	assert_bool(tool.update_button.disabled).is_false()
+
+func test_new_clears_the_loaded_identity() -> void:
+	var tool := _tool()
+	assert_int(tool.load_dropdown.item_count).is_greater(0)
+	tool.load_dropdown.select(0)
+	tool._on_load_pressed()
+	assert_str(tool._loaded_name).is_not_empty()
+
+	tool.get_node("VBoxContainer/NewRow/NewButton").pressed.emit()
+
+	assert_str(tool._loaded_name).is_empty()
+	assert_int(tool.load_dropdown.selected).is_equal(-1)
+	assert_bool(tool.update_button.disabled).is_true()
+
+# ==============================================================================
+#  Save As: the refusals (all return before any save)
+# ==============================================================================
+
+func test_save_as_refuses_empty_illegal_and_taken_names() -> void:
+	var tool := _tool()
+	var save_as: Button = overlay.get_node("%SaveAsCharacterButton")
+
+	tool.name_input.text = ""
+	save_as.pressed.emit()
+	assert_str(tool.status_label.text).is_not_empty()
+
+	tool.name_input.text = "a:b"
+	save_as.pressed.emit()
+	assert_str(tool.status_label.text).contains("can't contain")
+
+	tool.name_input.text = "Aster"   # a shipped cast file -- Save As creates, Update overwrites
+	save_as.pressed.emit()
+	assert_str(tool.status_label.text).contains("already exists")
+
+# ==============================================================================
+#  The staged form's structural rules
+# ==============================================================================
+
+func test_slot_pick_stages_the_catalog_file_itself() -> void:
+	# The by-construction fix for the hand-inlined-WeaponInstance trap: a slot pick stages the
+	# catalog FILE resource, so a save writes an ExtResource reference, never an embedded copy.
+	var tool := _tool()
+	var catalog := tool._equippable_catalog()
+	assert_int(catalog.size()).is_greater(0)
+	tool._on_new_pressed()
+
+	tool._on_slot_picked(0, 1)   # first catalog entry
+
+	var staged: EquippableData = tool.current.starting_inventory[0]
+	assert_object(staged).is_same(catalog[catalog.keys()[0]])
+	assert_str(staged.resource_path).is_not_empty()
+
+func test_unchecking_an_affinity_erases_its_aura() -> void:
+	# The Rebecca-rule guard: aura outside affinity is unauthorable here, which is exactly the
+	# latent illegality the shipped cast files carry (their spawn drops it with a warning).
+	var tool := _tool()
+	tool._on_new_pressed()
+	tool._on_affinity_toggled(Elemental.Element.FIRE, true)
+	tool.current.base_aura[Elemental.Element.FIRE] = 3
+
+	tool._on_affinity_toggled(Elemental.Element.FIRE, false)
+
+	assert_bool(tool.current.base_aura.has(Elemental.Element.FIRE)).is_false()
+
+# ==============================================================================
+#  Capture: the live-unit -> character projection
+# ==============================================================================
+
+func test_capture_refuses_with_no_unit_selected() -> void:
+	var tool := _tool()
+	overlay.unit_editor.editing_unit = null
+
+	overlay.get_node("%CaptureCharacterButton").pressed.emit()
+
+	assert_str(tool.status_label.text).contains("No unit selected")
+
+func test_capture_projects_the_live_unit() -> void:
+	var abilities := AbilityCatalog.get_abilities()
+	assert_int(abilities.size()).is_greater(0)
+	var innate: AbilityData = abilities[abilities.keys()[0]]
+
+	var data := H.make_unit_data({Stats.Stat.STR: 9}, Team.Faction.ENEMY)
+	data.display_name = "Capture Subject"
+	data.innate_abilities.append(innate)
+	data.starting_jobs = ["scout"]
+	data.starting_inventory = [H.make_weapon(4), H.make_weapon(6)]
+	data.starting_equipped_index = 1
+	var unit: Unit = game.spawn_unit(data, Vector2i(1, 0))
+	assert_object(unit).is_not_null()
+	overlay.unit_editor.edit_unit(unit)
+
+	var tool := _tool()
+	overlay.get_node("%CaptureCharacterButton").pressed.emit()
+
+	var captured: UnitData = tool.current
+	assert_str(captured.display_name).is_equal("Capture Subject")
+	assert_int(captured.faction).is_equal(Team.Faction.ENEMY)
+	assert_int(captured.base_stats[Stats.Stat.STR]).is_equal(9)
+	assert_bool(captured.innate_abilities.has(innate)).is_true()
+	assert_array(captured.starting_jobs).contains(["scout"])
+	# Dense inventory, and the explicit equip pick survives capture_unit_state's index remap.
+	assert_int(captured.starting_inventory.size()).is_equal(2)
+	assert_int(captured.starting_equipped_index).is_equal(1)
+	# A capture is a NEW character, never the loaded one -- Update must stay blocked.
+	assert_str(tool._loaded_name).is_empty()
+	# The carried copies have no files behind them; the declared inline loss is said out loud.
+	assert_str(tool.status_label.text).contains("inline")
+
+# ==============================================================================
+#  The Spawn tab's dropdown refresh wire
+# ==============================================================================
+
+func test_spawn_tab_entry_rebuilds_the_character_dropdown() -> void:
+	# A character authored here must reach the Spawn tab's cast picker without a restart. Drives
+	# the real tab-entry hook, not refresh_characters() directly -- the wire is the claim.
+	var spawn: SpawnTool = overlay.spawn
+	spawn._character_dropdown.clear()   # a stale list, as if the catalog changed underneath
+	assert_int(spawn._character_dropdown.item_count).is_equal(0)
+
+	var tabs: TabContainer = overlay.get_node("%DevTabs")
+	tabs.current_tab = tabs.get_tab_idx_from_control(_tool())
+	tabs.current_tab = tabs.get_tab_idx_from_control(spawn)
+
+	assert_int(spawn._character_dropdown.item_count).is_equal(UnitCatalog.get_characters().size() + 1)

--- a/tests/dev/test_character_editor.gd.uid
+++ b/tests/dev/test_character_editor.gd.uid
@@ -1,0 +1,1 @@
+uid://gtxxxcvdpgm4


### PR DESCRIPTION
Closes #179.

## What this is

The Character tab in the dev tools — the authoring surface for `Resources/Units/` cast files (#177 made them load-bearing; nothing could edit one). Three commits:

1. **Plumbing** — `AbilityCatalog` (first enumerator of `Resources/Abilities/`), SpawnTool's Character row rebuilt inline with a stored dropdown + `refresh_characters()` fired on Spawn-tab entry, sprite-triple scan hoisted to a shared static.
2. **The tab** — Item Editor pool chrome (load-gated Update, Save As refusals, confirm-on-delete, visible status label) over a staged `UnitData`. Every identity + kit field gets a control: stats, faction, sprites/portrait, affinity/aura (Rebecca-rule guarded), alkahest, innate abilities, jobs, 6 kit slots picked **from the catalogs** (slots stage the catalog file itself, so saves write ExtResource references — the inlined-`WeaponInstance` trap is unhittable from here), equip/wear picks, prosthetics (gated by `can_install_as_prosthetic`), proficiency (absent = 3). **Capture selected unit** projects the live Unit-Editor unit through `ScenarioUnitEntry.capture_unit_state` onto the kit block; the four unrepresentable losses (inline items, auto-equip on captured-unarmed, limb states, >6 items) are all said in the status label, never silent.
3. **Tests** — 9 cases, no disk writes, all four guard falsifications proven red (details in the issue comment).

## Verification

- `tests/dev` 63/63; **full suite 1186/1186, 0 failures** (178.9s Elapsed).
- Falsified: Update gate removed, New-reset removed, aura-erase removed, refresh wire cut — each turns exactly its case red. The first falsification run caught a weak assertion (a gate-less Update still writes a "no map sprite" note into the label) and overwrote `Aster.tres` in the process — restored from git, assertion sharpened to the refusal wording.

## Playtest checklist (before merge)

- [ ] New → pick sprite/portrait → stats/kit from catalogs → Save As → new character appears in the Spawn tab's Character dropdown after switching tabs → spawn it, kit seeds
- [ ] Load Aster → tweak → Update → respawn shows the change (also: the load flags Aster's out-of-affinity aura — fixing it here is one checkbox + Update)
- [ ] Capture a live unit → read the inline-item notes → Save As
- [ ] Feel check: tab order (Character sits after Unit Editor), form section order, the red status label carrying informational capture notes

One cosmetic diff to expect: re-saving a cast file drops the editor-written `metadata/_custom_type_script` line (code-path `ResourceSaver` doesn't emit it — harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
