### PR TITLE
Hover card reads the tile's own data, not the Kind enum

### DIFF
--- a/Classes/board/HoverPresenter.gd
+++ b/Classes/board/HoverPresenter.gd
@@ -260,13 +260,20 @@ func _show_hover_panel(hovered: Unit, cell: Vector2i) -> void:
 	#   - hovering the inspected unit adds nothing -> suppress the hover card (tile card too)
 	#   - anything else -> the card keeps its own top/bottom logic, shifted right of the column
 	# The card is a stack since #135, and the tile half shows for EVERY real tile (dev, round 2):
-	# icon + kind name header, then the tile's states, rules and possible interactions.
+	# icon + name header, then the tile's states, rules and possible interactions.
 	var board: BoardContext = game._board()
 	var kind: Terrain.Kind = board.terrain_kind_at(cell)
-	# Direct map read, null for a decorative NONE-kind tile on purpose — a headerless card, not
-	# get_terrain_icon_at_cell's ERROR art (that fallback is for pathing readouts, not a display).
-	var icon: Texture2D = GridUtils.TERRAIN_ICONS.get(kind, null)
-	var header: String = Terrain.kind_display_name(kind) if kind != Terrain.Kind.NONE else ""
+	# The tile's OWN data names and pictures the card (2026-08-12): authored terrain_name first,
+	# kind name as the fallback, the tile's sprite as the picture -- the same policy the brush
+	# palette rows read (GridUtils.authored_tile_display_name / tile_sprite), so hover and palette
+	# cannot disagree. A bare unnamed NONE-kind tile stays headerless on purpose, and
+	# TERRAIN_ICONS stays the queue rows' pathing glyph, not a display read.
+	var data: TileData = game.grid.get_cell_tile_data(cell)
+	var authored: String = GridUtils.authored_tile_display_name(data)
+	var header: String = authored if authored != "" \
+		else (Terrain.kind_display_name(kind) if kind != Terrain.Kind.NONE else "")
+	var source: TileSetAtlasSource = game.grid.tile_set.get_source(game.grid.get_cell_source_id(cell)) as TileSetAtlasSource
+	var icon: Texture2D = GridUtils.tile_sprite(source, game.grid.get_cell_atlas_coords(cell))
 	var tile_lines: Array[String] = _tile_readout_lines(cell)
 	var world_pos: Vector2 = hovered.global_position if hovered != null \
 		else game.grid.to_global(game.grid.map_to_local(cell))

--- a/Classes/core/GridUtils.gd
+++ b/Classes/core/GridUtils.gd
@@ -68,6 +68,26 @@ static func get_terrain_icon_at_cell(grid: TileMapLayer, cell: Vector2i) -> Text
 	if TERRAIN_ICONS.has(kind):
 		return TERRAIN_ICONS[kind]
 	return ERROR_ICON
+
+# The authored display name a tile carries (terrain_name custom data, capitalized), "" when
+# unnamed. ONE naming policy for every surface that names a tile -- the brush palette rows and
+# the hover card must not disagree (2026-08-12).
+static func authored_tile_display_name(data: TileData) -> String:
+	if data == null or not data.has_custom_data("terrain_name"):
+		return ""
+	var raw: String = data.get_custom_data("terrain_name")
+	return raw.capitalize()
+
+# The tile's own sprite, cut from its atlas sheet -- what the palette rows and the hover card
+# draw. Rect2-wrapped: the getter returns Rect2i and AtlasTexture.region is Rect2, and Variant
+# equality across the two is FALSE, which bites anything comparing regions later.
+static func tile_sprite(source: TileSetAtlasSource, coords: Vector2i) -> Texture2D:
+	if source == null:
+		return null
+	var icon := AtlasTexture.new()
+	icon.atlas = source.texture
+	icon.region = Rect2(source.get_tile_texture_region(coords))
+	return icon
 	
 # Blended Manhattan/Chebyshev range (#25). `integral` = Manhattan reach; `and_a_half`
 # bevels in the diagonal corners of that ring (Chebyshev <= integral AND Manhattan

--- a/Classes/dev/TileBrushTool.gd
+++ b/Classes/dev/TileBrushTool.gd
@@ -118,21 +118,16 @@ func _palette_entry(source_id: int, source: TileSetAtlasSource, coords: Vector2i
 			kind = raw as Terrain.Kind
 		else:
 			push_warning("TileBrushTool: tile %s carries terrain_type %d, not in Terrain.Kind; treating as scenery" % [coords, raw])
-	var tile_name := ""
-	if data.has_custom_data("terrain_name"):
-		tile_name = data.get_custom_data("terrain_name")
+	var tile_name := GridUtils.authored_tile_display_name(data)
 	if kind == Terrain.Kind.NONE and tile_name == "":
 		return null
 	var entry := PaletteEntry.new()
 	entry.kind = kind
 	entry.source_id = source_id
 	entry.coords = coords
-	entry.label = tile_name.capitalize() if tile_name != "" \
+	entry.label = tile_name if tile_name != "" \
 		else "%s (%d:%d)" % [Terrain.kind_display_name(kind), coords.x, coords.y]
-	var icon := AtlasTexture.new()
-	icon.atlas = source.texture
-	icon.region = source.get_tile_texture_region(coords)
-	entry.icon = icon
+	entry.icon = GridUtils.tile_sprite(source, coords)
 	return entry
 
 # Real terrain first (grouped by kind, enum order), named scenery last; stable within a kind

--- a/Scenarios/missions/Level_1.tres
+++ b/Scenarios/missions/Level_1.tres
@@ -37,262 +37,37 @@
 [ext_resource type="Texture2D" path="res://Art/Units/Portraits/hair_mcgee.png" id="35_x3usm"]
 [ext_resource type="Resource" path="res://Resources/RuneVariants/FreezeRune.tres" id="36_o7ahr"]
 [ext_resource type="Resource" path="res://Resources/Units/Noemie.tres" id="37_3hm3v"]
-
-[sub_resource type="Resource" id="Resource_gbsh8"]
-script = ExtResource("4_xb5bl")
-template = ExtResource("6_4md37")
-display_name = "Chainsword"
+[ext_resource type="Resource" path="res://Resources/Units/Ross.tres" id="38_gbsh8"]
 
 [sub_resource type="Resource" id="Resource_svwhi"]
-script = ExtResource("13_547l0")
-display_name = "Thug"
-portrait = ExtResource("12_3ikya")
-base_stats = Dictionary[int, int]({
-0: 15,
-1: 5,
-2: 5,
-3: 5,
-4: 5,
-5: 5,
-6: 5,
-7: 4
-})
-faction = 1
-map_sprite = ExtResource("10_rxito")
-move_sprite = ExtResource("11_2b4hx")
-downed_sprite = ExtResource("8_ugkkt")
+script = ExtResource("4_xb5bl")
+template = ExtResource("6_4md37")
+display_name = "Chainsword"
 
 [sub_resource type="Resource" id="Resource_xky18"]
-script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_svwhi")
-cell = Vector2i(16, -18)
-squad_id = 0
-is_leader = true
-squad_archetype = 2
-stats = Dictionary[int, int]({
-0: 30,
-1: 8,
-2: 8,
+script = ExtResource("13_547l0")
+display_name = "Thug"
+portrait = ExtResource("12_3ikya")
+base_stats = Dictionary[int, int]({
+0: 15,
+1: 5,
+2: 5,
 3: 5,
 4: 5,
 5: 5,
 6: 5,
-7: 6
+7: 4
 })
-current_hp = 30
-current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_gbsh8")])
-equipped_index = 0
-affinity_saved = true
-limb_states = Dictionary[int, int]({
-0: 0,
-1: 0,
-2: 0,
-3: 0
-})
-weapon_battle_states = Dictionary[int, Dictionary]({
-0: {
-"rev": 0
-}
-})
+faction = 1
+map_sprite = ExtResource("10_rxito")
+move_sprite = ExtResource("11_2b4hx")
+downed_sprite = ExtResource("8_ugkkt")
 
 [sub_resource type="Resource" id="Resource_3id6q"]
-script = ExtResource("14_45ts8")
-template = ExtResource("15_y8oh2")
-display_name = "Gun"
-
-[sub_resource type="Resource" id="Resource_h3plt"]
-script = ExtResource("13_547l0")
-display_name = "Thug3"
-portrait = ExtResource("12_3ikya")
-base_stats = Dictionary[int, int]({
-0: 15,
-1: 5,
-2: 5,
-3: 5,
-4: 5,
-5: 5,
-6: 5,
-7: 4
-})
-faction = 1
-map_sprite = ExtResource("17_hmuey")
-move_sprite = ExtResource("18_n46v8")
-downed_sprite = ExtResource("16_gac6d")
-
-[sub_resource type="Resource" id="Resource_6id6f"]
 script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_h3plt")
-cell = Vector2i(15, -18)
-squad_id = 0
-stats = Dictionary[int, int]({
-0: 15,
-1: 5,
-2: 5,
-3: 5,
-4: 5,
-5: 5,
-6: 5,
-7: 4
-})
-current_hp = 15
-current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_3id6q")])
-equipped_index = 0
-affinity_saved = true
-limb_states = Dictionary[int, int]({
-0: 0,
-1: 0,
-2: 0,
-3: 0
-})
-weapon_battle_states = Dictionary[int, Dictionary]({
-0: {
-"shots": 2
-}
-})
-
-[sub_resource type="Resource" id="Resource_x3usm"]
-script = ExtResource("14_45ts8")
-template = ExtResource("15_y8oh2")
-display_name = "Gun"
-
-[sub_resource type="Resource" id="Resource_o7ahr"]
-script = ExtResource("13_547l0")
-display_name = "Thug4"
-portrait = ExtResource("12_3ikya")
-base_stats = Dictionary[int, int]({
-0: 15,
-1: 5,
-2: 5,
-3: 5,
-4: 5,
-5: 5,
-6: 5,
-7: 4
-})
-faction = 1
-map_sprite = ExtResource("17_hmuey")
-move_sprite = ExtResource("18_n46v8")
-downed_sprite = ExtResource("16_gac6d")
-
-[sub_resource type="Resource" id="Resource_ga0bu"]
-script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_o7ahr")
-cell = Vector2i(15, -19)
-squad_id = 0
-stats = Dictionary[int, int]({
-0: 15,
-1: 5,
-2: 5,
-3: 5,
-4: 5,
-5: 5,
-6: 5,
-7: 4
-})
-current_hp = 15
-current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_x3usm")])
-equipped_index = 0
-affinity_saved = true
-limb_states = Dictionary[int, int]({
-0: 0,
-1: 0,
-2: 0,
-3: 0
-})
-weapon_battle_states = Dictionary[int, Dictionary]({
-0: {
-"shots": 2
-}
-})
-
-[sub_resource type="Resource" id="Resource_qdfkr"]
-script = ExtResource("4_xb5bl")
-template = ExtResource("6_4md37")
-display_name = "Chainsword"
-
-[sub_resource type="Resource" id="Resource_c2j5n"]
-script = ExtResource("13_547l0")
-display_name = "Thug"
-portrait = ExtResource("12_3ikya")
-base_stats = Dictionary[int, int]({
-0: 15,
-1: 5,
-2: 5,
-3: 5,
-4: 5,
-5: 5,
-6: 5,
-7: 4
-})
-faction = 1
-map_sprite = ExtResource("10_rxito")
-move_sprite = ExtResource("11_2b4hx")
-downed_sprite = ExtResource("8_ugkkt")
-
-[sub_resource type="Resource" id="Resource_5a8c1"]
-script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_c2j5n")
-cell = Vector2i(16, -19)
-squad_id = 0
-stats = Dictionary[int, int]({
-0: 30,
-1: 8,
-2: 8,
-3: 5,
-4: 5,
-5: 5,
-6: 5,
-7: 6
-})
-current_hp = 30
-current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_qdfkr")])
-equipped_index = 0
-affinity_saved = true
-limb_states = Dictionary[int, int]({
-0: 0,
-1: 0,
-2: 0,
-3: 0
-})
-weapon_battle_states = Dictionary[int, Dictionary]({
-0: {
-"rev": 0
-}
-})
-
-[sub_resource type="Resource" id="Resource_1syme"]
-script = ExtResource("4_xb5bl")
-template = ExtResource("6_4md37")
-display_name = "Chainsword"
-
-[sub_resource type="Resource" id="Resource_id3v2"]
-script = ExtResource("13_547l0")
-display_name = "Thug"
-portrait = ExtResource("12_3ikya")
-base_stats = Dictionary[int, int]({
-0: 15,
-1: 5,
-2: 5,
-3: 5,
-4: 5,
-5: 5,
-6: 5,
-7: 4
-})
-faction = 1
-map_sprite = ExtResource("10_rxito")
-move_sprite = ExtResource("11_2b4hx")
-downed_sprite = ExtResource("8_ugkkt")
-
-[sub_resource type="Resource" id="Resource_p1dkl"]
-script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_id3v2")
+unit_data = SubResource("Resource_xky18")
 cell = Vector2i(19, 18)
-squad_id = 1
+squad_id = 0
 is_leader = true
 squad_archetype = 2
 stats = Dictionary[int, int]({
@@ -307,7 +82,7 @@ stats = Dictionary[int, int]({
 })
 current_hp = 30
 current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_1syme")])
+inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_svwhi")])
 equipped_index = 0
 affinity_saved = true
 limb_states = Dictionary[int, int]({
@@ -322,12 +97,12 @@ weapon_battle_states = Dictionary[int, Dictionary]({
 }
 })
 
-[sub_resource type="Resource" id="Resource_n5s48"]
+[sub_resource type="Resource" id="Resource_h3plt"]
 script = ExtResource("4_xb5bl")
 template = ExtResource("6_4md37")
 display_name = "Chainsword"
 
-[sub_resource type="Resource" id="Resource_os0fr"]
+[sub_resource type="Resource" id="Resource_6id6f"]
 script = ExtResource("13_547l0")
 display_name = "Thug"
 portrait = ExtResource("12_3ikya")
@@ -346,11 +121,11 @@ map_sprite = ExtResource("10_rxito")
 move_sprite = ExtResource("11_2b4hx")
 downed_sprite = ExtResource("8_ugkkt")
 
-[sub_resource type="Resource" id="Resource_1r2vb"]
+[sub_resource type="Resource" id="Resource_x3usm"]
 script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_os0fr")
+unit_data = SubResource("Resource_6id6f")
 cell = Vector2i(19, 17)
-squad_id = 1
+squad_id = 0
 stats = Dictionary[int, int]({
 0: 30,
 1: 8,
@@ -363,7 +138,7 @@ stats = Dictionary[int, int]({
 })
 current_hp = 30
 current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_n5s48")])
+inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_h3plt")])
 equipped_index = 0
 affinity_saved = true
 limb_states = Dictionary[int, int]({
@@ -378,12 +153,12 @@ weapon_battle_states = Dictionary[int, Dictionary]({
 }
 })
 
-[sub_resource type="Resource" id="Resource_ctcr5"]
+[sub_resource type="Resource" id="Resource_o7ahr"]
 script = ExtResource("4_xb5bl")
 template = ExtResource("6_4md37")
 display_name = "Chainsword"
 
-[sub_resource type="Resource" id="Resource_whq8x"]
+[sub_resource type="Resource" id="Resource_ga0bu"]
 script = ExtResource("13_547l0")
 display_name = "Thug"
 portrait = ExtResource("12_3ikya")
@@ -402,11 +177,11 @@ map_sprite = ExtResource("10_rxito")
 move_sprite = ExtResource("11_2b4hx")
 downed_sprite = ExtResource("8_ugkkt")
 
-[sub_resource type="Resource" id="Resource_f10k0"]
+[sub_resource type="Resource" id="Resource_qdfkr"]
 script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_whq8x")
+unit_data = SubResource("Resource_ga0bu")
 cell = Vector2i(19, 19)
-squad_id = 1
+squad_id = 0
 stats = Dictionary[int, int]({
 0: 30,
 1: 8,
@@ -419,7 +194,7 @@ stats = Dictionary[int, int]({
 })
 current_hp = 30
 current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_ctcr5")])
+inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_o7ahr")])
 equipped_index = 0
 affinity_saved = true
 limb_states = Dictionary[int, int]({
@@ -434,12 +209,12 @@ weapon_battle_states = Dictionary[int, Dictionary]({
 }
 })
 
-[sub_resource type="Resource" id="Resource_afmdw"]
+[sub_resource type="Resource" id="Resource_c2j5n"]
 script = ExtResource("19_h1cgr")
 template = ExtResource("20_7gc35")
 display_name = "Smasher"
 
-[sub_resource type="Resource" id="Resource_cc41g"]
+[sub_resource type="Resource" id="Resource_5a8c1"]
 script = ExtResource("13_547l0")
 display_name = "Thug5"
 portrait = ExtResource("12_3ikya")
@@ -458,11 +233,11 @@ map_sprite = ExtResource("22_u8yuh")
 move_sprite = ExtResource("23_02bmv")
 downed_sprite = ExtResource("21_dgd3j")
 
-[sub_resource type="Resource" id="Resource_8d3q1"]
+[sub_resource type="Resource" id="Resource_1syme"]
 script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_cc41g")
+unit_data = SubResource("Resource_5a8c1")
 cell = Vector2i(15, 14)
-squad_id = 2
+squad_id = 1
 is_leader = true
 squad_archetype = 3
 squad_zone = "PatrolZone"
@@ -478,7 +253,7 @@ stats = Dictionary[int, int]({
 })
 current_hp = 15
 current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_afmdw")])
+inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_c2j5n")])
 equipped_index = 0
 affinity_saved = true
 limb_states = Dictionary[int, int]({
@@ -493,12 +268,12 @@ weapon_battle_states = Dictionary[int, Dictionary]({
 }
 })
 
-[sub_resource type="Resource" id="Resource_4yu8n"]
+[sub_resource type="Resource" id="Resource_id3v2"]
 script = ExtResource("4_xb5bl")
 template = ExtResource("6_4md37")
 display_name = "Chainsword"
 
-[sub_resource type="Resource" id="Resource_jfk3a"]
+[sub_resource type="Resource" id="Resource_p1dkl"]
 script = ExtResource("13_547l0")
 display_name = "Thug6"
 portrait = ExtResource("12_3ikya")
@@ -517,11 +292,11 @@ map_sprite = ExtResource("25_kfy1x")
 move_sprite = ExtResource("26_1q2cn")
 downed_sprite = ExtResource("24_q3c41")
 
-[sub_resource type="Resource" id="Resource_8uilc"]
+[sub_resource type="Resource" id="Resource_n5s48"]
 script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_jfk3a")
+unit_data = SubResource("Resource_p1dkl")
 cell = Vector2i(16, 13)
-squad_id = 2
+squad_id = 1
 stats = Dictionary[int, int]({
 0: 15,
 1: 5,
@@ -534,7 +309,7 @@ stats = Dictionary[int, int]({
 })
 current_hp = 15
 current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_4yu8n")])
+inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_id3v2")])
 equipped_index = 0
 affinity_saved = true
 limb_states = Dictionary[int, int]({
@@ -549,12 +324,12 @@ weapon_battle_states = Dictionary[int, Dictionary]({
 }
 })
 
-[sub_resource type="Resource" id="Resource_mgyax"]
+[sub_resource type="Resource" id="Resource_os0fr"]
 script = ExtResource("4_xb5bl")
 template = ExtResource("6_4md37")
 display_name = "Chainsword"
 
-[sub_resource type="Resource" id="Resource_h7ob1"]
+[sub_resource type="Resource" id="Resource_1r2vb"]
 script = ExtResource("13_547l0")
 display_name = "Thug7"
 portrait = ExtResource("12_3ikya")
@@ -573,11 +348,11 @@ map_sprite = ExtResource("25_kfy1x")
 move_sprite = ExtResource("26_1q2cn")
 downed_sprite = ExtResource("24_q3c41")
 
-[sub_resource type="Resource" id="Resource_kj2a7"]
+[sub_resource type="Resource" id="Resource_ctcr5"]
 script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_h7ob1")
+unit_data = SubResource("Resource_1r2vb")
 cell = Vector2i(14, 13)
-squad_id = 2
+squad_id = 1
 stats = Dictionary[int, int]({
 0: 15,
 1: 5,
@@ -590,7 +365,7 @@ stats = Dictionary[int, int]({
 })
 current_hp = 15
 current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_mgyax")])
+inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_os0fr")])
 equipped_index = 0
 affinity_saved = true
 limb_states = Dictionary[int, int]({
@@ -605,12 +380,12 @@ weapon_battle_states = Dictionary[int, Dictionary]({
 }
 })
 
-[sub_resource type="Resource" id="Resource_5rv14"]
+[sub_resource type="Resource" id="Resource_whq8x"]
 script = ExtResource("14_45ts8")
 template = ExtResource("15_y8oh2")
 display_name = "Gun"
 
-[sub_resource type="Resource" id="Resource_cmop5"]
+[sub_resource type="Resource" id="Resource_f10k0"]
 script = ExtResource("13_547l0")
 display_name = "Thug8"
 portrait = ExtResource("12_3ikya")
@@ -629,11 +404,11 @@ map_sprite = ExtResource("17_hmuey")
 move_sprite = ExtResource("18_n46v8")
 downed_sprite = ExtResource("16_gac6d")
 
-[sub_resource type="Resource" id="Resource_mq5u2"]
+[sub_resource type="Resource" id="Resource_afmdw"]
 script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_cmop5")
+unit_data = SubResource("Resource_f10k0")
 cell = Vector2i(17, 6)
-squad_id = 3
+squad_id = 2
 is_leader = true
 squad_archetype = 3
 squad_zone = "PatrolZone"
@@ -649,7 +424,7 @@ stats = Dictionary[int, int]({
 })
 current_hp = 15
 current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_5rv14")])
+inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_whq8x")])
 equipped_index = 0
 affinity_saved = true
 limb_states = Dictionary[int, int]({
@@ -664,12 +439,12 @@ weapon_battle_states = Dictionary[int, Dictionary]({
 }
 })
 
-[sub_resource type="Resource" id="Resource_cqy3p"]
+[sub_resource type="Resource" id="Resource_cc41g"]
 script = ExtResource("14_45ts8")
 template = ExtResource("15_y8oh2")
 display_name = "Gun"
 
-[sub_resource type="Resource" id="Resource_8mey3"]
+[sub_resource type="Resource" id="Resource_8d3q1"]
 script = ExtResource("13_547l0")
 display_name = "Thug9"
 portrait = ExtResource("12_3ikya")
@@ -688,11 +463,11 @@ map_sprite = ExtResource("17_hmuey")
 move_sprite = ExtResource("18_n46v8")
 downed_sprite = ExtResource("16_gac6d")
 
-[sub_resource type="Resource" id="Resource_sk6hk"]
+[sub_resource type="Resource" id="Resource_4yu8n"]
 script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_8mey3")
+unit_data = SubResource("Resource_8d3q1")
 cell = Vector2i(13, 6)
-squad_id = 4
+squad_id = 3
 is_leader = true
 squad_archetype = 3
 squad_zone = "PatrolZone"
@@ -708,7 +483,7 @@ stats = Dictionary[int, int]({
 })
 current_hp = 15
 current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_cqy3p")])
+inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_cc41g")])
 equipped_index = 0
 affinity_saved = true
 limb_states = Dictionary[int, int]({
@@ -723,12 +498,12 @@ weapon_battle_states = Dictionary[int, Dictionary]({
 }
 })
 
-[sub_resource type="Resource" id="Resource_gi3f2"]
+[sub_resource type="Resource" id="Resource_jfk3a"]
 script = ExtResource("14_45ts8")
 template = ExtResource("15_y8oh2")
 display_name = "Gun"
 
-[sub_resource type="Resource" id="Resource_14186"]
+[sub_resource type="Resource" id="Resource_8uilc"]
 script = ExtResource("13_547l0")
 display_name = "Thug10"
 portrait = ExtResource("12_3ikya")
@@ -747,11 +522,11 @@ map_sprite = ExtResource("17_hmuey")
 move_sprite = ExtResource("18_n46v8")
 downed_sprite = ExtResource("16_gac6d")
 
-[sub_resource type="Resource" id="Resource_5ohq1"]
+[sub_resource type="Resource" id="Resource_mgyax"]
 script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_14186")
+unit_data = SubResource("Resource_8uilc")
 cell = Vector2i(17, 7)
-squad_id = 3
+squad_id = 2
 stats = Dictionary[int, int]({
 0: 15,
 1: 5,
@@ -764,7 +539,7 @@ stats = Dictionary[int, int]({
 })
 current_hp = 15
 current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_gi3f2")])
+inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_jfk3a")])
 equipped_index = 0
 affinity_saved = true
 limb_states = Dictionary[int, int]({
@@ -779,12 +554,12 @@ weapon_battle_states = Dictionary[int, Dictionary]({
 }
 })
 
-[sub_resource type="Resource" id="Resource_f8ocy"]
+[sub_resource type="Resource" id="Resource_h7ob1"]
 script = ExtResource("14_45ts8")
 template = ExtResource("15_y8oh2")
 display_name = "Gun"
 
-[sub_resource type="Resource" id="Resource_moa87"]
+[sub_resource type="Resource" id="Resource_kj2a7"]
 script = ExtResource("13_547l0")
 display_name = "Thug11"
 portrait = ExtResource("12_3ikya")
@@ -803,11 +578,11 @@ map_sprite = ExtResource("17_hmuey")
 move_sprite = ExtResource("18_n46v8")
 downed_sprite = ExtResource("16_gac6d")
 
-[sub_resource type="Resource" id="Resource_tk5sp"]
+[sub_resource type="Resource" id="Resource_5rv14"]
 script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_moa87")
+unit_data = SubResource("Resource_kj2a7")
 cell = Vector2i(13, 7)
-squad_id = 4
+squad_id = 3
 stats = Dictionary[int, int]({
 0: 15,
 1: 5,
@@ -820,7 +595,7 @@ stats = Dictionary[int, int]({
 })
 current_hp = 15
 current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_f8ocy")])
+inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_h7ob1")])
 equipped_index = 0
 affinity_saved = true
 limb_states = Dictionary[int, int]({
@@ -835,46 +610,46 @@ weapon_battle_states = Dictionary[int, Dictionary]({
 }
 })
 
-[sub_resource type="Resource" id="Resource_ppevu"]
+[sub_resource type="Resource" id="Resource_cmop5"]
 script = ExtResource("28_3hm3v")
 length = 3
 
-[sub_resource type="Resource" id="Resource_a5xao"]
+[sub_resource type="Resource" id="Resource_mq5u2"]
 script = ExtResource("27_1tkim")
 sigils = Array[int]([2, 2])
 flourishes = Array[int]([4, 3])
 display_name = "Freeze"
 power = 4
-attack_pattern = SubResource("Resource_ppevu")
+attack_pattern = SubResource("Resource_cmop5")
 hits_allies = true
 targets = 2
 
-[sub_resource type="Resource" id="Resource_c0ty7"]
+[sub_resource type="Resource" id="Resource_cqy3p"]
 script = ExtResource("29_gbsh8")
 length = 2
 metadata/_custom_type_script = "uid://cuvfasmongryk"
 
-[sub_resource type="Resource" id="Resource_iq7nb"]
+[sub_resource type="Resource" id="Resource_8mey3"]
 script = ExtResource("27_1tkim")
 sigils = Array[int]([2])
 popup = "It wasn't very effective"
 icon = ExtResource("30_svwhi")
 display_name = "Splash"
 power = 2
-attack_pattern = SubResource("Resource_c0ty7")
+attack_pattern = SubResource("Resource_cqy3p")
 hits_allies = true
 targets = 2
 deals_no_damage = true
 metadata/_custom_type_script = "uid://bgbidu2bbf33l"
 
-[sub_resource type="Resource" id="Resource_0q1e1"]
+[sub_resource type="Resource" id="Resource_sk6hk"]
 script = ExtResource("31_xky18")
 size = 1
-inscriptions = Array[ExtResource("27_1tkim")]([SubResource("Resource_a5xao"), SubResource("Resource_iq7nb")])
+inscriptions = Array[ExtResource("27_1tkim")]([SubResource("Resource_mq5u2"), SubResource("Resource_8mey3")])
 temper = 2
 display_name = "FreezeRune"
 
-[sub_resource type="Resource" id="Resource_6m8ya"]
+[sub_resource type="Resource" id="Resource_gi3f2"]
 script = ExtResource("13_547l0")
 display_name = "Isaac"
 portrait = ExtResource("35_x3usm")
@@ -892,11 +667,11 @@ base_affinity = Array[int]([7, 6, 5, 2, 1])
 base_is_alkahest_affine = true
 starting_inventory = Array[ExtResource("3_xuexq")]([ExtResource("36_o7ahr")])
 
-[sub_resource type="Resource" id="Resource_xsnkf"]
+[sub_resource type="Resource" id="Resource_14186"]
 script = ExtResource("2_bkn2k")
-unit_data = SubResource("Resource_6m8ya")
+unit_data = SubResource("Resource_gi3f2")
 cell = Vector2i(27, 1)
-squad_id = 5
+squad_id = 4
 is_leader = true
 stats = Dictionary[int, int]({
 0: 20,
@@ -910,7 +685,7 @@ stats = Dictionary[int, int]({
 })
 current_hp = 20
 current_will = 5
-inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_0q1e1")])
+inventory = Array[ExtResource("3_xuexq")]([SubResource("Resource_sk6hk")])
 equipped_index = 0
 aura = Dictionary[int, int]({
 1: 1,
@@ -929,46 +704,46 @@ limb_states = Dictionary[int, int]({
 3: 0
 })
 
-[sub_resource type="Resource" id="Resource_60ity"]
+[sub_resource type="Resource" id="Resource_5ohq1"]
 script = ExtResource("2_bkn2k")
 unit_data = ExtResource("37_3hm3v")
+state_saved = false
+cell = Vector2i(27, 4)
+squad_id = 5
+is_leader = true
+
+[sub_resource type="Resource" id="Resource_f8ocy"]
+script = ExtResource("2_bkn2k")
+unit_data = ExtResource("38_gbsh8")
 state_saved = false
 cell = Vector2i(27, 3)
 squad_id = 6
 is_leader = true
 
-[sub_resource type="Resource" id="Resource_e266y"]
-script = ExtResource("2_bkn2k")
-unit_data = ExtResource("37_3hm3v")
-state_saved = false
-cell = Vector2i(27, 4)
-squad_id = 7
-is_leader = true
-
 [resource]
 script = ExtResource("1_u67y6")
 scenario_name = "missions/Level_1"
-unit_entries = Array[ExtResource("2_bkn2k")]([SubResource("Resource_xky18"), SubResource("Resource_6id6f"), SubResource("Resource_ga0bu"), SubResource("Resource_5a8c1"), SubResource("Resource_p1dkl"), SubResource("Resource_1r2vb"), SubResource("Resource_f10k0"), SubResource("Resource_8d3q1"), SubResource("Resource_8uilc"), SubResource("Resource_kj2a7"), SubResource("Resource_mq5u2"), SubResource("Resource_sk6hk"), SubResource("Resource_5ohq1"), SubResource("Resource_tk5sp"), SubResource("Resource_xsnkf"), SubResource("Resource_60ity"), SubResource("Resource_e266y")])
-tile_data = PackedByteArray("AAAQAAAAAAAFAAEAAAARAAAAAAASAA0AAAAAAAcAAAAFAAEAAAABAAcAAAAFAAEAAAACAAcAAAAGAAAAAAADAAcAAAAGAAAAAAAEAAcAAAAFAAEAAAAFAAcAAAAFAAEAAAAGAAcAAAAFAAAAAAAHAAcAAAAFAAEAAAAIAAgAAAAFAAEAAAAJAAgAAAAFAAEAAAAKAAgAAAAFAAEAAAALAAgAAAAFAAEAAAAMAAgAAAAAAA0AAAANAAgAAAAFAAEAAAAOAAgAAAAFAAEAAAAPAAgAAAAFAAEAAAAEAAgAAAAGAAEAAAADAAgAAAAGAAAAAAACAAgAAAAFAAEAAAABAAgAAAAFAAEAAAAAAAgAAAAFAAEAAAAIAAcAAAAFAAEAAAAJAAcAAAAFAAEAAAAKAAcAAAAFAAEAAAALAAcAAAAFAAEAAAAMAAcAAAAAAA0AAAANAAcAAAAFAAEAAAAQAAgAAAAFAAEAAAARAAgAAAAFAAEAAAAGAAgAAAASAA0AAAAFAAgAAAAFAAEAAAAHAAgAAAAFAAEAAAAOAAcAAAAFAAEAAAAPAAcAAAAFAAEAAAAQAAcAAAAFAAEAAAARAAcAAAAFAAEAAAAGAAYAAAAFAAAAAAAFAAYAAAAFAAEAAAAEAAYAAAAFAAEAAAADAAYAAAAFAAEAAAACAAYAAAAFAAEAAAABAAYAAAAFAAEAAAAAAAYAAAAFAAEAAAAAAAUAAAAFAAEAAAABAAUAAAAFAAEAAAACAAUAAAASAA0AAAADAAUAAAAFAAEAAAAEAAUAAAAFAAEAAAAFAAUAAAASAA0AAAAGAAUAAAAFAAEAAAAHAAUAAAAFAAEAAAAIAAUAAAAFAAEAAAAJAAUAAAAFAAEAAAAKAAUAAAAFAAEAAAALAAUAAAAFAAEAAAANAAYAAAAFAAEAAAAOAAYAAAAFAAEAAAAPAAYAAAAFAAEAAAAQAAYAAAAFAAEAAAARAAYAAAAFAAEAAAAMAAYAAAAAAA0AAAALAAYAAAAFAAEAAAAKAAYAAAAFAAEAAAAJAAYAAAAFAAEAAAAIAAYAAAAFAAEAAAAHAAYAAAAFAAEAAAAPAAUAAAAGAAgAAAAQAAUAAAAFAAEAAAARAAUAAAAJAAoAAAADAAQAAAAFAAEAAAAEAAQAAAAFAAEAAAAFAAQAAAAFAAEAAAAGAAQAAAAFAAEAAAAHAAQAAAAGAAEAAAAIAAQAAAAFAAEAAAAJAAQAAAAFAAEAAAAKAAQAAAAFAAEAAAALAAQAAAAFAAEAAAANAAQAAAAJAAcAAAAPAAQAAAAFAAoAAAAJAAMAAAAFAAEAAAAKAAMAAAAFAAEAAAALAAMAAAAFAAEAAAAPAAMAAAABAAwAAAAQAAMAAAABAAwAAAARAAMAAAABAAwAAAAIAAMAAAAFAAEAAAAHAAMAAAAFAAEAAAAGAAMAAAAFAAEAAAAFAAMAAAAFAAEAAAAEAAMAAAAFAAEAAAADAAMAAAAGAAEAAAACAAMAAAAFAAEAAAAGAAIAAAAFAAAAAAAHAAIAAAAFAAAAAAAIAAIAAAAFAAAAAAAJAAIAAAAFAAEAAAAKAAIAAAAFAAEAAAALAAIAAAAFAAEAAAAMAAIAAAAFAAEAAAANAAIAAAASAA0AAAAOAAIAAAAFAAEAAAAPAAIAAAAFAAEAAAAQAAIAAAAFAAEAAAARAAIAAAAFAAEAAAAQAAQAAAAFAAoAAAARAAQAAAAJAAcAAAACAAQAAAAFAAEAAAAAAAMAAAAFAAEAAAABAAMAAAAFAAEAAAABAAQAAAAFAAEAAAAAAAQAAAAFAAEAAAAAAAIAAAAFAAEAAAABAAIAAAAFAAEAAAACAAIAAAAFAAEAAAADAAIAAAAFAAEAAAAEAAIAAAAFAAEAAAAAAAEAAAAFAAEAAAABAAEAAAAFAAEAAAAFAAIAAAAFAAAAAAAMAAEAAAAFAAEAAAALAAEAAAAFAAEAAAAKAAEAAAAGAAAAAAAJAAEAAAAGAAAAAAAIAAEAAAAFAAEAAAAHAAEAAAAFAAEAAAAGAAEAAAAFAAEAAAAFAAEAAAAFAAEAAAAEAAEAAAAFAAEAAAADAAEAAAAFAAEAAAACAAEAAAAFAAEAAAANAAEAAAAFAAEAAAAOAAEAAAASAA0AAAAOAAAAAAAFAAEAAAAPAAAAAAAFAAEAAAANAAAAAAAFAAEAAAAMAAAAAAAFAAEAAAALAAAAAAAFAAEAAAAKAAAAAAAFAAEAAAAJAAAAAAAFAAEAAAAIAAAAAAAFAAEAAAAHAAAAAAAFAAEAAAAGAAAAAAAFAAEAAAAFAAAAAAAFAAEAAAAEAAAAAAAFAAEAAAADAAAAAAAFAAEAAAACAAAAAAAFAAEAAAABAAAAAAAFAAEAAAAAAAAAAAAFAAEAAAAPAAEAAAAFAAEAAAAQAAEAAAASAA0AAAARAAEAAAAFAAEAAAASAAgAAAACAA0AAAASAAcAAAACAA0AAAASAAYAAAACAA0AAAASAAUAAAACAA0AAAASAAQAAAACAA0AAAASAAMAAAACAAwAAAASAAIAAAAFAAEAAAASAAEAAAAFAAEAAAASAAAAAAAFAAEAAAATAAAAAAAFAAYAAAATAAEAAAAFAAYAAAATAAIAAAAFAAYAAAATAAMAAAAFAAYAAAATAAQAAAAFAAYAAAATAAUAAAAFAAYAAAATAAYAAAAFAAYAAAATAAcAAAAFAAYAAAATAAgAAAAFAAYAAAAUAAAAAAAFAAYAAAAUAAEAAAAFAAYAAAAUAAIAAAAFAAYAAAAUAAMAAAAFAAYAAAAUAAQAAAAFAAYAAAAUAAUAAAAFAAYAAAAUAAYAAAAFAAYAAAAUAAcAAAAFAAYAAAAUAAgAAAAFAAYAAAAbAAAAAAAFAAEAAAAbAAEAAAAFAAEAAAAbAAIAAAAFAAEAAAAbAAMAAAAFAAAAAAAbAAQAAAAFAAAAAAAbAAUAAAAFAAEAAAAbAAYAAAAFAAEAAAAbAAcAAAAFAAEAAAAbAAgAAAAFAAEAAAAXAAYAAAAFAAEAAAAXAAUAAAAFAAEAAAAXAAQAAAAFAAEAAAAXAAMAAAAFAAEAAAAXAAIAAAAFAAEAAAAXAAEAAAAFAAEAAAAXAAAAAAAFAAEAAAAVAAAAAAAFAAYAAAAVAAEAAAAFAAYAAAAVAAIAAAAFAAYAAAAVAAMAAAAFAAYAAAAVAAQAAAAFAAYAAAAVAAUAAAAFAAYAAAAVAAYAAAAFAAYAAAAVAAcAAAAFAAYAAAAVAAgAAAAFAAYAAAAWAAgAAAAFAAEAAAAWAAcAAAAFAAEAAAAWAAYAAAAFAAEAAAAWAAUAAAAGAAEAAAAWAAQAAAAFAAEAAAAWAAMAAAAFAAEAAAAWAAIAAAAFAAEAAAAWAAEAAAAFAAEAAAAWAAAAAAAFAAEAAAAXAAcAAAAFAAEAAAAXAAgAAAAGAAAAAAAYAAgAAAAFAAEAAAAYAAcAAAAFAAEAAAAYAAYAAAAFAAEAAAAYAAUAAAAFAAEAAAAYAAQAAAAFAAEAAAAYAAMAAAAFAAEAAAAYAAIAAAAFAAEAAAAYAAEAAAAFAAEAAAAYAAAAAAAFAAEAAAAZAAAAAAAFAAEAAAAZAAEAAAAFAAEAAAAZAAIAAAAFAAEAAAAZAAMAAAAGAAEAAAAZAAQAAAAFAAEAAAAZAAUAAAAFAAEAAAAZAAYAAAAFAAEAAAAZAAcAAAAFAAEAAAAZAAgAAAAFAAEAAAAaAAgAAAAFAAEAAAAaAAcAAAAGAAEAAAAaAAYAAAAFAAEAAAAaAAUAAAAFAAEAAAAaAAQAAAAFAAEAAAAaAAMAAAAFAAAAAAAaAAIAAAAFAAEAAAAaAAEAAAAFAAEAAAAaAAAAAAAFAAEAAAAcAAAAAAAFAAEAAAAcAAEAAAABAAwAAAAcAAIAAAAFAAEAAAAcAAMAAAAFAAEAAAAcAAQAAAAFAAAAAAAcAAUAAAABAAwAAAAcAAYAAAAFAAEAAAAcAAcAAAAFAAEAAAAcAAgAAAAFAAEAAAAdAAAAAAAFAAEAAAAdAAEAAAABAAwAAAAdAAIAAAAFAAEAAAAdAAMAAAAFAAEAAAAdAAQAAAAFAAEAAAAdAAUAAAABAAwAAAAdAAYAAAAFAAEAAAAdAAcAAAAFAAEAAAAdAAgAAAAFAAEAAAAMAAMAAAAAAAwAAAAMAAQAAAAAAA0AAAAMAAUAAAAAAA0AAAANAAMAAAABAAwAAAANAAUAAAAJAAoAAAAOAAMAAAABAAwAAAAOAAQAAAAFAAoAAAAOAAUAAAAFAAEAAAAAAAkAAAAFAAEAAAAAAAoAAAAFAAEAAAAAAAsAAAAFAAEAAAAAAAwAAAAFAAEAAAAAAA0AAAAFAAEAAAAAAA4AAAAFAAEAAAAAAA8AAAAFAAEAAAAAABAAAAAFAAEAAAAAABEAAAAFAAEAAAAAABIAAAAFAAEAAAAAABMAAAAFAAEAAAABAAkAAAAFAAEAAAABAAoAAAAFAAEAAAABAAsAAAAFAAEAAAABAAwAAAAFAAEAAAABAA0AAAAFAAEAAAABAA4AAAAFAAEAAAABAA8AAAAFAAEAAAABABAAAAAFAAEAAAABABEAAAAFAAEAAAABABIAAAAFAAEAAAABABMAAAAFAAEAAAACAAkAAAAFAAEAAAACAAoAAAAFAAEAAAACAAsAAAAFAAEAAAACAAwAAAAFAAEAAAACAA0AAAAFAAEAAAACAA4AAAAFAAEAAAACAA8AAAAFAAEAAAACABAAAAAFAAEAAAACABEAAAAGAAEAAAACABIAAAAFAAEAAAACABMAAAAFAAEAAAADAAkAAAAGAAAAAAADAAoAAAASAA0AAAADAAsAAAAFAAEAAAADAAwAAAAFAAEAAAADAA0AAAAFAAEAAAADAA4AAAASAA0AAAADAA8AAAAFAAEAAAADABAAAAAFAAEAAAADABEAAAAFAAEAAAADABIAAAAFAAEAAAADABMAAAAFAAEAAAAEAAkAAAAFAAEAAAAEAAoAAAAFAAEAAAAEAAsAAAAFAAEAAAAEAAwAAAAFAAEAAAAEAA0AAAAFAAEAAAAEAA4AAAAFAAEAAAAEAA8AAAAFAAEAAAAEABAAAAAFAAEAAAAEABEAAAAFAAEAAAAEABIAAAAFAAEAAAAEABMAAAAFAAEAAAAFAAkAAAAFAAEAAAAFAAoAAAAFAAEAAAAFAAsAAAAFAAEAAAAFAAwAAAAFAAEAAAAFAA0AAAAFAAEAAAAFAA4AAAAGAAEAAAAFAA8AAAAFAAEAAAAFABAAAAAFAAEAAAAFABEAAAAFAAEAAAAFABIAAAAFAAAAAAAFABMAAAAFAAEAAAAGAAkAAAAFAAEAAAAGAAoAAAAFAAEAAAAGAAsAAAAFAAEAAAAGAAwAAAAFAAEAAAAGAA0AAAAFAAEAAAAGAA4AAAAFAAEAAAAGAA8AAAAFAAEAAAAGABAAAAAFAAEAAAAGABEAAAAFAAEAAAAGABIAAAAFAAAAAAAGABMAAAAFAAEAAAAHAAkAAAAFAAAAAAAHAAoAAAAFAAEAAAAHAAsAAAASAA0AAAAHAAwAAAAGAAAAAAAHAA0AAAAFAAEAAAAHAA4AAAAFAAEAAAAHAA8AAAAFAAEAAAAHABAAAAAFAAEAAAAHABEAAAAFAAEAAAAHABIAAAAFAAAAAAAHABMAAAAFAAEAAAAIAAkAAAAFAAEAAAAIAAoAAAAFAAEAAAAIAAsAAAAFAAEAAAAIAAwAAAAGAAAAAAAIAA0AAAAGAAAAAAAIAA4AAAAFAAEAAAAIAA8AAAAFAAEAAAAIABAAAAAFAAEAAAAIABEAAAAFAAEAAAAIABIAAAAFAAAAAAAIABMAAAAFAAEAAAAJAAkAAAAFAAEAAAAJAAoAAAAFAAEAAAAJAAsAAAAFAAEAAAAJAAwAAAAFAAEAAAAJAA0AAAAGAAAAAAAJAA4AAAAGAAAAAAAJAA8AAAAFAAEAAAAJABAAAAAFAAEAAAAJABEAAAAFAAEAAAAJABIAAAAFAAEAAAAJABMAAAAFAAEAAAAKAAkAAAAFAAEAAAAKAAoAAAAGAAEAAAAKAAsAAAAFAAEAAAAKAAwAAAAFAAEAAAAKAA0AAAAFAAEAAAAKAA4AAAAFAAEAAAAKAA8AAAAGAAAAAAAKABAAAAAFAAEAAAAKABEAAAASAAoAAAAKABIAAAAFAAEAAAAKABMAAAAFAAEAAAALAAkAAAAFAAEAAAALAAoAAAAGAAEAAAALAAsAAAAFAAEAAAALAAwAAAAFAAEAAAALAA0AAAAFAAEAAAALAA4AAAAFAAEAAAALAA8AAAAFAAEAAAALABAAAAAFAAEAAAALABEAAAAFAAEAAAALABIAAAAFAAEAAAALABMAAAAFAAEAAAAMAAkAAAAFAAEAAAAMAAoAAAAFAAEAAAAMAAsAAAAFAAEAAAAMAAwAAAAFAAEAAAAMAA0AAAAFAAEAAAAMAA4AAAASAAoAAAAMAA8AAAAFAAEAAAAMABAAAAAFAAEAAAAMABEAAAAFAAEAAAAMABIAAAAFAAEAAAAMABMAAAAFAAEAAAANAAkAAAAFAAEAAAANAAoAAAAFAAEAAAANAAsAAAAFAAEAAAANAAwAAAAFAAAAAAANAA0AAAAFAAEAAAANAA4AAAAFAAEAAAANAA8AAAAFAAEAAAANABAAAAAGAAEAAAANABEAAAAFAAEAAAANABIAAAAFAAEAAAANABMAAAAFAAEAAAAOAAkAAAAFAAEAAAAOAAoAAAAFAAEAAAAOAAsAAAAGAAAAAAAOAAwAAAAFAAAAAAAOAA0AAAAFAAEAAAAOAA4AAAAFAAEAAAAOAA8AAAAFAAEAAAAOABAAAAAFAAEAAAAOABEAAAAFAAEAAAAOABIAAAAFAAEAAAAOABMAAAAFAAEAAAAPAAkAAAAFAAEAAAAPAAoAAAAFAAEAAAAPAAsAAAAGAAAAAAAPAAwAAAAFAAEAAAAPAA0AAAAFAAEAAAAPAA4AAAAFAAEAAAAPAA8AAAAFAAEAAAAPABAAAAAFAAEAAAAPABEAAAAFAAEAAAAPABIAAAAFAAEAAAAPABMAAAAFAAEAAAAQAAkAAAAFAAEAAAAQAAoAAAAFAAEAAAAQAAsAAAAFAAEAAAAQAAwAAAAFAAEAAAAQAA0AAAAFAAEAAAAQAA4AAAAFAAEAAAAQAA8AAAAFAAEAAAAQABAAAAAFAAEAAAAQABEAAAAFAAEAAAAQABIAAAAGAAEAAAAQABMAAAAFAAEAAAARAAkAAAAFAAEAAAARAAoAAAASAA0AAAARAAsAAAAFAAEAAAARAAwAAAAFAAEAAAARAA0AAAAFAAEAAAARAA4AAAAFAAEAAAARAA8AAAAFAAEAAAARABAAAAAGAAEAAAARABEAAAAFAAEAAAARABIAAAAGAAEAAAARABMAAAAFAAEAAAASAAkAAAAFAAEAAAASAAoAAAASAA0AAAASAAsAAAASAA0AAAASAAwAAAASAA0AAAASAA0AAAAFAAEAAAASAA4AAAAFAAEAAAASAA8AAAAFAAAAAAASABAAAAAFAAAAAAASABEAAAAFAAEAAAASABIAAAAGAAEAAAASABMAAAAFAAEAAAATAAkAAAAFAAYAAAATAAoAAAAFAAYAAAATAAsAAAAFAAYAAAATAAwAAAAFAAYAAAATAA0AAAAFAAYAAAATAA4AAAAFAAYAAAATAA8AAAAFAAYAAAATABAAAAAFAAYAAAATABEAAAAFAAEAAAATABIAAAAGAAEAAAATABMAAAAFAAEAAAAUAAkAAAAFAAYAAAAUAAoAAAAFAAYAAAAUAAsAAAAFAAYAAAAUAAwAAAAFAAYAAAAUAA0AAAAFAAYAAAAUAA4AAAAFAAYAAAAUAA8AAAAFAAYAAAAUABAAAAAFAAYAAAAUABEAAAAFAAAAAAAUABIAAAAGAAAAAAAUABMAAAAFAAAAAAAVAAkAAAAFAAYAAAAVAAoAAAAFAAYAAAAVAAsAAAAFAAYAAAAVAAwAAAAFAAYAAAAVAA0AAAAFAAYAAAAVAA4AAAAFAAYAAAAVAA8AAAAFAAYAAAAVABAAAAAFAAYAAAAVABEAAAAFAAEAAAAVABIAAAAGAAAAAAAVABMAAAAFAAEAAAAWAAkAAAAGAAAAAAAWAAoAAAAFAAEAAAAWAAsAAAAFAAEAAAAWAAwAAAAFAAEAAAAWAA0AAAAFAAEAAAAWAA4AAAAFAAEAAAAWAA8AAAAFAAAAAAAWABAAAAAFAAEAAAAWABEAAAAFAAEAAAAWABIAAAAGAAAAAAAWABMAAAAGAAAAAAAXAAkAAAAGAAAAAAAXAAoAAAAFAAEAAAAXAAsAAAAFAAEAAAAXAAwAAAAFAAEAAAAXAA0AAAAFAAEAAAAXAA4AAAAFAAEAAAAXAA8AAAAFAAEAAAAXABAAAAAGAAAAAAAXABEAAAAFAAEAAAAXABIAAAASAAoAAAAXABMAAAAGAAAAAAAYAAkAAAAFAAEAAAAYAAoAAAAFAAEAAAAYAAsAAAAFAAEAAAAYAAwAAAAFAAEAAAAYAA0AAAAFAAEAAAAYAA4AAAAFAAEAAAAYAA8AAAAFAAEAAAAYABAAAAAFAAEAAAAYABEAAAAFAAEAAAAYABIAAAAFAAEAAAAYABMAAAAFAAEAAAAZAAkAAAAFAAEAAAAZAAoAAAAFAAEAAAAZAAsAAAAFAAEAAAAZAAwAAAAGAAAAAAAZAA0AAAAGAAAAAAAZAA4AAAAFAAEAAAAZAA8AAAAFAAEAAAAZABAAAAAFAAEAAAAZABEAAAAFAAEAAAAZABIAAAAFAAEAAAAZABMAAAAFAAEAAAAaAAkAAAAFAAEAAAAaAAoAAAAFAAEAAAAaAAsAAAAGAAAAAAAaAAwAAAAGAAAAAAAaAA0AAAAFAAEAAAAaAA4AAAAFAAEAAAAaAA8AAAAFAAEAAAAaABAAAAAFAAEAAAAaABEAAAAFAAEAAAAaABIAAAAFAAEAAAAaABMAAAAFAAEAAAAbAAkAAAAFAAEAAAAbAAoAAAAFAAEAAAAbAAsAAAAFAAEAAAAbAAwAAAAFAAEAAAAbAA0AAAAFAAEAAAAbAA4AAAAFAAEAAAAbAA8AAAAFAAEAAAAbABAAAAAFAAEAAAAbABEAAAAFAAEAAAAbABIAAAAFAAEAAAAbABMAAAAFAAEAAAAcAAkAAAAFAAEAAAAcAAoAAAAFAAEAAAAcAAsAAAAFAAEAAAAcAAwAAAAFAAEAAAAcAA0AAAAFAAEAAAAcAA4AAAAGAAAAAAAcAA8AAAAGAAAAAAAcABAAAAAGAAAAAAAcABEAAAAGAAAAAAAcABIAAAAGAAAAAAAcABMAAAAFAAEAAAAdAAkAAAAFAAEAAAAdAAoAAAAFAAEAAAAdAAsAAAAFAAEAAAAdAAwAAAAGAAAAAAAdAA0AAAAGAAAAAAAdAA4AAAAGAAAAAAAdAA8AAAAGAAAAAAAdABAAAAAGAAAAAAAdABEAAAAGAAAAAAAdABIAAAAGAAAAAAAdABMAAAAFAAEAAAA=")
+unit_entries = Array[ExtResource("2_bkn2k")]([SubResource("Resource_3id6q"), SubResource("Resource_x3usm"), SubResource("Resource_qdfkr"), SubResource("Resource_1syme"), SubResource("Resource_n5s48"), SubResource("Resource_ctcr5"), SubResource("Resource_afmdw"), SubResource("Resource_4yu8n"), SubResource("Resource_mgyax"), SubResource("Resource_5rv14"), SubResource("Resource_14186"), SubResource("Resource_5ohq1"), SubResource("Resource_f8ocy")])
+tile_data = PackedByteArray("AAAQAAAAAAAFAAEAAAARAAAAAAASAA0AAAAAAAcAAAAFAAEAAAABAAcAAAAFAAEAAAACAAcAAAAGAAAAAAADAAcAAAAGAAAAAAAEAAcAAAAFAAEAAAAFAAcAAAAFAAEAAAAGAAcAAAAFAAAAAAAHAAcAAAAFAAEAAAAIAAgAAAAFAAEAAAAJAAgAAAAFAAEAAAAKAAgAAAAFAAEAAAALAAgAAAAFAAEAAAAMAAgAAAAAAA0AAAANAAgAAAAFAAEAAAAOAAgAAAAFAAEAAAAPAAgAAAAFAAEAAAAQAAkAAAAFAAEAAAARAAkAAAAFAAEAAAAJAAkAAAAFAAEAAAAIAAkAAAAFAAEAAAAHAAkAAAAFAAAAAAAGAAkAAAAFAAEAAAAFAAkAAAAFAAEAAAAEAAgAAAAGAAEAAAADAAgAAAAGAAAAAAACAAgAAAAFAAEAAAABAAgAAAAFAAEAAAAAAAgAAAAFAAEAAAAIAAcAAAAFAAEAAAAJAAcAAAAFAAEAAAAKAAcAAAAFAAEAAAALAAcAAAAFAAEAAAAMAAcAAAAAAA0AAAANAAcAAAAFAAEAAAAQAAgAAAAFAAEAAAARAAgAAAAFAAEAAAACAAkAAAAFAAEAAAADAAkAAAAGAAAAAAAEAAkAAAAFAAEAAAAKAAkAAAAFAAEAAAABAAkAAAAFAAEAAAAAAAkAAAAFAAEAAAAOAAkAAAAFAAEAAAANAAkAAAAFAAEAAAAMAAkAAAAFAAEAAAALAAkAAAAFAAEAAAAGAAgAAAASAA0AAAAFAAgAAAAFAAEAAAAHAAgAAAAFAAEAAAAPAAkAAAAFAAEAAAAOAAcAAAAFAAEAAAAPAAcAAAAFAAEAAAAQAAcAAAAFAAEAAAARAAcAAAAFAAEAAAAGAAYAAAAFAAAAAAAFAAYAAAAFAAEAAAAEAAYAAAAFAAEAAAADAAYAAAAFAAEAAAACAAYAAAAFAAEAAAABAAYAAAAFAAEAAAAAAAYAAAAFAAEAAAAAAAUAAAAFAAEAAAABAAUAAAAFAAEAAAACAAUAAAASAA0AAAADAAUAAAAFAAEAAAAEAAUAAAAFAAEAAAAFAAUAAAASAA0AAAAGAAUAAAAFAAEAAAAHAAUAAAAFAAEAAAAIAAUAAAAFAAEAAAAJAAUAAAAFAAEAAAAKAAUAAAAFAAEAAAALAAUAAAAFAAEAAAANAAYAAAAFAAEAAAAOAAYAAAAFAAEAAAAPAAYAAAAFAAEAAAAQAAYAAAAFAAEAAAARAAYAAAAFAAEAAAAMAAYAAAAAAA0AAAALAAYAAAAFAAEAAAAKAAYAAAAFAAEAAAAJAAYAAAAFAAEAAAAIAAYAAAAFAAEAAAAHAAYAAAAFAAEAAAAPAAUAAAAGAAgAAAAQAAUAAAAFAAEAAAARAAUAAAAJAAoAAAADAAQAAAAFAAEAAAAEAAQAAAAFAAEAAAAFAAQAAAAFAAEAAAAGAAQAAAAFAAEAAAAHAAQAAAAGAAEAAAAIAAQAAAAFAAEAAAAJAAQAAAAFAAEAAAAKAAQAAAAFAAEAAAALAAQAAAAFAAEAAAANAAQAAAAJAAcAAAAPAAQAAAAFAAoAAAAJAAMAAAAFAAEAAAAKAAMAAAAFAAEAAAALAAMAAAAFAAEAAAAPAAMAAAABAAwAAAAQAAMAAAABAAwAAAARAAMAAAABAAwAAAAIAAMAAAAFAAEAAAAHAAMAAAAFAAEAAAAGAAMAAAAFAAEAAAAFAAMAAAAFAAEAAAAEAAMAAAAFAAEAAAADAAMAAAAGAAEAAAACAAMAAAAFAAEAAAAGAAIAAAAFAAAAAAAHAAIAAAAFAAAAAAAIAAIAAAAFAAAAAAAJAAIAAAAFAAEAAAAKAAIAAAAFAAEAAAALAAIAAAAFAAEAAAAMAAIAAAAFAAEAAAANAAIAAAASAA0AAAAOAAIAAAAFAAEAAAAPAAIAAAAFAAEAAAAQAAIAAAAFAAEAAAARAAIAAAAFAAEAAAAQAAQAAAAFAAoAAAARAAQAAAAJAAcAAAACAAQAAAAFAAEAAAAAAAMAAAAFAAEAAAABAAMAAAAFAAEAAAABAAQAAAAFAAEAAAAAAAQAAAAFAAEAAAAAAAIAAAAFAAEAAAABAAIAAAAFAAEAAAACAAIAAAAFAAEAAAADAAIAAAAFAAEAAAAEAAIAAAAFAAEAAAAAAAEAAAAFAAEAAAABAAEAAAAFAAEAAAAFAAIAAAAFAAAAAAAMAAEAAAAFAAEAAAALAAEAAAAFAAEAAAAKAAEAAAAGAAAAAAAJAAEAAAAGAAAAAAAIAAEAAAAFAAEAAAAHAAEAAAAFAAEAAAAGAAEAAAAFAAEAAAAFAAEAAAAFAAEAAAAEAAEAAAAFAAEAAAADAAEAAAAFAAEAAAACAAEAAAAFAAEAAAANAAEAAAAFAAEAAAAOAAEAAAASAA0AAAAOAAAAAAAFAAEAAAAPAAAAAAAFAAEAAAANAAAAAAAFAAEAAAAMAAAAAAAFAAEAAAALAAAAAAAFAAEAAAAKAAAAAAAFAAEAAAAJAAAAAAAFAAEAAAAIAAAAAAAFAAEAAAAHAAAAAAAFAAEAAAAGAAAAAAAFAAEAAAAFAAAAAAAFAAEAAAAEAAAAAAAFAAEAAAADAAAAAAAFAAEAAAACAAAAAAAFAAEAAAABAAAAAAAFAAEAAAAAAAAAAAAFAAEAAAAPAAEAAAAFAAEAAAAQAAEAAAASAA0AAAARAAEAAAAFAAEAAAASAAkAAAAFAAEAAAASAAgAAAACAA0AAAASAAcAAAACAA0AAAASAAYAAAACAA0AAAASAAUAAAACAA0AAAASAAQAAAACAA0AAAASAAMAAAACAAwAAAASAAIAAAAFAAEAAAASAAEAAAAFAAEAAAASAAAAAAAFAAEAAAATAAAAAAAFAAYAAAATAAEAAAAFAAYAAAATAAIAAAAFAAYAAAATAAMAAAAFAAYAAAATAAQAAAAFAAYAAAATAAUAAAAFAAYAAAATAAYAAAAFAAYAAAATAAcAAAAFAAYAAAATAAgAAAAFAAYAAAATAAkAAAAFAAYAAAATAAoAAAAFAAYAAAASAAoAAAASAA0AAAARAAoAAAASAA0AAAAQAAoAAAAFAAEAAAAPAAoAAAAFAAEAAAAOAAoAAAAFAAEAAAANAAoAAAAFAAEAAAAMAAoAAAAFAAEAAAALAAoAAAAGAAEAAAAKAAoAAAAGAAEAAAAJAAoAAAAFAAEAAAAIAAoAAAAFAAEAAAAHAAoAAAAFAAEAAAAGAAoAAAAFAAEAAAAFAAoAAAAFAAEAAAAEAAoAAAAFAAEAAAADAAoAAAASAA0AAAACAAoAAAAFAAEAAAABAAoAAAAFAAEAAAAAAAoAAAAFAAEAAAAUAAAAAAAFAAYAAAAUAAEAAAAFAAYAAAAUAAIAAAAFAAYAAAAUAAMAAAAFAAYAAAAUAAQAAAAFAAYAAAAUAAUAAAAFAAYAAAAUAAYAAAAFAAYAAAAUAAcAAAAFAAYAAAAUAAgAAAAFAAYAAAAUAAkAAAAFAAYAAAAUAAoAAAAFAAYAAAAUAAsAAAAFAAYAAAATAAsAAAAFAAYAAAASAAsAAAASAA0AAAARAAsAAAAFAAEAAAAQAAsAAAAFAAEAAAAPAAsAAAAGAAAAAAAOAAsAAAAGAAAAAAANAAsAAAAFAAEAAAAMAAsAAAAFAAEAAAALAAsAAAAFAAEAAAAKAAsAAAAFAAEAAAAJAAsAAAAFAAEAAAAIAAsAAAAFAAEAAAAHAAsAAAASAA0AAAAGAAsAAAAFAAEAAAAFAAsAAAAFAAEAAAAEAAsAAAAFAAEAAAADAAsAAAAFAAEAAAACAAsAAAAFAAEAAAABAAsAAAAFAAEAAAAAAAsAAAAFAAEAAAAbAAAAAAAFAAEAAAAbAAEAAAAFAAEAAAAbAAIAAAAFAAEAAAAbAAMAAAAFAAAAAAAbAAQAAAAFAAAAAAAbAAUAAAAFAAEAAAAbAAYAAAAFAAEAAAAbAAcAAAAFAAEAAAAbAAgAAAAFAAEAAAAbAAkAAAAFAAEAAAAbAAoAAAAFAAEAAAAbAAsAAAAFAAEAAAAaAAsAAAAGAAAAAAAZAAsAAAAFAAEAAAAYAAsAAAAFAAEAAAAXAAsAAAAFAAEAAAAWAAsAAAAFAAEAAAAVAAsAAAAFAAYAAAAXAAYAAAAFAAEAAAAXAAUAAAAFAAEAAAAXAAQAAAAFAAEAAAAXAAMAAAAFAAEAAAAXAAIAAAAFAAEAAAAXAAEAAAAFAAEAAAAXAAAAAAAFAAEAAAAVAAAAAAAFAAYAAAAVAAEAAAAFAAYAAAAVAAIAAAAFAAYAAAAVAAMAAAAFAAYAAAAVAAQAAAAFAAYAAAAVAAUAAAAFAAYAAAAVAAYAAAAFAAYAAAAVAAcAAAAFAAYAAAAVAAgAAAAFAAYAAAAVAAkAAAAFAAYAAAAVAAoAAAAFAAYAAAAWAAoAAAAFAAEAAAAWAAkAAAAGAAAAAAAWAAgAAAAFAAEAAAAWAAcAAAAFAAEAAAAWAAYAAAAFAAEAAAAWAAUAAAAGAAEAAAAWAAQAAAAFAAEAAAAWAAMAAAAFAAEAAAAWAAIAAAAFAAEAAAAWAAEAAAAFAAEAAAAWAAAAAAAFAAEAAAAXAAcAAAAFAAEAAAAXAAgAAAAGAAAAAAAXAAkAAAAGAAAAAAAXAAoAAAAFAAEAAAAYAAoAAAAFAAEAAAAYAAkAAAAFAAEAAAAYAAgAAAAFAAEAAAAYAAcAAAAFAAEAAAAYAAYAAAAFAAEAAAAYAAUAAAAFAAEAAAAYAAQAAAAFAAEAAAAYAAMAAAAFAAEAAAAYAAIAAAAFAAEAAAAYAAEAAAAFAAEAAAAYAAAAAAAFAAEAAAAZAAAAAAAFAAEAAAAZAAEAAAAFAAEAAAAZAAIAAAAFAAEAAAAZAAMAAAAGAAEAAAAZAAQAAAAFAAEAAAAZAAUAAAAFAAEAAAAZAAYAAAAFAAEAAAAZAAcAAAAFAAEAAAAZAAgAAAAFAAEAAAAZAAkAAAAFAAEAAAAZAAoAAAAFAAEAAAAaAAoAAAAFAAEAAAAaAAkAAAAFAAEAAAAaAAgAAAAFAAEAAAAaAAcAAAAGAAEAAAAaAAYAAAAFAAEAAAAaAAUAAAAFAAEAAAAaAAQAAAAFAAEAAAAaAAMAAAAFAAAAAAAaAAIAAAAFAAEAAAAaAAEAAAAFAAEAAAAaAAAAAAAFAAEAAAAcAAAAAAAFAAEAAAAcAAEAAAABAAwAAAAcAAIAAAAFAAEAAAAcAAMAAAAFAAEAAAAcAAQAAAAFAAAAAAAcAAUAAAABAAwAAAAcAAYAAAAFAAEAAAAcAAcAAAAFAAEAAAAcAAgAAAAFAAEAAAAcAAkAAAAFAAEAAAAcAAoAAAAFAAEAAAAcAAsAAAAFAAEAAAAcAAwAAAAFAAEAAAAbAAwAAAAFAAEAAAAaAAwAAAAGAAAAAAAZAAwAAAAGAAAAAAAYAAwAAAAFAAEAAAAXAAwAAAAFAAEAAAAWAAwAAAAFAAEAAAAVAAwAAAAFAAYAAAAUAAwAAAAFAAYAAAATAAwAAAAFAAYAAAASAAwAAAASAA0AAAARAAwAAAAFAAEAAAAQAAwAAAAFAAEAAAAPAAwAAAAFAAEAAAAOAAwAAAAFAAAAAAANAAwAAAAFAAAAAAAMAAwAAAAFAAEAAAALAAwAAAAFAAEAAAAKAAwAAAAFAAEAAAAJAAwAAAAFAAEAAAAIAAwAAAAGAAAAAAAHAAwAAAAGAAAAAAAGAAwAAAAFAAEAAAAFAAwAAAAFAAEAAAAEAAwAAAAFAAEAAAADAAwAAAAFAAEAAAACAAwAAAAFAAEAAAABAAwAAAAFAAEAAAAAAAwAAAAFAAEAAAAdAAAAAAAFAAEAAAAdAAEAAAABAAwAAAAdAAIAAAAFAAEAAAAdAAMAAAAFAAEAAAAdAAQAAAAFAAEAAAAdAAUAAAABAAwAAAAdAAYAAAAFAAEAAAAdAAwAAAAGAAAAAAAdAAcAAAAFAAEAAAAdAAgAAAAFAAEAAAAdAAkAAAAFAAEAAAAdAAoAAAAFAAEAAAAdAAsAAAAFAAEAAAAdABMAAAAFAAEAAAAcABMAAAAFAAEAAAAbABMAAAAFAAEAAAAaABMAAAAFAAEAAAAZABMAAAAFAAEAAAAYABMAAAAFAAEAAAAXABMAAAAGAAAAAAAWABMAAAAGAAAAAAAVABMAAAAFAAEAAAAUABMAAAAFAAAAAAATABMAAAAFAAEAAAASABMAAAAFAAEAAAARABMAAAAFAAEAAAAQABMAAAAFAAEAAAAPABMAAAAFAAEAAAAOABMAAAAFAAEAAAANABMAAAAFAAEAAAAMABMAAAAFAAEAAAALABMAAAAFAAEAAAAKABMAAAAFAAEAAAAJABMAAAAFAAEAAAAIABMAAAAFAAEAAAAHABMAAAAFAAEAAAAGABMAAAAFAAEAAAAFABMAAAAFAAEAAAAEABMAAAAFAAEAAAADABMAAAAFAAEAAAACABMAAAAFAAEAAAABABMAAAAFAAEAAAAAABMAAAAFAAEAAAAAABIAAAAFAAEAAAAAABEAAAAFAAEAAAAAABAAAAAFAAEAAAAAAA8AAAAFAAEAAAAAAA4AAAAFAAEAAAAAAA0AAAAFAAEAAAABAA0AAAAFAAEAAAABAA4AAAAFAAEAAAABAA8AAAAFAAEAAAABABAAAAAFAAEAAAABABEAAAAFAAEAAAABABIAAAAFAAEAAAACABIAAAAFAAEAAAACABEAAAAGAAEAAAACABAAAAAFAAEAAAACAA8AAAAFAAEAAAACAA4AAAAFAAEAAAACAA0AAAAFAAEAAAADAA0AAAAFAAEAAAADAA4AAAASAA0AAAADAA8AAAAFAAEAAAADABAAAAAFAAEAAAADABEAAAAFAAEAAAADABIAAAAFAAEAAAAEABIAAAAFAAEAAAAEABEAAAAFAAEAAAAEABAAAAAFAAEAAAAEAA8AAAAFAAEAAAAEAA4AAAAFAAEAAAAEAA0AAAAFAAEAAAAFAA0AAAAFAAEAAAAFAA4AAAAGAAEAAAAFAA8AAAAFAAEAAAAFABAAAAAFAAEAAAAFABEAAAAFAAEAAAAFABIAAAAFAAAAAAAGABIAAAAFAAAAAAAGABEAAAAFAAEAAAAGABAAAAAFAAEAAAAGAA8AAAAFAAEAAAAGAA4AAAAFAAEAAAAGAA0AAAAFAAEAAAAHAA0AAAAFAAEAAAAHAA4AAAAFAAEAAAAHAA8AAAAFAAEAAAAHABAAAAAFAAEAAAAHABEAAAAFAAEAAAAHABIAAAAFAAAAAAAIABIAAAAFAAAAAAAIABEAAAAFAAEAAAAIABAAAAAFAAEAAAAIAA8AAAAFAAEAAAAIAA4AAAAFAAEAAAAIAA0AAAAGAAAAAAAJAA0AAAAGAAAAAAAJAA4AAAAGAAAAAAAJAA8AAAAFAAEAAAAJABAAAAAFAAEAAAAJABEAAAAFAAEAAAAJABIAAAAFAAEAAAAKABIAAAAFAAEAAAAKABEAAAASAAoAAAAKABAAAAAFAAEAAAAKAA8AAAAGAAAAAAAKAA4AAAAFAAEAAAAKAA0AAAAFAAEAAAALAA0AAAAFAAEAAAALAA4AAAAFAAEAAAALAA8AAAAFAAEAAAALABAAAAAFAAEAAAALABEAAAAFAAEAAAALABIAAAAFAAEAAAAMABIAAAAFAAEAAAAMABEAAAAFAAEAAAAMABAAAAAFAAEAAAAMAA8AAAAFAAEAAAAMAA4AAAASAAoAAAAMAA0AAAAFAAEAAAANAA0AAAAFAAEAAAANAA4AAAAFAAEAAAANAA8AAAAFAAEAAAANABAAAAAGAAEAAAANABEAAAAFAAEAAAANABIAAAAFAAEAAAAOABIAAAAFAAEAAAAOABEAAAAFAAEAAAAOABAAAAAFAAEAAAAOAA8AAAAFAAEAAAAOAA4AAAAFAAEAAAAOAA0AAAAFAAEAAAAPAA0AAAAFAAEAAAAPAA4AAAAFAAEAAAAPAA8AAAAFAAEAAAAPABAAAAAFAAEAAAAPABEAAAAFAAEAAAAPABIAAAAFAAEAAAAQABIAAAAGAAEAAAAQABEAAAAFAAEAAAAQABAAAAAFAAEAAAAQAA8AAAAFAAEAAAAQAA4AAAAFAAEAAAAQAA0AAAAFAAEAAAARAA0AAAAFAAEAAAARAA4AAAAFAAEAAAARAA8AAAAFAAEAAAARABAAAAAGAAEAAAARABEAAAAFAAEAAAARABIAAAAGAAEAAAASABIAAAAGAAEAAAASABEAAAAFAAEAAAASABAAAAAFAAAAAAASAA8AAAAFAAAAAAASAA4AAAAFAAEAAAASAA0AAAAFAAEAAAATAA0AAAAFAAYAAAATAA4AAAAFAAYAAAATAA8AAAAFAAYAAAATABAAAAAFAAYAAAATABEAAAAFAAEAAAATABIAAAAGAAEAAAAUABIAAAAGAAAAAAAUABEAAAAFAAAAAAAUABAAAAAFAAYAAAAUAA8AAAAFAAYAAAAUAA4AAAAFAAYAAAAUAA0AAAAFAAYAAAAVAA0AAAAFAAYAAAAVAA4AAAAFAAYAAAAVAA8AAAAFAAYAAAAVABAAAAAFAAYAAAAVABEAAAAFAAEAAAAVABIAAAAGAAAAAAAWABIAAAAGAAAAAAAWABEAAAAFAAEAAAAWABAAAAAFAAEAAAAWAA8AAAAFAAAAAAAWAA4AAAAFAAEAAAAWAA0AAAAFAAEAAAAXAA0AAAAFAAEAAAAXAA4AAAAFAAEAAAAXAA8AAAAFAAEAAAAXABAAAAAGAAAAAAAXABEAAAAFAAEAAAAXABIAAAASAAoAAAAYABIAAAAFAAEAAAAYABEAAAAFAAEAAAAYABAAAAAFAAEAAAAYAA8AAAAFAAEAAAAYAA4AAAAFAAEAAAAYAA0AAAAFAAEAAAAZAA0AAAAGAAAAAAAZAA4AAAAFAAEAAAAZAA8AAAAFAAEAAAAZABAAAAAFAAEAAAAZABEAAAAFAAEAAAAZABIAAAAFAAEAAAAaABIAAAAFAAEAAAAaABEAAAAFAAEAAAAaABAAAAAFAAEAAAAaAA8AAAAFAAEAAAAaAA4AAAAFAAEAAAAaAA0AAAAFAAEAAAAbAA0AAAAFAAEAAAAbAA4AAAAFAAEAAAAbAA8AAAAFAAEAAAAbABAAAAAFAAEAAAAbABEAAAAFAAEAAAAbABIAAAAFAAEAAAAcABIAAAAGAAAAAAAcABEAAAAGAAAAAAAcABAAAAAGAAAAAAAcAA8AAAAGAAAAAAAcAA4AAAAGAAAAAAAcAA0AAAAFAAEAAAAdAA0AAAAGAAAAAAAdAA4AAAAGAAAAAAAdAA8AAAAGAAAAAAAdABAAAAAGAAAAAAAdABEAAAAGAAAAAAAdABIAAAAGAAAAAAAMAAMAAAAAAAwAAAAMAAQAAAAAAA0AAAAMAAUAAAAAAA0AAAANAAMAAAABAAwAAAANAAUAAAAJAAoAAAAOAAMAAAABAAwAAAAOAAQAAAAFAAoAAAAOAAUAAAAFAAEAAAA=")
 zones = {
 "Capturewa": {
 "cells": Array[Vector2i]([Vector2i(16, 5), Vector2i(15, 6), Vector2i(14, 5)]),
 "kind": 1
 },
 "ChestPatrol": {
-"cells": [Vector2i(16, 7), Vector2i(16, 6), Vector2i(17, 6), Vector2i(17, 7), Vector2i(17, 8), Vector2i(16, 8), Vector2i(15, 8), Vector2i(14, 8), Vector2i(13, 8), Vector2i(13, 7), Vector2i(13, 6), Vector2i(14, 6), Vector2i(14, 7), Vector2i(15, 7), Vector2i(15, 6), Vector2i(16, 5), Vector2i(15, 5), Vector2i(14, 5), Vector2i(12, 9), Vector2i(13, 9), Vector2i(14, 9), Vector2i(15, 9), Vector2i(16, 9), Vector2i(17, 9), Vector2i(18, 9), Vector2i(18, 10), Vector2i(17, 10), Vector2i(16, 10), Vector2i(15, 10), Vector2i(12, 10), Vector2i(13, 10), Vector2i(14, 10)],
+"cells": Array[Vector2i]([Vector2i(16, 7), Vector2i(16, 6), Vector2i(17, 6), Vector2i(17, 7), Vector2i(17, 8), Vector2i(16, 8), Vector2i(15, 8), Vector2i(14, 8), Vector2i(13, 8), Vector2i(13, 7), Vector2i(13, 6), Vector2i(14, 6), Vector2i(14, 7), Vector2i(15, 7), Vector2i(15, 6), Vector2i(16, 5), Vector2i(15, 5), Vector2i(14, 5), Vector2i(12, 9), Vector2i(13, 9), Vector2i(14, 9), Vector2i(15, 9), Vector2i(16, 9), Vector2i(17, 9), Vector2i(18, 9), Vector2i(18, 10), Vector2i(17, 10), Vector2i(16, 10), Vector2i(15, 10), Vector2i(12, 10), Vector2i(13, 10), Vector2i(14, 10)]),
 "kind": 0
 },
 "Extract": {
-"cells": [Vector2i(29, 2), Vector2i(29, 3), Vector2i(29, 4), Vector2i(28, 2), Vector2i(28, 3), Vector2i(28, 4)],
+"cells": Array[Vector2i]([Vector2i(29, 2), Vector2i(29, 3), Vector2i(29, 4), Vector2i(28, 2), Vector2i(28, 3), Vector2i(28, 4)]),
 "kind": 2
 },
 "GapPatrol": {
-"cells": [Vector2i(19, 17), Vector2i(20, 17), Vector2i(21, 17), Vector2i(21, 18), Vector2i(21, 19), Vector2i(20, 19), Vector2i(19, 19), Vector2i(19, 18), Vector2i(20, 18), Vector2i(22, 16), Vector2i(23, 16), Vector2i(24, 16), Vector2i(24, 17), Vector2i(24, 18), Vector2i(24, 19), Vector2i(23, 19), Vector2i(22, 19), Vector2i(22, 18), Vector2i(22, 17), Vector2i(23, 17), Vector2i(23, 18), Vector2i(25, 16), Vector2i(25, 17), Vector2i(25, 18), Vector2i(25, 19)],
+"cells": Array[Vector2i]([Vector2i(19, 17), Vector2i(20, 17), Vector2i(21, 17), Vector2i(21, 18), Vector2i(21, 19), Vector2i(20, 19), Vector2i(19, 19), Vector2i(19, 18), Vector2i(20, 18), Vector2i(22, 16), Vector2i(23, 16), Vector2i(24, 16), Vector2i(24, 17), Vector2i(24, 18), Vector2i(24, 19), Vector2i(23, 19), Vector2i(22, 19), Vector2i(22, 18), Vector2i(22, 17), Vector2i(23, 17), Vector2i(23, 18), Vector2i(25, 16), Vector2i(25, 17), Vector2i(25, 18), Vector2i(25, 19)]),
 "kind": 0
 },
 "RiverPatrol": {
-"cells": [Vector2i(17, 13), Vector2i(18, 12), Vector2i(18, 13), Vector2i(18, 14), Vector2i(18, 15), Vector2i(17, 15), Vector2i(16, 15), Vector2i(15, 15), Vector2i(14, 15), Vector2i(13, 15), Vector2i(12, 15), Vector2i(11, 15), Vector2i(11, 14), Vector2i(12, 13), Vector2i(12, 12), Vector2i(11, 12), Vector2i(11, 11), Vector2i(12, 11), Vector2i(13, 11), Vector2i(14, 11), Vector2i(15, 11), Vector2i(16, 11), Vector2i(17, 11), Vector2i(18, 11), Vector2i(17, 12), Vector2i(17, 14), Vector2i(16, 12), Vector2i(15, 12), Vector2i(15, 13), Vector2i(15, 14), Vector2i(16, 14), Vector2i(16, 13), Vector2i(14, 13), Vector2i(14, 12), Vector2i(13, 12), Vector2i(13, 14), Vector2i(14, 14), Vector2i(13, 13), Vector2i(12, 14), Vector2i(11, 13), Vector2i(18, 16), Vector2i(17, 16), Vector2i(16, 16), Vector2i(15, 16), Vector2i(14, 16), Vector2i(13, 16), Vector2i(12, 16), Vector2i(11, 16), Vector2i(18, 10), Vector2i(17, 10), Vector2i(16, 10), Vector2i(15, 10), Vector2i(14, 10), Vector2i(13, 10), Vector2i(12, 10), Vector2i(11, 10)],
+"cells": Array[Vector2i]([Vector2i(17, 13), Vector2i(18, 12), Vector2i(18, 13), Vector2i(18, 14), Vector2i(18, 15), Vector2i(17, 15), Vector2i(16, 15), Vector2i(15, 15), Vector2i(14, 15), Vector2i(13, 15), Vector2i(12, 15), Vector2i(11, 15), Vector2i(11, 14), Vector2i(12, 13), Vector2i(12, 12), Vector2i(11, 12), Vector2i(11, 11), Vector2i(12, 11), Vector2i(13, 11), Vector2i(14, 11), Vector2i(15, 11), Vector2i(16, 11), Vector2i(17, 11), Vector2i(18, 11), Vector2i(17, 12), Vector2i(17, 14), Vector2i(16, 12), Vector2i(15, 12), Vector2i(15, 13), Vector2i(15, 14), Vector2i(16, 14), Vector2i(16, 13), Vector2i(14, 13), Vector2i(14, 12), Vector2i(13, 12), Vector2i(13, 14), Vector2i(14, 14), Vector2i(13, 13), Vector2i(12, 14), Vector2i(11, 13), Vector2i(18, 16), Vector2i(17, 16), Vector2i(16, 16), Vector2i(15, 16), Vector2i(14, 16), Vector2i(13, 16), Vector2i(12, 16), Vector2i(11, 16), Vector2i(18, 10), Vector2i(17, 10), Vector2i(16, 10), Vector2i(15, 10), Vector2i(14, 10), Vector2i(13, 10), Vector2i(12, 10), Vector2i(11, 10)]),
 "kind": 0
 }
 }

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Iosis"
-config/version="0.6.0"
+config/version="0.6.1"
 run/main_scene="uid://cxiu0yvwwxlgo"
 config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"

--- a/tests/ui/test_tile_hover_readout.gd
+++ b/tests/ui/test_tile_hover_readout.gd
@@ -1,21 +1,26 @@
 # The tile hover card (#135, rebuilt round 2), on the real scene: EVERY real tile shows a card
-# (icon + kind header), states join as content with their live clocks, a unit standing there
+# (icon + name header), states join as content with their live clocks, a unit standing there
 # stacks both halves, and the interactions list is filtered through the resolver's own predicate
 # (TerrainReaction.applies_to_tile) so the card never promises a deposit the resolver refuses.
 # Driven through the real hover path (HoverPresenter.update_hover_visuals), because composition,
 # panel and parking only meet there.
 #
-# Fixture is test_menu_catalogue_rows.gd's: the real game scene, a row of grass + one water cell.
+# The card reads the TILE'S OWN data since 2026-08-12 -- authored terrain_name first, kind name
+# as the fallback, the tile's sprite as the picture (the palette rows' policy, shared through
+# GridUtils). Fixture is a SYNTHETIC tileset (the palette suite's pattern): the dev names his
+# real TestTiles content live, so header assertions against it would move under his authoring.
 extends GdUnitTestSuite
 
 const MAIN_SCENE := "res://Scenes/Main.tscn"
 const H := preload("res://tests/support/squad_fixtures.gd")
-const GRASS_SOURCE := 0
-const GRASS_ATLAS := Vector2i(5, 0)
-const WATER_ATLAS := Vector2i(5, 6)
+const GRASS_ATLAS := Vector2i(0, 0)         # unnamed GRASS -- the default paint, kind fallback
+const NAMED_GRASS_ATLAS := Vector2i(1, 0)   # GRASS authored "spring meadow"
+const CRATE_ATLAS := Vector2i(2, 0)         # kindless scenery authored "crate"
+const WATER_ATLAS := Vector2i(3, 0)         # unnamed WATER, no walkable flag (impassable)
 
 var _main: Node
 var game: Node2D
+var _src_id: int
 
 
 func before_test() -> void:
@@ -26,10 +31,51 @@ func before_test() -> void:
 	game = _main.get_node("GameContainer/GameView/Game")
 	game.scenario_manager.clear_board()
 	game.game_state = game.GameState.IDLE
+	game.grid.tile_set = _build_tile_set()
 	for x in range(8):
-		game.grid.set_cell(Vector2i(x, 0), GRASS_SOURCE, GRASS_ATLAS)
-	game.grid.set_cell(Vector2i(0, 1), GRASS_SOURCE, WATER_ATLAS)
+		game.grid.set_cell(Vector2i(x, 0), _src_id, GRASS_ATLAS)
+	game.grid.set_cell(Vector2i(0, 1), _src_id, WATER_ATLAS)
 	await await_idle_frame()
+
+
+func _build_tile_set() -> TileSet:
+	var tiles := TileSet.new()
+	tiles.tile_size = Vector2i(16, 16)
+	tiles.add_custom_data_layer()
+	tiles.set_custom_data_layer_name(0, "walkable")
+	tiles.set_custom_data_layer_type(0, TYPE_BOOL)
+	tiles.add_custom_data_layer()
+	tiles.set_custom_data_layer_name(1, "move_cost")
+	tiles.set_custom_data_layer_type(1, TYPE_INT)
+	tiles.add_custom_data_layer()
+	tiles.set_custom_data_layer_name(2, "terrain_type")
+	tiles.set_custom_data_layer_type(2, TYPE_INT)
+	tiles.add_custom_data_layer()
+	tiles.set_custom_data_layer_name(3, "terrain_name")
+	tiles.set_custom_data_layer_type(3, TYPE_STRING)
+	var source := TileSetAtlasSource.new()
+	source.texture = ImageTexture.create_from_image(
+		Image.create_empty(64, 16, false, Image.FORMAT_RGBA8))
+	source.texture_region_size = Vector2i(16, 16)
+	_src_id = tiles.add_source(source)
+	_author_tile(source, GRASS_ATLAS, Terrain.Kind.GRASS, "", true)
+	_author_tile(source, NAMED_GRASS_ATLAS, Terrain.Kind.GRASS, "spring meadow", true)
+	_author_tile(source, CRATE_ATLAS, Terrain.Kind.NONE, "crate", false)
+	_author_tile(source, WATER_ATLAS, Terrain.Kind.WATER, "", false)
+	return tiles
+
+
+func _author_tile(source: TileSetAtlasSource, coords: Vector2i, kind: Terrain.Kind,
+		tile_name: String, walkable: bool) -> void:
+	source.create_tile(coords)
+	var data := source.get_tile_data(coords, 0)
+	if walkable:
+		data.set_custom_data("walkable", true)
+	data.set_custom_data("move_cost", 1)
+	if kind != Terrain.Kind.NONE:
+		data.set_custom_data("terrain_type", kind)
+	if tile_name != "":
+		data.set_custom_data("terrain_name", tile_name)
 
 
 func after_test() -> void:
@@ -80,6 +126,42 @@ func test_every_tile_shows_a_card_with_its_kind() -> void:
 		.override_failure_message("the tile card has no kind picture").is_not_null()
 	# And the unit half stays down — nobody is standing there.
 	assert_bool(game.hover_info_panel.hover_panel.visible).is_false()
+
+
+func test_a_named_tile_headers_its_authored_name() -> void:
+	# The 2026-08-12 report: the card assumed the name off the Kind enum, so an authored
+	# variant read as plain "Grass" however it was named.
+	game.grid.set_cell(Vector2i(6, 0), _src_id, NAMED_GRASS_ATLAS)
+	game.hover_presenter.update_hover_visuals(Vector2i(6, 0))
+	await await_idle_frame()
+
+	assert_str(_tile_header_text()).is_equal("Spring Meadow")
+
+
+func test_named_kindless_scenery_gets_a_named_card() -> void:
+	# Kind NONE used to mean a headerless card no matter what the tile was authored as -- a
+	# Crate is scenery with a name, and the card must say so.
+	game.grid.set_cell(Vector2i(6, 0), _src_id, CRATE_ATLAS)
+	game.hover_presenter.update_hover_visuals(Vector2i(6, 0))
+	await await_idle_frame()
+
+	assert_bool(game.hover_info_panel._tile_panel.visible).is_true()
+	assert_str(_tile_header_text()).is_equal("Crate")
+
+
+func test_the_card_icon_is_the_tiles_own_sprite() -> void:
+	# The icon is the tile's actual art (an AtlasTexture cut from its own sheet region), not the
+	# hand-drawn kind icon -- TERRAIN_ICONS stays the queue rows' pathing glyph. NB the region
+	# getter returns Rect2i while AtlasTexture.region is Rect2; Variant equality across them is
+	# FALSE, hence the wrap.
+	game.hover_presenter.update_hover_visuals(Vector2i(2, 0))
+	await await_idle_frame()
+
+	var icon := game.hover_info_panel._tile_icon.texture as AtlasTexture
+	assert_object(icon).is_not_null()
+	var source := (game.grid.tile_set as TileSet).get_source(_src_id) as TileSetAtlasSource
+	assert_object(icon.atlas).is_same(source.texture)
+	assert_that(icon.region).is_equal(Rect2(source.get_tile_texture_region(GRASS_ATLAS)))
 
 
 func test_a_burning_tile_works_the_state_into_the_card() -> void:
@@ -146,7 +228,7 @@ func test_a_bottom_parked_card_stays_on_screen_after_a_taller_one() -> void:
 	var attempts := 0
 	while not _screen_pos_in_top_half(cell):
 		cell.y -= 1
-		game.grid.set_cell(cell, GRASS_SOURCE, GRASS_ATLAS)
+		game.grid.set_cell(cell, _src_id, GRASS_ATLAS)
 		attempts += 1
 		assert_int(attempts) \
 			.override_failure_message("could not find a cell in the top half of the viewport — fixture camera assumption is broken") \


### PR DESCRIPTION
The missed surface of #195's palette rework, reported in-session: the tile hover card assumed its header and icon off the Kind enum — `Terrain.kind_display_name(kind)` + `GridUtils.TERRAIN_ICONS[kind]` — so an authored variant read as plain "Grass" and named kindless scenery (Crate, pre-authoring `mud_basic`) got a headerless card. **Stacked on #197**; the stack is #195 → #196 → #197 → this.

## What changed

- The card reads **the tile's own data**: authored `terrain_name` first, kind name as the fallback, and the tile's **actual sprite** as the picture. Bare unnamed decoration stays headerless, exactly as before.
- **One policy, shared (Law #4):** the palette rows already answered "what is this tile called / what does it look like" — the shared reads now live in `GridUtils.authored_tile_display_name` / `tile_sprite` (GridUtils' charter is tile-data reads shared by every layer), and both `TileBrushTool._palette_entry` and `HoverPresenter._show_hover_panel` consume them, so hover and palette cannot disagree. The palette keeps its own coords-suffix fallback for unnamed variants.
- **`TERRAIN_ICONS` / `get_terrain_icon_at_cell` untouched** — counted from the code, their 8 remaining callers are all queue-row/pathing glyph sites, deliberately kind-based. If you ever want queue rows showing real sprites too, that's its own change.
- The hover suite's fixture went **synthetic** (the palette suite's pattern): you name your real TestTiles content live (`grass_basic`, `water_basic`, `mud_basic`), so header assertions against it would move under your authoring. Existing case meanings unchanged; the default paint is an *unnamed* grass so the kind-fallback assertions stay literally true.

## Verification

- Full suite **1269/1269, 0 orphans**.
- Falsified against **two separate mutants**, each caught by exactly its own case: enum-derived header → `test_a_named_tile_headers_its_authored_name`; kind-icon-instead-of-sprite → `test_the_card_icon_is_the_tiles_own_sprite`. The palette suite stayed green under both, proving the helper refactor didn't move its behavior.
- **Your half:** hover a named grass / mud / crate / the lantern in-game — sprite legibility at card size is a by-eye call (the panel's TextureRect scales pixel-crisp, keep-aspect).

## Version bump — pending one commit

This PR owes a `0.6.0 → 0.6.1` bump (bugfix-only). Your editor was open when the PR went up, so the `project.godot` line waits (the stale-editor-write rule); it lands as a follow-up commit on this branch next time Godot is closed — **before merge**, so the diff carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
