### PR TITLE
Wait no longer offered after a squad has acted (#190)

### DIFF
--- a/Classes/ui/MainActionMenu.gd
+++ b/Classes/ui/MainActionMenu.gd
@@ -251,7 +251,10 @@ func populate(unit: Unit) -> Array:
 		options.append(INSPECT)
 
 	if game.squad_manager.active_squad == null:
-		options.append(WAIT)
+		# Wait is a choice a squad makes ONCE; an acted squad has nothing left to end (#190).
+		# End Turn stays unconditional -- it's about the faction's turn, not this squad's state.
+		if not unit.squad.has_acted:
+			options.append(WAIT)
 		options.append(ENDTURN)
 
 	if unit != null and unit.has_any_actions(): #TODO separate general cancel and cancel queued plans

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Iosis"
-config/version="0.2.0"
+config/version="0.2.1"
 run/main_scene="uid://cxiu0yvwwxlgo"
 config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"

--- a/tests/ui/test_main_action_menu_wait_gate.gd
+++ b/tests/ui/test_main_action_menu_wait_gate.gd
@@ -1,0 +1,56 @@
+# Wait must only be offered to a squad that hasn't acted yet (#190). Wait and End Turn used to
+# share one gate (active_squad == null), so an already-spent squad's menu still offered Wait --
+# pressing it re-ran set_has_acted(true), a harmless no-op that told the player the squad could
+# still do something. End Turn stays unconditional: it's about the faction's turn, not this
+# squad's state.
+#
+# Real game scene (the #114 fixture -- root MUST be named "Main").
+extends GdUnitTestSuite
+
+const MAIN_SCENE := "res://Scenes/Main.tscn"
+const H := preload("res://tests/support/squad_fixtures.gd")
+
+var _main: Node
+var game: Node2D
+
+
+func before_test() -> void:
+	_main = (load(MAIN_SCENE) as PackedScene).instantiate()
+	_main.name = "Main"
+	get_tree().root.add_child(_main)
+	await await_idle_frame()
+	game = _main.get_node("GameContainer/GameView/Game")
+	game.scenario_manager.clear_board()
+	game.game_state = game.GameState.IDLE
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	get_tree().root.remove_child(_main)
+	_main.free()
+
+
+func _spawn_player() -> Unit:
+	var unit: Unit = game.spawn_unit(H.make_unit_data({}, Team.Faction.PLAYER), Vector2i(1, 1))
+	assert_object(unit).is_not_null()
+	game.turn_manager.set_active_faction(Team.Faction.PLAYER)
+	return unit
+
+
+func test_wait_is_offered_before_the_squad_acts() -> void:
+	var unit := _spawn_player()
+	var options: Array = game.main_action_menu.populate(unit)
+	assert_array(options).contains([MainActionMenu.WAIT])
+
+
+func test_wait_is_withdrawn_once_the_squad_has_acted() -> void:
+	var unit := _spawn_player()
+	game.squad_manager.set_has_acted(unit.squad, true)
+
+	var options: Array = game.main_action_menu.populate(unit)
+
+	assert_bool(options.has(MainActionMenu.WAIT)) \
+		.override_failure_message("Wait was still offered to a squad that already acted") \
+		.is_false()
+	# End Turn is unaffected -- ending the faction's turn stays meaningful either way.
+	assert_array(options).contains([MainActionMenu.ENDTURN])

--- a/tests/ui/test_main_action_menu_wait_gate.gd.uid
+++ b/tests/ui/test_main_action_menu_wait_gate.gd.uid
@@ -1,0 +1,1 @@
+uid://dcbfai8ug0tmt


### PR DESCRIPTION
Closes #190.

## The bug

`MainActionMenu.populate` gated Wait and End Turn together on `active_squad == null`, with no `has_acted` check. So an already-spent squad's menu still offered Wait; pressing it just re-ran `set_has_acted(true)`, a harmless no-op that told the player the squad could still do something.

## The fix

Wait now hides once the squad has acted — matching the Restart-row precedent (hidden, not greyed: "Wait — you already acted" explains nothing useful). End Turn stays unconditional, since it answers a question about the faction's turn, not this squad's state.

## Verification

New suite `tests/ui/test_main_action_menu_wait_gate.gd` (2 cases, real game scene): Wait offered before acting, withdrawn after. Falsified — reverting the gate turns the withdrawn-after-acting case red. Full suite 1223/1223.

v0.2.1 (bugfix-only bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
