### PR TITLE
Burning tiles finish downed units (#191)

### DIFF
--- a/Classes/actions/OrderExecutor.gd
+++ b/Classes/actions/OrderExecutor.gd
@@ -169,11 +169,14 @@ func _apply_cell_effects(cell_effects: Array[ResolvedCellEffect]) -> void:
 # ==============================================================================
 
 # End-of-phase burn: a unit standing in fire when ITS faction's turn ends takes damage. Routed
-# through take_damage so downs/kills/Crisis apply, then the same ejection sweep the attack pass uses.
+# through take_damage so downs/kills/Crisis apply, then the same ejection sweep the attack pass
+# uses. No is_active() filter (#191): LethalityRules.predict already rules DOWNED-plus-any-damage
+# as KILLED (Fork 3, #33) -- burn is a damage source like any other and take_damage no-ops safely
+# on an already-DEAD unit, so nothing upstream needs to ask the question again.
 func apply_burning_tile_damage(faction: Team.Faction) -> void:
 	for cell in game.terrain_states.burning_cells():
 		var unit: Unit = game.get_unit_at_cell(cell)
-		if unit != null and unit.is_active() and unit.get_faction() == faction:
+		if unit != null and unit.get_faction() == faction:
 			unit.take_damage(Terrain.BURNING_TILE_DAMAGE)
 	_process_downed_pending()
 

--- a/Resources/Units/Aster.tres
+++ b/Resources/Units/Aster.tres
@@ -1,10 +1,12 @@
-[gd_resource type="Resource" script_class="UnitData" format=3 uid="uid://b3nnfkt85unrg"]
+[gd_resource type="Resource" script_class="UnitData" format=3]
 
-[ext_resource type="Script" uid="uid://cvvknuw621ar2" path="res://Classes/units/UnitData.gd" id="1_02q80"]
-[ext_resource type="Texture2D" uid="uid://dnujumhyrhxk1" path="res://Art/Units/MapSprites/Archer_Downed.png" id="1_pp1ba"]
-[ext_resource type="Texture2D" uid="uid://fru8tri4sat1" path="res://Art/Units/MapSprites/Archer.png" id="2_eboe8"]
-[ext_resource type="Texture2D" uid="uid://bjd6rwjgyea45" path="res://Art/Units/MapSprites/Archer_Moving.png" id="3_e65li"]
-[ext_resource type="Texture2D" uid="uid://dio6wu07l06cy" path="res://Art/Units/Portraits/hair_mcgee_sky.png" id="4_7fkxf"]
+[ext_resource type="Script" path="res://Classes/units/UnitData.gd" id="1_02q80"]
+[ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Archer_Downed.png" id="1_pp1ba"]
+[ext_resource type="Script" path="res://Classes/jobs/AbilityData.gd" id="2_e65li"]
+[ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Archer.png" id="2_eboe8"]
+[ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Archer_Moving.png" id="3_e65li"]
+[ext_resource type="Texture2D" path="res://Art/Units/Portraits/hair_mcgee_sky.png" id="4_7fkxf"]
+[ext_resource type="Script" path="res://Classes/items/EquippableData.gd" id="7_7fkxf"]
 
 [resource]
 script = ExtResource("1_02q80")
@@ -25,4 +27,5 @@ downed_sprite = ExtResource("1_pp1ba")
 base_aura = Dictionary[int, int]({
 2: 1
 })
+base_affinity = Array[int]([2])
 metadata/_custom_type_script = "uid://cvvknuw621ar2"

--- a/Resources/Units/Bram.tres
+++ b/Resources/Units/Bram.tres
@@ -1,10 +1,12 @@
-[gd_resource type="Resource" script_class="UnitData" format=3 uid="uid://dnkm0jkhvbdso"]
+[gd_resource type="Resource" script_class="UnitData" format=3]
 
-[ext_resource type="Texture2D" uid="uid://cxaxsc32mh1ld" path="res://Art/Units/MapSprites/Basic_Soldier_Downed.png" id="1_ef1sp"]
-[ext_resource type="Script" uid="uid://cvvknuw621ar2" path="res://Classes/units/UnitData.gd" id="1_v2kxy"]
-[ext_resource type="Texture2D" uid="uid://dwv13r7ee4qf6" path="res://Art/Units/MapSprites/Basic_Soldier.png" id="2_nyms1"]
-[ext_resource type="Texture2D" uid="uid://deyav21j482j7" path="res://Art/Units/MapSprites/Basic_Soldier_Moving.png" id="3_t8aii"]
-[ext_resource type="Texture2D" uid="uid://bun6xqwudsavw" path="res://Art/Units/Portraits/hair_mcgee.png" id="4_1fjdo"]
+[ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Basic_Soldier_Downed.png" id="1_ef1sp"]
+[ext_resource type="Script" path="res://Classes/units/UnitData.gd" id="1_v2kxy"]
+[ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Basic_Soldier.png" id="2_nyms1"]
+[ext_resource type="Script" path="res://Classes/jobs/AbilityData.gd" id="2_t8aii"]
+[ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Basic_Soldier_Moving.png" id="3_t8aii"]
+[ext_resource type="Texture2D" path="res://Art/Units/Portraits/hair_mcgee.png" id="4_1fjdo"]
+[ext_resource type="Script" path="res://Classes/items/EquippableData.gd" id="7_1fjdo"]
 
 [resource]
 script = ExtResource("1_v2kxy")
@@ -25,4 +27,5 @@ downed_sprite = ExtResource("1_ef1sp")
 base_aura = Dictionary[int, int]({
 5: 2
 })
+base_affinity = Array[int]([5])
 metadata/_custom_type_script = "uid://cvvknuw621ar2"

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -1,8 +1,11 @@
+[runnable_presets]
+
+"Windows Desktop"="Windows Desktop"
+
 [preset.0]
 
 name="Windows Desktop"
 platform="Windows Desktop"
-runnable=true
 dedicated_server=false
 custom_features=""
 export_filter="all_resources"

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Iosis"
-config/version="0.2.0"
+config/version="0.2.2"
 run/main_scene="uid://cxiu0yvwwxlgo"
 config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"

--- a/tests/terrain/test_burning_damage.gd
+++ b/tests/terrain/test_burning_damage.gd
@@ -80,3 +80,17 @@ func test_fire_spares_the_faction_whose_turn_is_not_ending() -> void:
 	game.order_executor.apply_burning_tile_damage(Team.Faction.ENEMY)
 
 	assert_int(unit.get_current_hp()).is_equal(hp_before)
+
+func test_burning_finishes_a_downed_unit_standing_on_the_fire() -> void:
+	# Fork 3 (#33): a downed body takes any damaging hit as a kill. Burn is a damage source like
+	# any other -- it must not be the one thing on the board that lets a downed unit sit in fire
+	# forever (#191).
+	var unit := _spawn(CELL, Team.Faction.PLAYER)
+	unit.force_down()
+	_deposit(CELL, Terrain.TileState.BURNING)
+
+	game.order_executor.apply_burning_tile_damage(Team.Faction.PLAYER)
+
+	assert_bool(unit.is_dead()) \
+		.override_failure_message("a downed unit standing in fire survived its faction's turn end") \
+		.is_true()


### PR DESCRIPTION
Closes #191.

## The bug

`OrderExecutor.apply_burning_tile_damage` filtered on `unit.is_active()`, so a downed body standing on a burning tile was never even asked `take_damage` — silently immune to the one damage source that skipped it.

## Why it's a one-clause fix, not a new design call

`LethalityRules.predict` already has a shipped, decided rule (Fork 3, #33's lifecycle grill): **any damaging hit on a DOWNED unit is a kill.** Every other damage source honors that by routing through `take_damage`. Burn was the one source that filtered downed units out before ever asking the question. `take_damage` is also provably safe to call on an already-DEAD unit (`LethalityRules.predict` no-ops it, and `Unit.die()` is idempotent) — so the fix is dropping the filter, not adding a smarter one.

## Verification

New case in `tests/terrain/test_burning_damage.gd`: force a unit DOWNED, deposit fire on its tile, run the end-of-turn burn, assert it's dead. Falsified — reverting the filter turns the new case red; the four pre-existing burning-damage cases are unaffected. Full suite 1222/1222.

## Also in this branch

Two unrelated local changes that were sitting uncommitted, wrapped in at your request, as their own commit:
- `Resources/Units/Aster.tres` / `Bram.tres` — `base_affinity` set to match each unit's existing `base_aura` element (authored via the in-game Character Editor, which is also why their `uid=` headers changed — a runtime save doesn't carry the editor's uid cache).
- `export_presets.cfg` — the Godot 4.7 Export dialog's own reformat (`runnable=true` → a `[runnable_presets]` section) from building the test .exe for #144's playtest.

v0.2.2 (bugfix-only bump). **Note for merge order:** PR #192 (#190) also bumps this line, to 0.2.1 — whichever of the two merges second will hit a one-line conflict on `project.godot`'s version string. Trivial to resolve (keep the higher number), flagging so it's not a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
