### PR TITLE
HD-2D Stage 2: the unit layer (#210, v0.10.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Tactical RPG (Fire Emblem-influenced), Godot 4.7, GDScript. Solo hobbyist develo
 - **Content is disposable; cleanliness is not.** `.tscn` scenes and saved `Scenarios/*.tres` are placeholder — fix them to match the code rather than carrying a legacy-compat branch for their sake.
 - **File header comments.** Any `Classes/`/`Scenes/`/`game.gd` file touched that lacks a top-of-file description comment (what the file/class IS and its place in the architecture) gets one added.
 - **Terse comments in source.** Rationale goes in chat, `docs/`, and issue text — never walkthrough prose in a `.gd` file.
+- **Aesthetic tuning values get a knob, not a guess (dev rule, 2026-08-12).** When a shader/lighting/post/animation value is a matter of taste, don't burn rounds picking numbers — expose it (an `@export`, an inspector-reachable resource, or the look-dev tuning panel) and hand it to the dev: *"I can find the values that work, and we can save a lot of time."*
 
 ## GitHub issue workflow (Claude ↔ human handoff)
 

--- a/Classes/presentation/UnitSprite3D.gd
+++ b/Classes/presentation/UnitSprite3D.gd
@@ -1,0 +1,115 @@
+extends Sprite3D
+class_name UnitSprite3D
+
+# The 3D presentation stack's unit visual (#210 / #176 stage 2): one Sprite3D driven
+# by a UnitData's sprite triple (map / move / downed), standing on BoardSpace cells,
+# walking per-cell tweens that mirror MovementComponent's pattern (authoritative
+# `cell`, teleport vs walk verbs, a finished signal). The HD-2D sprite settings live
+# in _init as their ONE home — scenes stop authoring them per-node.
+#
+# Facing seam v1 (#176 seam 3): _facing_flip_for judges each step against the LIVE
+# camera's right vector and mirrors the sprite when travelling screen-left. When
+# multi-facing art exists this function becomes frame_for(unit_facing, camera_yaw);
+# ART_FACES_SCREEN_RIGHT is the one const to invert if the art reads the other way.
+
+signal walk_finished
+
+const ART_FACES_SCREEN_RIGHT := true
+const FALLBACK_SPRITE := "res://Art/Units/MapSprites/Recruit.png"
+
+# Matches the 2D game's cadence: 120 px/s over 32 px cells = 3.75 cells per second.
+@export var move_speed := 3.75
+
+var cell := BoardSpace.NO_CELL
+var display_name := "Unit"
+
+var _map_texture: Texture2D
+var _move_texture: Texture2D
+var _downed_texture: Texture2D
+var _walk_path: Array[Vector3i] = []
+var _walking := false
+var _downed := false
+
+
+func _init() -> void:
+	billboard = BaseMaterial3D.BILLBOARD_FIXED_Y
+	texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST
+	alpha_cut = SpriteBase3D.ALPHA_CUT_OPAQUE_PREPASS
+	shaded = true
+	cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
+	pixel_size = 1.0 / 32.0  # the one-density convention: 32 texels per world unit
+	offset = Vector2(0, 16)  # pivot at the feet
+
+
+static func for_unit_data(data: UnitData) -> UnitSprite3D:
+	var sprite := UnitSprite3D.new()
+	sprite.display_name = data.display_name
+	sprite._map_texture = data.map_sprite
+	sprite._move_texture = data.move_sprite
+	sprite._downed_texture = data.downed_sprite
+	if sprite._map_texture == null:
+		push_warning("UnitSprite3D: '%s' has no map_sprite authored; using the fallback." % data.display_name)
+		sprite._map_texture = load(FALLBACK_SPRITE) as Texture2D
+	sprite.texture = sprite._map_texture
+	sprite.name = data.display_name
+	return sprite
+
+
+# Teleport: spawn/reset placement, no animation (MovementComponent.set_cell's twin).
+func place_at(new_cell: Vector3i) -> void:
+	cell = new_cell
+	position = BoardSpace.standing_point(new_cell)
+
+
+# Walk the path one cell-tween at a time; `cell` is assigned as each step BEGINS,
+# mirroring MovementComponent's in-flight semantics. Always emits walk_finished.
+func walk_path(cells: Array[Vector3i]) -> void:
+	if cells.size() <= 1:
+		walk_finished.emit()
+		return
+	_walk_path = cells.duplicate()
+	_walk_path.pop_front()
+	_walking = true
+	if _move_texture != null and not _downed:
+		texture = _move_texture
+	_step_to_next_cell()
+
+
+func is_walking() -> bool:
+	return _walking
+
+
+func set_downed(down: bool) -> void:
+	_downed = down
+	if down and _downed_texture != null:
+		texture = _downed_texture
+	elif not down:
+		texture = _map_texture
+
+
+func _step_to_next_cell() -> void:
+	if _walk_path.is_empty():
+		_walking = false
+		if not _downed:
+			texture = _map_texture
+		walk_finished.emit()
+		return
+	var next_cell: Vector3i = _walk_path.pop_front()
+	var target := BoardSpace.standing_point(next_cell)
+	flip_h = _facing_flip_for(target - position)
+	var duration := position.distance_to(target) / maxf(move_speed, 0.01)
+	cell = next_cell
+	var tween := create_tween()
+	tween.tween_property(self, "position", target, duration)
+	tween.finished.connect(_step_to_next_cell)
+
+
+# Facing seam v1: mirror when the step travels screen-left, judged against the live
+# camera. No camera (headless unit tests) = no flip, deterministically.
+func _facing_flip_for(step_direction: Vector3) -> bool:
+	var camera := get_viewport().get_camera_3d() if is_inside_tree() else null
+	if camera == null:
+		return false
+	var screen_right := camera.global_transform.basis.x
+	var travels_right := step_direction.dot(screen_right) >= 0.0
+	return travels_right != ART_FACES_SCREEN_RIGHT

--- a/Classes/presentation/UnitSprite3D.gd
+++ b/Classes/presentation/UnitSprite3D.gd
@@ -14,11 +14,19 @@ class_name UnitSprite3D
 
 signal walk_finished
 
-const ART_FACES_SCREEN_RIGHT := true
+# false: the MapSprites face screen-LEFT natively (dev feel-check 2026-08-12 —
+# "all units look like they're moonwalking" with this set true).
+const ART_FACES_SCREEN_RIGHT := false
 const FALLBACK_SPRITE := "res://Art/Units/MapSprites/Recruit.png"
 
 # Matches the 2D game's cadence: 120 px/s over 32 px cells = 3.75 cells per second.
 @export var move_speed := 3.75
+
+# Where a cell's stand-point is. Defaults to the flat convention; a board-aware
+# owner injects its own (the walk demo lowers ramp cells to the slope midpoint,
+# dev feel-check 2026-08-12: units floated over slopes). Passing beats looking up:
+# the component never reads a GridMap.
+var stand_at: Callable = BoardSpace.standing_point
 
 var cell := BoardSpace.NO_CELL
 var display_name := "Unit"
@@ -58,7 +66,7 @@ static func for_unit_data(data: UnitData) -> UnitSprite3D:
 # Teleport: spawn/reset placement, no animation (MovementComponent.set_cell's twin).
 func place_at(new_cell: Vector3i) -> void:
 	cell = new_cell
-	position = BoardSpace.standing_point(new_cell)
+	position = stand_at.call(new_cell)
 
 
 # Walk the path one cell-tween at a time; `cell` is assigned as each step BEGINS,
@@ -95,7 +103,7 @@ func _step_to_next_cell() -> void:
 		walk_finished.emit()
 		return
 	var next_cell: Vector3i = _walk_path.pop_front()
-	var target := BoardSpace.standing_point(next_cell)
+	var target: Vector3 = stand_at.call(next_cell)
 	flip_h = _facing_flip_for(target - position)
 	var duration := position.distance_to(target) / maxf(move_speed, 0.01)
 	cell = next_cell

--- a/Classes/presentation/UnitSprite3D.gd.uid
+++ b/Classes/presentation/UnitSprite3D.gd.uid
@@ -1,0 +1,1 @@
+uid://c66rgbl4fe78a

--- a/Scenes/LookDev/LookDev.tscn
+++ b/Scenes/LookDev/LookDev.tscn
@@ -1,16 +1,13 @@
-[gd_scene load_steps=23 format=3]
+[gd_scene load_steps=20 format=3]
 
 [ext_resource type="Script" path="res://Scenes/LookDev/look_dev.gd" id="1"]
 [ext_resource type="Script" path="res://Scenes/LookDev/board_painter.gd" id="2"]
 [ext_resource type="Script" path="res://Scenes/LookDev/look_dev_camera.gd" id="3"]
 [ext_resource type="MeshLibrary" path="res://Scenes/LookDev/lookdev_meshlib.tres" id="4"]
-[ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Knight.png" id="5"]
-[ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Mage.png" id="6"]
-[ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Archer.png" id="7"]
-[ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Brigand.png" id="8"]
 [ext_resource type="Texture2D" path="res://Art/LookDev/torch_flame.png" id="9"]
 [ext_resource type="Shader" path="res://Scenes/LookDev/vignette.gdshader" id="10"]
 [ext_resource type="Script" path="res://Scenes/LookDev/cell_picker_demo.gd" id="11"]
+[ext_resource type="Script" path="res://Scenes/LookDev/unit_walk_demo.gd" id="12"]
 
 [sub_resource type="ProceduralSkyMaterial" id="sky_mat"]
 sky_top_color = Color(0.32, 0.5, 0.78, 1)
@@ -120,46 +117,6 @@ omni_range = 6.0
 
 [node name="Units" type="Node3D" parent="."]
 
-[node name="Knight" type="Sprite3D" parent="Units"]
-position = Vector3(5.5, 1, 8.5)
-pixel_size = 0.03125
-billboard = 2
-shaded = true
-offset = Vector2(0, 16)
-alpha_cut = 2
-texture_filter = 0
-texture = ExtResource("5")
-
-[node name="Mage" type="Sprite3D" parent="Units"]
-position = Vector3(6.5, 1, 7.5)
-pixel_size = 0.03125
-billboard = 2
-shaded = true
-offset = Vector2(0, 16)
-alpha_cut = 2
-texture_filter = 0
-texture = ExtResource("6")
-
-[node name="Archer" type="Sprite3D" parent="Units"]
-position = Vector3(8.5, 3, 3.5)
-pixel_size = 0.03125
-billboard = 2
-shaded = true
-offset = Vector2(0, 16)
-alpha_cut = 2
-texture_filter = 0
-texture = ExtResource("7")
-
-[node name="Brigand" type="Sprite3D" parent="Units"]
-position = Vector3(11.5, 1, 11.5)
-pixel_size = 0.03125
-billboard = 2
-shaded = true
-offset = Vector2(0, 16)
-alpha_cut = 2
-texture_filter = 0
-texture = ExtResource("8")
-
 [node name="CameraRig" type="Node3D" parent="."]
 position = Vector3(7, 1, 7)
 script = ExtResource("3")
@@ -181,6 +138,9 @@ visible = false
 cast_shadow = 0
 mesh = SubResource("highlight_quad")
 
+[node name="WalkDemo" type="Node3D" parent="."]
+script = ExtResource("12")
+
 [node name="UI" type="CanvasLayer" parent="."]
 
 [node name="Vignette" type="ColorRect" parent="UI"]
@@ -191,6 +151,17 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
+
+[node name="WalkReadout" type="Label" parent="UI"]
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = -50.0
+offset_right = 320.0
+offset_bottom = -30.0
+grow_vertical = 0
+theme_override_font_sizes/font_size = 13
+modulate = Color(1, 1, 1, 0.85)
 
 [node name="CellReadout" type="Label" parent="UI"]
 anchor_top = 1.0

--- a/Scenes/LookDev/look_dev.gd
+++ b/Scenes/LookDev/look_dev.gd
@@ -20,11 +20,13 @@ const PRESETS: Array[Dictionary] = [
 		"sky_horizon": Color(0.68, 0.74, 0.82),
 	},
 	{
+		# Fog tamed 2026-08-12 ("looks like a forest fire") — stopgap until the
+		# tuning panel; the dev owns these numbers.
 		"sun_rotation": Vector3(-14.0, -62.0, 0.0),
 		"sun_color": Color(1.0, 0.62, 0.32),
 		"sun_energy": 1.1,
-		"fog_density": 0.03,
-		"fog_albedo": Color(0.98, 0.75, 0.55),
+		"fog_density": 0.018,
+		"fog_albedo": Color(0.9, 0.78, 0.62),
 		"saturation": 1.12,
 		"sky_top": Color(0.36, 0.28, 0.5),
 		"sky_horizon": Color(0.98, 0.6, 0.35),

--- a/Scenes/LookDev/unit_walk_demo.gd
+++ b/Scenes/LookDev/unit_walk_demo.gd
@@ -1,10 +1,10 @@
 # Stage-2 proof (#210): real cast members walking the diorama. Spawns UnitSprite3Ds
 # from UnitCatalog at authored columns, then LMB drives select-and-walk through the
 # stage-1 picker. The BFS here is DEMO-ONLY scaffolding, thrown away when the sim's
-# real move rules arrive (stage 4): 4-neighbor over column tops, a step is legal iff
-# |top delta| <= 1, other units block. Ramps read as the intended path visually but
-# are not yet mechanically required — traversal doctrine belongs to the rules layer,
-# and the demo deliberately does not pre-decide it.
+# real move rules arrive (stage 4) — but it implements the dev's traversal RULING
+# (2026-08-12): height changes happen ONLY via ramps, and a ramp connects exactly
+# its high-side and low-side neighbors (no sideways entry). Flat steps need equal
+# tops; other units block. Units on ramp cells stand at the slope midpoint.
 extends Node3D
 
 const SELECTED_MODULATE := Color(1.4, 1.4, 1.0)  # UnitVisuals.HIGHLIGHT_MODULATE's twin
@@ -24,12 +24,14 @@ const SPAWN_COLUMNS: Array[Vector2i] = [
 @onready var _readout: Label = $"../UI/WalkReadout"
 
 var _tops: Dictionary[Vector2i, int] = {}
+var _ramp_exits: Dictionary[Vector2i, Array] = {}
 var _units: Array[UnitSprite3D] = []
 var _selected: UnitSprite3D = null
 
 
 func _ready() -> void:
 	_tops = BoardPicker.column_tops_from(_board)
+	_ramp_exits = ramp_exits_from(_board, _board.RAMP)
 	_spawn_cast()
 	_update_readout()
 
@@ -59,7 +61,7 @@ func order_walk(target_cell: Vector3i) -> void:
 	for unit in _units:
 		if unit != _selected:
 			blocked[Vector2i(unit.cell.x, unit.cell.z)] = true
-	var path := find_path(_selected.cell, target_cell, _tops, blocked)
+	var path := find_path(_selected.cell, target_cell, _tops, blocked, _ramp_exits)
 	if path.size() > 1:
 		_selected.walk_path(path)
 
@@ -72,9 +74,26 @@ func units() -> Array[UnitSprite3D]:
 	return _units
 
 
-# DEMO-ONLY pathing (see header): BFS over columns, |top delta| <= 1 per step.
+# The ramp adjacency map: ramp column -> [high-side column, low-side column].
+# Orientation basis maps the mesh's high edge (-Z at yaw 0) into the world.
+static func ramp_exits_from(board: GridMap, ramp_item: int) -> Dictionary[Vector2i, Array]:
+	var exits: Dictionary[Vector2i, Array] = {}
+	for cell in board.get_used_cells():
+		if board.get_cell_item(cell) != ramp_item:
+			continue
+		var column := Vector2i(cell.x, cell.z)
+		var basis := board.get_basis_with_orthogonal_index(board.get_cell_item_orientation(cell))
+		var high_dir := basis * Vector3(0, 0, -1)
+		var high_step := Vector2i(roundi(high_dir.x), roundi(high_dir.z))
+		exits[column] = [column + high_step, column - high_step]
+	return exits
+
+
+# DEMO-ONLY pathing (see header), under the dev's traversal ruling: flat steps need
+# equal tops; any height change routes through a ramp, and a ramp connects ONLY its
+# high- and low-side neighbors.
 static func find_path(from_cell: Vector3i, to_cell: Vector3i, tops: Dictionary[Vector2i, int],
-		blocked: Dictionary[Vector2i, bool]) -> Array[Vector3i]:
+		blocked: Dictionary[Vector2i, bool], ramp_exits: Dictionary[Vector2i, Array]) -> Array[Vector3i]:
 	var from_col := Vector2i(from_cell.x, from_cell.z)
 	var to_col := Vector2i(to_cell.x, to_cell.z)
 	if not tops.has(from_col) or not tops.has(to_col):
@@ -92,7 +111,7 @@ static func find_path(from_cell: Vector3i, to_cell: Vector3i, tops: Dictionary[V
 			var next: Vector2i = col + side
 			if came_from.has(next) or not tops.has(next) or blocked.has(next):
 				continue
-			if absi(tops[next] - tops[col]) > 1:
+			if not _step_legal(col, next, tops, ramp_exits):
 				continue
 			came_from[next] = col
 			frontier.append(next)
@@ -108,6 +127,19 @@ static func find_path(from_cell: Vector3i, to_cell: Vector3i, tops: Dictionary[V
 	return path
 
 
+static func _step_legal(col: Vector2i, next: Vector2i, tops: Dictionary[Vector2i, int],
+		ramp_exits: Dictionary[Vector2i, Array]) -> bool:
+	var col_is_ramp := ramp_exits.has(col)
+	var next_is_ramp := ramp_exits.has(next)
+	if col_is_ramp and not (ramp_exits[col] as Array).has(next):
+		return false
+	if next_is_ramp and not (ramp_exits[next] as Array).has(col):
+		return false
+	if not col_is_ramp and not next_is_ramp and tops[next] != tops[col]:
+		return false
+	return true
+
+
 # --- Internals -----------------------------------------------------------------
 
 func _spawn_cast() -> void:
@@ -119,9 +151,19 @@ func _spawn_cast() -> void:
 			break
 		var data: UnitData = characters[names[i]]
 		var sprite := UnitSprite3D.for_unit_data(data)
+		sprite.stand_at = _surface_point
 		_units_root.add_child(sprite)
 		sprite.place_at(_top_cell(SPAWN_COLUMNS[i]))
 		_units.append(sprite)
+
+
+# Board-aware stand-point: ramp cells stand at the slope midpoint, half a cell
+# below the flat convention (dev feel-check 2026-08-12: units floated over slopes).
+func _surface_point(cell: Vector3i) -> Vector3:
+	var point := BoardSpace.standing_point(cell)
+	if _ramp_exits.has(Vector2i(cell.x, cell.z)):
+		point.y -= BoardSpace.CELL_SIZE * 0.5
+	return point
 
 
 func _top_cell(column: Vector2i) -> Vector3i:

--- a/Scenes/LookDev/unit_walk_demo.gd
+++ b/Scenes/LookDev/unit_walk_demo.gd
@@ -1,0 +1,153 @@
+# Stage-2 proof (#210): real cast members walking the diorama. Spawns UnitSprite3Ds
+# from UnitCatalog at authored columns, then LMB drives select-and-walk through the
+# stage-1 picker. The BFS here is DEMO-ONLY scaffolding, thrown away when the sim's
+# real move rules arrive (stage 4): 4-neighbor over column tops, a step is legal iff
+# |top delta| <= 1, other units block. Ramps read as the intended path visually but
+# are not yet mechanically required — traversal doctrine belongs to the rules layer,
+# and the demo deliberately does not pre-decide it.
+extends Node3D
+
+const SELECTED_MODULATE := Color(1.4, 1.4, 1.0)  # UnitVisuals.HIGHLIGHT_MODULATE's twin
+
+# Cast members to spawn (first found wins) and the columns they stand on.
+const SPAWN_COLUMNS: Array[Vector2i] = [
+	Vector2i(5, 8),    # plain, near the torch
+	Vector2i(6, 7),    # plain, in the torchlight
+	Vector2i(8, 3),    # the plateau top
+	Vector2i(4, 10),   # the stone platform
+	Vector2i(11, 11),  # far corner, deep in the DoF falloff
+]
+
+@onready var _board: GridMap = $"../Board"
+@onready var _camera: Camera3D = $"../CameraRig/Pitch/Camera"
+@onready var _units_root: Node3D = $"../Units"
+@onready var _readout: Label = $"../UI/WalkReadout"
+
+var _tops: Dictionary[Vector2i, int] = {}
+var _units: Array[UnitSprite3D] = []
+var _selected: UnitSprite3D = null
+
+
+func _ready() -> void:
+	_tops = BoardPicker.column_tops_from(_board)
+	_spawn_cast()
+	_update_readout()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	var click := event as InputEventMouseButton
+	if click == null or not click.pressed or click.button_index != MOUSE_BUTTON_LEFT:
+		return
+	var cell := BoardPicker.pick_cell(
+			_camera.project_ray_origin(click.position),
+			_camera.project_ray_normal(click.position), _tops)
+	if cell == BoardSpace.NO_CELL:
+		return
+	var clicked_unit := _unit_at(cell)
+	if clicked_unit != null:
+		_select(clicked_unit)
+	elif _selected != null:
+		order_walk(cell)
+
+
+# --- The demo's walk order (public so tests drive it without input synthesis) -----
+
+func order_walk(target_cell: Vector3i) -> void:
+	if _selected == null or _selected.is_walking():
+		return
+	var blocked: Dictionary[Vector2i, bool] = {}
+	for unit in _units:
+		if unit != _selected:
+			blocked[Vector2i(unit.cell.x, unit.cell.z)] = true
+	var path := find_path(_selected.cell, target_cell, _tops, blocked)
+	if path.size() > 1:
+		_selected.walk_path(path)
+
+
+func selected_unit() -> UnitSprite3D:
+	return _selected
+
+
+func units() -> Array[UnitSprite3D]:
+	return _units
+
+
+# DEMO-ONLY pathing (see header): BFS over columns, |top delta| <= 1 per step.
+static func find_path(from_cell: Vector3i, to_cell: Vector3i, tops: Dictionary[Vector2i, int],
+		blocked: Dictionary[Vector2i, bool]) -> Array[Vector3i]:
+	var from_col := Vector2i(from_cell.x, from_cell.z)
+	var to_col := Vector2i(to_cell.x, to_cell.z)
+	if not tops.has(from_col) or not tops.has(to_col):
+		return []
+	if blocked.has(to_col):
+		return []
+	var came_from: Dictionary[Vector2i, Vector2i] = {}
+	var frontier: Array[Vector2i] = [from_col]
+	came_from[from_col] = from_col
+	while not frontier.is_empty():
+		var col: Vector2i = frontier.pop_front()
+		if col == to_col:
+			break
+		for side in [Vector2i.RIGHT, Vector2i.LEFT, Vector2i.UP, Vector2i.DOWN]:
+			var next: Vector2i = col + side
+			if came_from.has(next) or not tops.has(next) or blocked.has(next):
+				continue
+			if absi(tops[next] - tops[col]) > 1:
+				continue
+			came_from[next] = col
+			frontier.append(next)
+	if not came_from.has(to_col):
+		return []
+	var path: Array[Vector3i] = []
+	var walk_back := to_col
+	while true:
+		path.push_front(Vector3i(walk_back.x, tops[walk_back] - 1, walk_back.y))
+		if walk_back == from_col:
+			break
+		walk_back = came_from[walk_back]
+	return path
+
+
+# --- Internals -----------------------------------------------------------------
+
+func _spawn_cast() -> void:
+	var characters: Dictionary = UnitCatalog.get_characters()
+	var names: Array = characters.keys()
+	names.sort()
+	for i in SPAWN_COLUMNS.size():
+		if i >= names.size():
+			break
+		var data: UnitData = characters[names[i]]
+		var sprite := UnitSprite3D.for_unit_data(data)
+		_units_root.add_child(sprite)
+		sprite.place_at(_top_cell(SPAWN_COLUMNS[i]))
+		_units.append(sprite)
+
+
+func _top_cell(column: Vector2i) -> Vector3i:
+	var top: int = _tops.get(column, 1)
+	return Vector3i(column.x, top - 1, column.y)
+
+
+func _unit_at(cell: Vector3i) -> UnitSprite3D:
+	for unit in _units:
+		if Vector2i(unit.cell.x, unit.cell.z) == Vector2i(cell.x, cell.z):
+			return unit
+	return null
+
+
+func _select(unit: UnitSprite3D) -> void:
+	if _selected != null:
+		_selected.modulate = Color.WHITE
+	_selected = unit
+	_selected.modulate = SELECTED_MODULATE
+	_update_readout()
+
+
+func _update_readout() -> void:
+	if _readout == null:
+		return
+	if _selected == null:
+		_readout.text = "click a unit to select"
+	else:
+		_readout.text = "%s selected - click a tile to walk" % _selected.display_name

--- a/Scenes/LookDev/unit_walk_demo.gd.uid
+++ b/Scenes/LookDev/unit_walk_demo.gd.uid
@@ -1,0 +1,1 @@
+uid://dxldlnofs5o7i

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Iosis"
-config/version="0.9.0"
+config/version="0.10.0"
 run/main_scene="uid://cxiu0yvwwxlgo"
 config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"

--- a/tests/presentation/test_look_dev.gd
+++ b/tests/presentation/test_look_dev.gd
@@ -46,6 +46,7 @@ func test_sprites_are_billboarded_lit_pixel_quads() -> void:
 	for child in sprites:
 		var sprite := child as Sprite3D
 		assert_object(sprite).is_not_null()
+		assert_bool(sprite is UnitSprite3D).is_true()  # stage 2: the component is the one author
 		assert_object(sprite.texture).is_not_null()
 		assert_int(sprite.billboard).is_equal(BaseMaterial3D.BILLBOARD_FIXED_Y)
 		assert_int(sprite.alpha_cut).is_equal(SpriteBase3D.ALPHA_CUT_OPAQUE_PREPASS)

--- a/tests/presentation/test_unit_sprite.gd
+++ b/tests/presentation/test_unit_sprite.gd
@@ -1,0 +1,97 @@
+# UnitSprite3D (#210): the component's contract — factory invariants (the HD-2D
+# settings now live in code, not scene authoring), placement on standing points,
+# the walk (finishes, updates cell, swaps the move sprite mid-walk and back), the
+# downed swap, and the always-emits rule for degenerate paths. Camera-dependent
+# facing is covered in test_walk_demo.gd where a real camera exists; here the
+# facing helper's no-camera fallback keeps everything deterministic.
+extends GdUnitTestSuite
+
+
+func _texture(shade: float) -> ImageTexture:
+	var img := Image.create_empty(2, 2, false, Image.FORMAT_RGBA8)
+	img.fill(Color(shade, shade, shade))
+	return ImageTexture.create_from_image(img)
+
+
+func _data(with_map := true) -> UnitData:
+	var data := UnitData.new()
+	data.display_name = "Testy"
+	if with_map:
+		data.map_sprite = _texture(0.2)
+	data.move_sprite = _texture(0.5)
+	data.downed_sprite = _texture(0.8)
+	return data
+
+
+func test_factory_applies_the_hd2d_invariants() -> void:
+	var sprite: UnitSprite3D = auto_free(UnitSprite3D.for_unit_data(_data()))
+	assert_int(sprite.billboard).is_equal(BaseMaterial3D.BILLBOARD_FIXED_Y)
+	assert_int(sprite.alpha_cut).is_equal(SpriteBase3D.ALPHA_CUT_OPAQUE_PREPASS)
+	assert_bool(sprite.shaded).is_true()
+	assert_int(sprite.texture_filter).is_equal(BaseMaterial3D.TEXTURE_FILTER_NEAREST)
+	assert_int(sprite.cast_shadow).is_equal(GeometryInstance3D.SHADOW_CASTING_SETTING_ON)
+	assert_float(sprite.pixel_size).is_equal_approx(1.0 / 32.0, 0.0001)
+	assert_object(sprite.texture).is_not_null()
+	assert_str(sprite.display_name).is_equal("Testy")
+
+
+func test_factory_falls_back_when_map_sprite_is_missing() -> void:
+	var sprite: UnitSprite3D = auto_free(UnitSprite3D.for_unit_data(_data(false)))
+	assert_object(sprite.texture).is_not_null()
+
+
+func test_place_at_stands_on_the_cell() -> void:
+	var sprite: UnitSprite3D = auto_free(UnitSprite3D.for_unit_data(_data()))
+	sprite.place_at(Vector3i(3, 1, 4))
+	assert_that(sprite.cell).is_equal(Vector3i(3, 1, 4))
+	assert_that(sprite.position).is_equal(BoardSpace.standing_point(Vector3i(3, 1, 4)))
+
+
+func test_walk_reaches_the_end_updates_cell_and_reports() -> void:
+	var sprite: UnitSprite3D = auto_free(UnitSprite3D.for_unit_data(_data()))
+	add_child(sprite)
+	sprite.place_at(Vector3i(0, 0, 0))
+	sprite.move_speed = 1000.0
+	var monitor := assert_signal(sprite)
+	sprite.walk_path([Vector3i(0, 0, 0), Vector3i(1, 0, 0), Vector3i(1, 0, 1)])
+	await monitor.is_emitted("walk_finished")
+	assert_that(sprite.cell).is_equal(Vector3i(1, 0, 1))
+	assert_that(sprite.position).is_equal(BoardSpace.standing_point(Vector3i(1, 0, 1)))
+	remove_child(sprite)
+
+
+func test_walk_swaps_to_the_move_sprite_and_back() -> void:
+	var data := _data()
+	var sprite: UnitSprite3D = auto_free(UnitSprite3D.for_unit_data(data))
+	add_child(sprite)
+	sprite.place_at(Vector3i(0, 0, 0))
+	sprite.move_speed = 2.0  # ~0.5s for the step: slow enough to observe mid-walk
+	var monitor := assert_signal(sprite)
+	sprite.walk_path([Vector3i(0, 0, 0), Vector3i(1, 0, 0)])
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_object(sprite.texture).is_same(data.move_sprite)
+	await monitor.is_emitted("walk_finished")
+	assert_object(sprite.texture).is_same(data.map_sprite)
+	remove_child(sprite)
+
+
+func test_degenerate_paths_still_report_finished() -> void:
+	# Degenerate paths emit synchronously (no tween), so a plain counter beats a
+	# signal monitor here — gdUnit's collector doesn't re-arm cleanly on one object.
+	var sprite: UnitSprite3D = auto_free(UnitSprite3D.for_unit_data(_data()))
+	var finished: Array[int] = [0]
+	sprite.walk_finished.connect(func() -> void: finished[0] += 1)
+	sprite.walk_path([])
+	assert_int(finished[0]).is_equal(1)
+	sprite.walk_path([Vector3i(2, 0, 2)])
+	assert_int(finished[0]).is_equal(2)
+
+
+func test_set_downed_swaps_both_ways() -> void:
+	var data := _data()
+	var sprite: UnitSprite3D = auto_free(UnitSprite3D.for_unit_data(data))
+	sprite.set_downed(true)
+	assert_object(sprite.texture).is_same(data.downed_sprite)
+	sprite.set_downed(false)
+	assert_object(sprite.texture).is_same(data.map_sprite)

--- a/tests/presentation/test_unit_sprite.gd.uid
+++ b/tests/presentation/test_unit_sprite.gd.uid
@@ -1,0 +1,1 @@
+uid://dbsr7mlh8mp0j

--- a/tests/presentation/test_walk_demo.gd
+++ b/tests/presentation/test_walk_demo.gd
@@ -1,0 +1,107 @@
+# The stage-2 walk demo (#210): the DEMO-ONLY BFS pinned pure (the height-step rule,
+# blocking, routing around a blocker), the spawn-and-walk wire through the real scene,
+# and the facing seam's one property — the SAME world step flips opposite when the
+# camera stands on the opposite side (camera-relativity, not an art convention).
+extends GdUnitTestSuite
+
+const SCENE_PATH := "res://Scenes/LookDev/LookDev.tscn"
+const UnitWalkDemo := preload("res://Scenes/LookDev/unit_walk_demo.gd")
+
+var _scene: Node3D
+
+
+func before_test() -> void:
+	_scene = (load(SCENE_PATH) as PackedScene).instantiate() as Node3D
+	get_tree().root.add_child(_scene)
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	get_tree().root.remove_child(_scene)
+	_scene.free()
+
+
+# --- The demo BFS, pure -----------------------------------------------------------
+
+var _stair_tops: Dictionary[Vector2i, int] = {
+	Vector2i(0, 0): 1, Vector2i(1, 0): 2, Vector2i(2, 0): 3,
+}
+
+
+func test_bfs_climbs_a_legal_stair() -> void:
+	var path := UnitWalkDemo.find_path(
+			Vector3i(0, 0, 0), Vector3i(2, 2, 0), _stair_tops, {})
+	assert_int(path.size()).is_equal(3)
+	assert_that(path[2]).is_equal(Vector3i(2, 2, 0))
+
+
+func test_bfs_refuses_a_two_high_step() -> void:
+	var cliff: Dictionary[Vector2i, int] = {Vector2i(0, 0): 1, Vector2i(1, 0): 3}
+	var path := UnitWalkDemo.find_path(Vector3i(0, 0, 0), Vector3i(1, 2, 0), cliff, {})
+	assert_int(path.size()).is_equal(0)
+
+
+func test_bfs_routes_around_a_blocking_unit() -> void:
+	var flat: Dictionary[Vector2i, int] = {}
+	for x in 3:
+		for z in 2:
+			flat[Vector2i(x, z)] = 1
+	var blocked: Dictionary[Vector2i, bool] = {Vector2i(1, 0): true}
+	var path := UnitWalkDemo.find_path(Vector3i(0, 0, 0), Vector3i(2, 0, 0), flat, blocked)
+	assert_int(path.size()).is_equal(5)  # the detour through the z=1 row
+
+
+func test_bfs_refuses_an_occupied_destination() -> void:
+	var flat: Dictionary[Vector2i, int] = {Vector2i(0, 0): 1, Vector2i(1, 0): 1}
+	var blocked: Dictionary[Vector2i, bool] = {Vector2i(1, 0): true}
+	var path := UnitWalkDemo.find_path(Vector3i(0, 0, 0), Vector3i(1, 0, 0), flat, blocked)
+	assert_int(path.size()).is_equal(0)
+
+
+# --- The wire: spawn, select, walk in the real scene -------------------------------
+
+func test_cast_spawns_under_the_units_node() -> void:
+	var demo := _scene.get_node("WalkDemo")
+	var spawned: Array[UnitSprite3D] = demo.units()
+	assert_bool(spawned.size() >= 4).is_true()
+	for unit in spawned:
+		assert_bool(unit.cell != BoardSpace.NO_CELL).is_true()
+		assert_object(unit.texture).is_not_null()
+
+
+func test_order_walk_moves_a_unit_to_the_target() -> void:
+	var demo := _scene.get_node("WalkDemo")
+	var unit: UnitSprite3D = demo.units()[0]  # spawns on the plain
+	unit.move_speed = 1000.0
+	demo._select(unit)
+	var target := Vector3i(7, 0, 8)  # open plain, two cells east of the first spawn
+	var monitor := assert_signal(unit)
+	demo.order_walk(target)
+	await monitor.is_emitted("walk_finished")
+	assert_that(unit.cell).is_equal(target)
+	assert_that(unit.position).is_equal(BoardSpace.standing_point(target))
+
+
+func test_facing_flip_is_camera_relative() -> void:
+	var rig := _scene.get_node("CameraRig") as Node3D
+	var demo := _scene.get_node("WalkDemo")
+	var unit: UnitSprite3D = demo.units()[0]
+	unit.move_speed = 1000.0
+
+	rig.rotation_degrees = Vector3(0.0, 0.0, 0.0)
+	rig._target_yaw_degrees = 0.0
+	await await_idle_frame()
+	var start := unit.cell
+	var east := start + Vector3i(1, 0, 0)
+	var monitor := assert_signal(unit)
+	unit.walk_path([start, east])
+	await monitor.is_emitted("walk_finished")
+	var flip_at_yaw_0 := unit.flip_h
+
+	rig.rotation_degrees = Vector3(0.0, 180.0, 0.0)
+	rig._target_yaw_degrees = 180.0
+	await await_idle_frame()
+	var monitor_back := assert_signal(unit)
+	unit.walk_path([east, east + Vector3i(1, 0, 0)])  # the same world direction again
+	await monitor_back.is_emitted("walk_finished")
+	assert_bool(unit.flip_h).is_not_equal(flip_at_yaw_0)

--- a/tests/presentation/test_walk_demo.gd
+++ b/tests/presentation/test_walk_demo.gd
@@ -21,24 +21,44 @@ func after_test() -> void:
 	_scene.free()
 
 
-# --- The demo BFS, pure -----------------------------------------------------------
+# --- The demo BFS, pure (the dev's 2026-08-12 traversal ruling) --------------------
 
-var _stair_tops: Dictionary[Vector2i, int] = {
-	Vector2i(0, 0): 1, Vector2i(1, 0): 2, Vector2i(2, 0): 3,
+# A plain, a ramp up, and the high ground: (0,0) h1 -> ramp (1,0) -> (2,0) h2.
+var _ramp_tops: Dictionary[Vector2i, int] = {
+	Vector2i(0, 0): 1, Vector2i(1, 0): 2, Vector2i(2, 0): 2,
+}
+var _ramp_exits: Dictionary[Vector2i, Array] = {
+	Vector2i(1, 0): [Vector2i(2, 0), Vector2i(0, 0)],
 }
 
 
-func test_bfs_climbs_a_legal_stair() -> void:
+func test_climbing_works_through_a_ramp() -> void:
 	var path := UnitWalkDemo.find_path(
-			Vector3i(0, 0, 0), Vector3i(2, 2, 0), _stair_tops, {})
+			Vector3i(0, 0, 0), Vector3i(2, 1, 0), _ramp_tops, {}, _ramp_exits)
 	assert_int(path.size()).is_equal(3)
-	assert_that(path[2]).is_equal(Vector3i(2, 2, 0))
+	assert_that(path[2]).is_equal(Vector3i(2, 1, 0))
 
 
-func test_bfs_refuses_a_two_high_step() -> void:
-	var cliff: Dictionary[Vector2i, int] = {Vector2i(0, 0): 1, Vector2i(1, 0): 3}
-	var path := UnitWalkDemo.find_path(Vector3i(0, 0, 0), Vector3i(1, 2, 0), cliff, {})
+func test_climbs_without_a_ramp_are_refused_even_one_high() -> void:
+	var stair: Dictionary[Vector2i, int] = {
+		Vector2i(0, 0): 1, Vector2i(1, 0): 2, Vector2i(2, 0): 3,
+	}
+	var path := UnitWalkDemo.find_path(Vector3i(0, 0, 0), Vector3i(2, 2, 0), stair, {}, {})
 	assert_int(path.size()).is_equal(0)
+
+
+func test_ramps_refuse_sideways_entry() -> void:
+	# (1,1) sits beside the ramp at its own top level; the only route runs through
+	# the ramp's SIDE, which the ruling forbids — in BOTH directions (leaving the
+	# ramp sideways and entering it sideways are separate clauses).
+	var tops := _ramp_tops.duplicate()
+	tops[Vector2i(1, 1)] = 2
+	var out_through_the_side := UnitWalkDemo.find_path(
+			Vector3i(0, 0, 0), Vector3i(1, 1, 1), tops, {}, _ramp_exits)
+	assert_int(out_through_the_side.size()).is_equal(0)
+	var in_through_the_side := UnitWalkDemo.find_path(
+			Vector3i(1, 1, 1), Vector3i(0, 0, 0), tops, {}, _ramp_exits)
+	assert_int(in_through_the_side.size()).is_equal(0)
 
 
 func test_bfs_routes_around_a_blocking_unit() -> void:
@@ -47,18 +67,37 @@ func test_bfs_routes_around_a_blocking_unit() -> void:
 		for z in 2:
 			flat[Vector2i(x, z)] = 1
 	var blocked: Dictionary[Vector2i, bool] = {Vector2i(1, 0): true}
-	var path := UnitWalkDemo.find_path(Vector3i(0, 0, 0), Vector3i(2, 0, 0), flat, blocked)
+	var path := UnitWalkDemo.find_path(Vector3i(0, 0, 0), Vector3i(2, 0, 0), flat, blocked, {})
 	assert_int(path.size()).is_equal(5)  # the detour through the z=1 row
 
 
 func test_bfs_refuses_an_occupied_destination() -> void:
 	var flat: Dictionary[Vector2i, int] = {Vector2i(0, 0): 1, Vector2i(1, 0): 1}
 	var blocked: Dictionary[Vector2i, bool] = {Vector2i(1, 0): true}
-	var path := UnitWalkDemo.find_path(Vector3i(0, 0, 0), Vector3i(1, 0, 0), flat, blocked)
+	var path := UnitWalkDemo.find_path(Vector3i(0, 0, 0), Vector3i(1, 0, 0), flat, blocked, {})
 	assert_int(path.size()).is_equal(0)
 
 
 # --- The wire: spawn, select, walk in the real scene -------------------------------
+
+func test_scene_ramps_are_climbable_and_slope_standing_is_lowered() -> void:
+	# The painted board under the ruling: the hill and platform stay reachable
+	# through their authored ramps, and a ramp cell's stand-point sits half a cell
+	# below the flat convention (the slope midpoint).
+	var demo := _scene.get_node("WalkDemo")
+	var unit: UnitSprite3D = demo.units()[0]  # spawns on the plain at (5, 8)
+	unit.move_speed = 1000.0
+	demo._select(unit)
+	var plateau_edge := Vector3i(7, 2, 3)  # up two ramps: (5,z3) then (6,z3)
+	var monitor := assert_signal(unit)
+	demo.order_walk(plateau_edge)
+	await monitor.is_emitted("walk_finished")
+	assert_that(unit.cell).is_equal(plateau_edge)
+	var ramp_cell := Vector3i(5, 1, 3)
+	var flat_point := BoardSpace.standing_point(ramp_cell)
+	var stand: Vector3 = unit.stand_at.call(ramp_cell)
+	assert_float(stand.y).is_equal_approx(flat_point.y - 0.5, 0.001)
+
 
 func test_cast_spawns_under_the_units_node() -> void:
 	var demo := _scene.get_node("WalkDemo")

--- a/tests/presentation/test_walk_demo.gd.uid
+++ b/tests/presentation/test_walk_demo.gd.uid
@@ -1,0 +1,1 @@
+uid://4yt60rjt7mt7


### PR DESCRIPTION
Implements #210's approved plan. Part of #176. **#210 closes on your feel-check**, not on merge alone.

## What this is

The unit layer: **`UnitSprite3D`**, the reusable 3D unit visual, proven by real cast members walking the diorama. Click Aster (or whoever's nearest), click a tile — they path over heights, swap to their moving sprite, and face their direction of travel relative to the orbiting camera.

## The component (`Classes/presentation/UnitSprite3D.gd`)

- **`UnitData`-driven**: the map/move/downed sprite triple straight off the character files (all seven cast members author them). Missing art warns and falls back.
- **Movement mirrors the 2D pattern** (`MovementComponent`'s shape): authoritative `cell`, `place_at` teleports, `walk_path` tweens one cell at a time and always emits `walk_finished`. Cadence = the 2D game's own 3.75 cells/s, exported for tuning.
- **The HD-2D sprite settings live in `_init` now** — one home; the scene's four hand-authored sprites are gone, and the existing invariants test walks the spawned ones instead.
- **Facing seam v1** (#176 seam 3): flip when travelling screen-left, judged against the live camera. `ART_FACES_SCREEN_RIGHT` is the one const to invert if the convention reads backwards to you. The header documents how this becomes `frame_for(unit_facing, camera_yaw)` when multi-facing art exists.
- `set_downed` completes the triple (unused by the demo; pinned by test for stage 4).

## The demo (`Scenes/LookDev/unit_walk_demo.gd`)

Five cast members spawn from `UnitCatalog` at composition spots (torchlight, plateau, stone platform, deep-focus corner). LMB selects (warm tint + readout) and orders walks. **The BFS is demo-only scaffolding, loudly labeled**: 4-neighbor over column tops, steps legal at |Δtop| ≤ 1, other units block. Real move rules stay the sim's (stage 4) — the demo deliberately doesn't pre-decide traversal doctrine, so units can hop one-block ledges anywhere and ramps read as the *intended* path without being mechanically required yet.

## Your half

Run the scene: select and walk the cast at every yaw and zoom. Judge —
1. the **moving-sprite swap** during walks,
2. the **facing flip** (if everyone faces the wrong way, say so — one const),
3. the **walk cadence** (matches the 2D game today; exported if it feels off in 3D),
4. units hopping 1-block ledges without ramps — acceptable demo behavior, or should the demo BFS require ramps? (Real answer arrives with the sim's move rules either way.)

## Verification (honest report)

- Full suite **1329/1329** (`Elapsed 151s`); 14 new cases: factory invariants, placement, walk completion + mid-walk texture swap + degenerate-path emission, downed swap, BFS (stair climb, two-high refusal, route around a blocker, occupied destination), the spawn wire, order-to-arrival, and the facing seam's camera-relativity property (same world step flips opposite at yaw 0 vs 180).
- **Falsified twice**: a height-rule mutant reds the two-high refusal; a camera-blind mutant reds the yaw-relativity case. Both restored.
- One test rewrite along the way: gdUnit's signal collector doesn't re-arm cleanly for a second monitor on one object — the degenerate-path case counts synchronous emissions directly instead.
- **Not checked headlessly (can't be)**: how the walks *feel*. That's your session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
