### PR TITLE
HD-2D Stage 4b: the input bridge - play the real game in 3D (#220, v0.13.0)

### DIFF
--- a/Classes/board/CameraController.gd
+++ b/Classes/board/CameraController.gd
@@ -1,3 +1,7 @@
+# The 2D board camera: WASD-scrolled with grid snapping, clamped to the board,
+# with AI-turn locks (set_ai_locked/follow) and the fixed-duration pan_to beat.
+# center_on_position glides via the _process lerp; snap_to_position is the instant
+# form (the 3D input bridge maps clicks through the live transform, #220).
 extends Node2D
 class_name CameraController
 
@@ -41,6 +45,15 @@ func center_on_position(world_pos: Vector2):
 	lock_manual_input = true
 	target_position = world_pos
 	clamp_target_position()
+
+# Instant, clamped reposition. The 3D input bridge (#220) maps a click's viewport
+# position through the LIVE canvas transform, so the camera must already be showing
+# the clicked cell when the synthetic event lands — a lerp target isn't enough.
+func snap_to_position(world_pos: Vector2) -> void:
+	target_position = world_pos
+	clamp_target_position()
+	_apply_pan_position(target_position)
+	camera.force_update_scroll()
 
 func clamp_target_position():
 	var viewport_size = get_viewport_rect().size

--- a/Classes/flow/MissionController.gd
+++ b/Classes/flow/MissionController.gd
@@ -85,7 +85,7 @@ func open_mission_select() -> void:
 		if not missions.has(path):
 			others.append(path)   # root playtest saves + fixtures/ -- selectable during development
 	_select_screen = MissionSelectScreen.open(game, missions, others)
-	_select_screen.mission_chosen.connect(_on_mission_chosen)
+	_select_screen.mission_chosen.connect(begin_mission)
 	_select_screen.load_game_chosen.connect(_on_load_game_chosen)
 	_select_screen.sandbox_chosen.connect(_on_sandbox_chosen)
 	_select_screen.glossary_chosen.connect(func(): GlossaryScreen.show_screen(game))
@@ -98,7 +98,9 @@ func _close_mission_select() -> void:
 		_select_screen.queue_free()
 	_select_screen = null
 
-func _on_mission_chosen(path: String) -> void:
+# The one path-taking mission entry, public since #220 — the Mission Select signal
+# and the Battle3D driver both start missions through this door.
+func begin_mission(path: String) -> void:
 	_close_mission_select()
 	game.scenario_manager.load_scenario(path)   # routes through clear_board() -> reset()
 	_begin_turn()
@@ -134,7 +136,7 @@ func restart_mission() -> void:
 	game.scenario_manager.reload_current()
 	_begin_turn()
 
-# Player-facing resume (#144): the same two-step arrival _on_mission_chosen makes, except the
+# Player-facing resume (#144): the same two-step arrival begin_mission makes, except the
 # board comes from a save slot and last_loaded_path is aimed at the ORIGIN mission -- so Restart
 # and F2 reload the mission start, and no dev tool can ever aim Update at a slot. _begin_turn no
 # longer resets actions (a menu arrival trusts the file -- see game._on_turn_started), which is

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -22,10 +22,10 @@ extends Node3D
 # PiP knobs (aesthetics get a knob, not a guess):
 @export var pip_scale := 0.35
 @export var pip_margin := Vector2(12.0, 12.0)
-
-# The 2D game's native resolution (Main.tscn authors GameView and the container's
-# minimum size to this); the PiP pins the container SIZE here and scales the display.
-const PIP_NATIVE := Vector2(1280.0, 720.0)
+# Bring-up diagnostic (4b): the bridge narrates each link on the help label —
+# pointer pick, click mapping, refusals — so a live run pinpoints which link is
+# dead without a debugger. Untick to silence; drop the mechanism at 4c.
+@export var debug_readout := true
 
 # Stamped on every synthetic event so the bridge never mistakes its own echo for
 # 3D pointing (InputEvent is a Resource — meta survives in-process delivery).
@@ -44,13 +44,19 @@ var _game_container: SubViewportContainer
 var _game_view: SubViewport
 var _tops: Dictionary[Vector2i, int] = {}
 var _pointer_cell: Vector3i = BoardSpace.NO_CELL
-var _last_view_pos: Vector2 = PIP_NATIVE * 0.5
+# The 2D game's native resolution, read in _ready off the container's authored
+# custom_minimum_size (Main.tscn) — the one source of that fact. The PiP pins the
+# container SIZE to it (GameView keeps full resolution under stretch) and shrinks
+# only the display via scale.
+var _pip_native: Vector2 = Vector2(1280.0, 720.0)
+var _base_help: String = ""
 
 
 func _ready() -> void:
 	game = _main.get_node("GameContainer/GameView/Game")
 	_game_container = _main.get_node("GameContainer") as SubViewportContainer
 	_game_view = _main.get_node("GameContainer/GameView") as SubViewport
+	_pip_native = _game_container.custom_minimum_size
 	var dev_overlay: Node = _main.get_node_or_null("DevOverlay")
 	if dev_overlay is Window:
 		(dev_overlay as Window).visible = false
@@ -61,6 +67,7 @@ func _ready() -> void:
 		_setup_pip()
 		get_viewport().size_changed.connect(_position_pip)
 		_help.text = "Battle3D (stage 4b, playable)  |  LMB act  |  RMB cancel  |  UI in the corner PiP  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset"
+	_base_help = _help.text
 	_board_mirror.board = $Board
 	_unit_mirror.units_root = game.units_root
 	game.turn_manager.turn_started.connect(_on_turn_started)
@@ -105,14 +112,14 @@ func _fit_camera() -> void:
 func _setup_pip() -> void:
 	_game_container.visible = true
 	_game_container.set_anchors_and_offsets_preset(Control.PRESET_TOP_LEFT)
-	_game_container.size = PIP_NATIVE
+	_game_container.size = _pip_native
 	_game_container.scale = Vector2(pip_scale, pip_scale)
 	_position_pip()
 
 
 func _position_pip() -> void:
 	var view: Vector2 = get_viewport().get_visible_rect().size
-	_game_container.position = view - PIP_NATIVE * pip_scale - pip_margin
+	_game_container.position = view - _pip_native * pip_scale - pip_margin
 
 
 # --- The input bridge (stage 4b) -------------------------------------------------------
@@ -121,8 +128,11 @@ func _position_pip() -> void:
 # ModalLock freezes the game subtree, and a freeze stops callbacks, not method calls
 # (#154) — so the bridge checks can_process() itself, and the 3D rig's global Input
 # polls are frozen alongside (typing into the report card must not pan the rig).
+# demo_mode is the carve-out: the bridge is off there, and the end-of-mission banner
+# (a modal inside the HIDDEN container) would otherwise freeze the diorama's camera
+# forever — 4a kept the rig alive after the battle ended, and so does demo mode.
 func _process(_delta: float) -> void:
-	var live: bool = game.can_process()
+	var live: bool = demo_mode or game.can_process()
 	_rig.set_process(live)
 	_rig.set_process_unhandled_input(live)
 
@@ -140,6 +150,9 @@ func _unhandled_input(event: InputEvent) -> void:
 		return
 	# Real events over the PiP belong to the 2D game — the container forwards them
 	# itself, and they too bubble back when unconsumed. Never read them as 3D pointing.
+	# Load-bearing BESIDE the meta tag, not redundant with it: accumulated input can
+	# MERGE a synthetic motion into a pending physical one, which drops the tag — the
+	# rect test still catches the merged event.
 	if _game_container.get_global_rect().has_point(mouse.position):
 		return
 	var motion := event as InputEventMouseMotion
@@ -147,13 +160,18 @@ func _unhandled_input(event: InputEvent) -> void:
 		_update_pointer(motion.position)
 		return
 	var click := event as InputEventMouseButton
-	if not click.pressed:
+	if click == null or not click.pressed:
 		return
 	if click.button_index == MOUSE_BUTTON_LEFT:
 		_update_pointer(click.position)  # a click is also a point — robust when no motion preceded it
 		_click_pointer_cell()
 	elif click.button_index == MOUSE_BUTTON_RIGHT:
-		_push_click(MOUSE_BUTTON_RIGHT, _last_view_pos)  # cancel — needs no cell, works aimed at sky
+		# Cancel is position-blind (game.gd:279 takes no cell), so push at the viewport
+		# center, which ALWAYS forwards — a far-cell hover's mapped position can fall
+		# outside the container rect and would be silently dropped, leaving the player
+		# stuck in a mode with a dead cancel.
+		_push_click(MOUSE_BUTTON_RIGHT, _pip_native * 0.5)
+		_diag("RMB cancel pushed at the viewport center")
 
 
 func _update_pointer(screen_pos: Vector2) -> void:
@@ -166,20 +184,32 @@ func _update_pointer(screen_pos: Vector2) -> void:
 		return
 	_overlays.set_cells(BoardOverlays.Layer.HOVER, [cell])
 	_push_motion(_cell_view_pos(_flat(cell)))
+	_diag("pointer %s" % cell)
 
 
 func _click_pointer_cell() -> void:
 	if _pointer_cell == BoardSpace.NO_CELL:
+		_diag("LMB ignored: no cell under the pointer")
+		return
+	# The game refuses clicks while the board is locked (AI turn / mission over / menu
+	# — game.gd's one predicate; read it, don't re-derive it). Without this, a refused
+	# click would still yank the hidden camera off the AI's pan_to/follow. It also
+	# covers the MENU case the can_process() gate above cannot: Mission Select opts
+	# OUT of the modal lock deliberately, so the game is unfrozen behind it.
+	if game._board_locked_for_player():
+		_diag("LMB refused: board locked (state %d)" % game.game_state)
 		return
 	var cell := _flat(_pointer_cell)
 	# The pushed position maps back to a cell through the LIVE 2D camera transform
 	# (game.gd:192), so the hidden camera must be showing the cell first. Side
-	# effect, by design: the PiP recenters on every 3D click.
+	# effect, by design: the PiP recenters on every 3D click the game can act on.
 	var cam: CameraController = game.camera_controller
 	cam.snap_to_position(_cell_world_2d(cell))
 	var view_pos := _cell_view_pos(cell)
 	_push_motion(view_pos)
 	_push_click(MOUSE_BUTTON_LEFT, view_pos)
+	_diag("LMB cell %s -> view %s -> root %s  (state %d)" % [
+		cell, view_pos.round(), (_game_container.get_global_transform() * view_pos).round(), game.game_state])
 
 
 func _pick(screen_pos: Vector2) -> Vector3i:
@@ -207,7 +237,6 @@ func _cell_view_pos(cell: Vector2i) -> Vector2:
 
 
 func _push_motion(view_pos: Vector2) -> void:
-	_last_view_pos = view_pos
 	_send_to_game(InputEventMouseMotion.new(), view_pos)
 
 
@@ -223,10 +252,18 @@ func _push_click(button: MouseButton, view_pos: Vector2) -> void:
 	_send_to_game(release, view_pos)
 
 
+func _diag(msg: String) -> void:
+	if debug_readout:
+		_help.text = _base_help + "\n[bridge] " + msg
+
+
 # One door, the same one real input uses: OS-level parse, positioned over the PiP,
 # so the container forwards into GameView exactly like a physical click there.
 # Parse only, never flush — this runs INSIDE input dispatch (a re-entrant flush is
-# not safe); the engine delivers the buffered events at the next frame's flush.
+# not safe). The drain loop re-checks its queue, so events parsed during dispatch
+# are delivered by the SAME flush — no frame boundary and no _process between the
+# camera snap and delivery, which is what makes reading the live transform at
+# parse time exact.
 func _send_to_game(ev: InputEventMouse, view_pos: Vector2) -> void:
 	var root_pos: Vector2 = _game_container.get_global_transform() * view_pos
 	ev.position = root_pos

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -1,31 +1,66 @@
-# The Battle3D shell (#215 / #176 stage 4a): the hidden-2D-game-as-authority
-# architecture's first scene. Hosts the REAL Main.tscn with its 2D view hidden —
-# the full sim runs untouched — while BoardMirror/UnitMirror render it as an
-# HD-2D diorama. 4a is READ-ONLY: auto_play loads Prolog through the real funnel
-# and sets both factions AI, so the battle demos itself. Input lands at 4b, the
-# 2D/3D chooser + viewport power savings at 4d.
+# The Battle3D shell (#215/#220 / #176 stage 4a+4b): the hidden-2D-game-as-authority
+# architecture. Hosts the REAL Main.tscn — the full sim runs untouched — while
+# BoardMirror/UnitMirror render it as an HD-2D diorama.
 #
-# Declared demo-driver liberty: load_mission calls MissionController's private
-# _on_mission_chosen — the real mission-entry funnel. 4b formalizes that seam.
+# Stage 4b makes it PLAYABLE: the bridge translates the 3D pointer to 2D-viewport
+# coordinates and feeds ordinary mouse events through Input.parse_input_event,
+# positioned over the PiP — the OS-driver entry, so the container forwards them
+# into GameView exactly like physical clicks and every gate (the board lock, the
+# modal freeze, menu placement) fires natively; game.gd needs no edits. (Measured:
+# Viewport.push_input dies against handle_input_locally=false — the container is
+# the only live door, and unconsumed events BUBBLE back out to the root.)
+# The 2D UI stays usable as a corner picture-in-picture: the container keeps its
+# native 1280x720 SIZE (so GameView keeps full resolution under stretch) and only
+# the display shrinks via scale; input maps through the container transform.
+#
+# demo_mode = stage-4a behavior: both factions AI, no PiP, watch-only.
 extends Node3D
 
-@export var auto_play := true
+@export var auto_play := true    # start mission_path on launch (test fixtures set false)
+@export var demo_mode := false   # true = the 4a diorama demo: AI-vs-AI, no PiP, no bridge
 @export var mission_path := "res://Scenarios/missions/Prolog.tres"
+# PiP knobs (aesthetics get a knob, not a guess):
+@export var pip_scale := 0.35
+@export var pip_margin := Vector2(12.0, 12.0)
+
+# The 2D game's native resolution (Main.tscn authors GameView and the container's
+# minimum size to this); the PiP pins the container SIZE here and scales the display.
+const PIP_NATIVE := Vector2(1280.0, 720.0)
+
+# Stamped on every synthetic event so the bridge never mistakes its own echo for
+# 3D pointing (InputEvent is a Resource — meta survives in-process delivery).
+const BRIDGE_EVENT_META := &"iosis_3d_bridge"
 
 @onready var _main: Node = $Main
 @onready var _board_mirror: BoardMirror = $BoardMirror
 @onready var _unit_mirror: UnitMirror = $UnitMirror
+@onready var _overlays: BoardOverlays = $BoardOverlays
 @onready var _rig: Node3D = $CameraRig
+@onready var _camera: Camera3D = $CameraRig/Pitch/Camera
+@onready var _help: Label = $UI/Help
 
 var game: Node2D
+var _game_container: SubViewportContainer
+var _game_view: SubViewport
+var _tops: Dictionary[Vector2i, int] = {}
+var _pointer_cell: Vector3i = BoardSpace.NO_CELL
+var _last_view_pos: Vector2 = PIP_NATIVE * 0.5
 
 
 func _ready() -> void:
 	game = _main.get_node("GameContainer/GameView/Game")
-	(_main.get_node("GameContainer") as Control).visible = false
+	_game_container = _main.get_node("GameContainer") as SubViewportContainer
+	_game_view = _main.get_node("GameContainer/GameView") as SubViewport
 	var dev_overlay: Node = _main.get_node_or_null("DevOverlay")
 	if dev_overlay is Window:
 		(dev_overlay as Window).visible = false
+	if demo_mode:
+		_game_container.visible = false
+		_help.text = "Battle3D mirror (demo mode, read-only)  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset"
+	else:
+		_setup_pip()
+		get_viewport().size_changed.connect(_position_pip)
+		_help.text = "Battle3D (stage 4b, playable)  |  LMB act  |  RMB cancel  |  UI in the corner PiP  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset"
 	_board_mirror.board = $Board
 	_unit_mirror.units_root = game.units_root
 	game.turn_manager.turn_started.connect(_on_turn_started)
@@ -36,18 +71,22 @@ func _ready() -> void:
 func _start() -> void:
 	await get_tree().process_frame  # let the hidden Mission Select finish its deferred open
 	load_mission(mission_path)
-	var both: Array[Team.Faction] = [Team.Faction.PLAYER, Team.Faction.ENEMY]
-	game.ai_controller.set_ai_factions(both)  # AI-vs-AI: the diorama plays itself
+	if demo_mode:
+		var both: Array[Team.Faction] = [Team.Faction.PLAYER, Team.Faction.ENEMY]
+		game.ai_controller.set_ai_factions(both)  # AI-vs-AI: the diorama plays itself
+	# Playable mode leaves the scenario's own ai_factions standing (#150) — the
+	# player faction is human, so squadding up is the player's own opening move.
 
 
 func load_mission(path: String) -> void:
-	game.mission_controller._on_mission_chosen(path)
+	game.mission_controller.begin_mission(path)
 	rebuild()
 	_fit_camera()
 
 
 func rebuild() -> void:
 	_board_mirror.rebuild(game.grid, game.terrain_states.to_state_dict())
+	_tops = BoardPicker.column_tops_from($Board)
 
 
 func _on_turn_started(_faction: int) -> void:
@@ -59,3 +98,138 @@ func _fit_camera() -> void:
 	var center := Vector2(rect.position) + Vector2(rect.size) * 0.5
 	_rig.position = Vector3(center.x, 1.0, center.y)
 	_rig.set_zoom(maxf(float(rect.size.x), float(rect.size.y)) * 1.05)
+
+
+# --- The PiP (stage 4b) --------------------------------------------------------------
+
+func _setup_pip() -> void:
+	_game_container.visible = true
+	_game_container.set_anchors_and_offsets_preset(Control.PRESET_TOP_LEFT)
+	_game_container.size = PIP_NATIVE
+	_game_container.scale = Vector2(pip_scale, pip_scale)
+	_position_pip()
+
+
+func _position_pip() -> void:
+	var view: Vector2 = get_viewport().get_visible_rect().size
+	_game_container.position = view - PIP_NATIVE * pip_scale - pip_margin
+
+
+# --- The input bridge (stage 4b) -------------------------------------------------------
+
+# The modal freeze must stop the bridge exactly as it stops engine input delivery:
+# ModalLock freezes the game subtree, and a freeze stops callbacks, not method calls
+# (#154) — so the bridge checks can_process() itself, and the 3D rig's global Input
+# polls are frozen alongside (typing into the report card must not pan the rig).
+func _process(_delta: float) -> void:
+	var live: bool = game.can_process()
+	_rig.set_process(live)
+	_rig.set_process_unhandled_input(live)
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if demo_mode or not game.can_process():
+		return
+	var mouse := event as InputEventMouse
+	if mouse == null:
+		return
+	# The bridge's own synthetics BUBBLE back here when the game leaves them unconsumed
+	# (measured). Re-reading one as 3D pointing forges a self-sustaining event loop that
+	# never lets a flush drain — the tag is the loop-breaker, not hygiene.
+	if mouse.has_meta(BRIDGE_EVENT_META):
+		return
+	# Real events over the PiP belong to the 2D game — the container forwards them
+	# itself, and they too bubble back when unconsumed. Never read them as 3D pointing.
+	if _game_container.get_global_rect().has_point(mouse.position):
+		return
+	var motion := event as InputEventMouseMotion
+	if motion != null:
+		_update_pointer(motion.position)
+		return
+	var click := event as InputEventMouseButton
+	if not click.pressed:
+		return
+	if click.button_index == MOUSE_BUTTON_LEFT:
+		_update_pointer(click.position)  # a click is also a point — robust when no motion preceded it
+		_click_pointer_cell()
+	elif click.button_index == MOUSE_BUTTON_RIGHT:
+		_push_click(MOUSE_BUTTON_RIGHT, _last_view_pos)  # cancel — needs no cell, works aimed at sky
+
+
+func _update_pointer(screen_pos: Vector2) -> void:
+	var cell := _pick(screen_pos)
+	if cell == _pointer_cell:
+		return
+	_pointer_cell = cell
+	if cell == BoardSpace.NO_CELL:
+		_overlays.clear(BoardOverlays.Layer.HOVER)
+		return
+	_overlays.set_cells(BoardOverlays.Layer.HOVER, [cell])
+	_push_motion(_cell_view_pos(_flat(cell)))
+
+
+func _click_pointer_cell() -> void:
+	if _pointer_cell == BoardSpace.NO_CELL:
+		return
+	var cell := _flat(_pointer_cell)
+	# The pushed position maps back to a cell through the LIVE 2D camera transform
+	# (game.gd:192), so the hidden camera must be showing the cell first. Side
+	# effect, by design: the PiP recenters on every 3D click.
+	var cam: CameraController = game.camera_controller
+	cam.snap_to_position(_cell_world_2d(cell))
+	var view_pos := _cell_view_pos(cell)
+	_push_motion(view_pos)
+	_push_click(MOUSE_BUTTON_LEFT, view_pos)
+
+
+func _pick(screen_pos: Vector2) -> Vector3i:
+	return BoardPicker.pick_cell(
+		_camera.project_ray_origin(screen_pos),
+		_camera.project_ray_normal(screen_pos),
+		_tops
+	)
+
+
+func _flat(cell: Vector3i) -> Vector2i:
+	return Vector2i(cell.x, cell.z)  # boards are flat; the mirror paints (x, 0, y)
+
+
+# A cell's center in the 2D game's canvas (world) coordinates.
+func _cell_world_2d(cell: Vector2i) -> Vector2:
+	var grid: TileMapLayer = game.grid
+	return grid.to_global(grid.map_to_local(cell))
+
+
+# A cell's center in GameView's viewport coordinates — the space pushed events use.
+func _cell_view_pos(cell: Vector2i) -> Vector2:
+	var canvas: Transform2D = _game_view.get_canvas_transform()
+	return canvas * _cell_world_2d(cell)
+
+
+func _push_motion(view_pos: Vector2) -> void:
+	_last_view_pos = view_pos
+	_send_to_game(InputEventMouseMotion.new(), view_pos)
+
+
+func _push_click(button: MouseButton, view_pos: Vector2) -> void:
+	var press := InputEventMouseButton.new()
+	press.button_index = button
+	press.pressed = true
+	press.button_mask = MOUSE_BUTTON_MASK_LEFT if button == MOUSE_BUTTON_LEFT else MOUSE_BUTTON_MASK_RIGHT
+	_send_to_game(press, view_pos)
+	var release := InputEventMouseButton.new()
+	release.button_index = button
+	release.pressed = false
+	_send_to_game(release, view_pos)
+
+
+# One door, the same one real input uses: OS-level parse, positioned over the PiP,
+# so the container forwards into GameView exactly like a physical click there.
+# Parse only, never flush — this runs INSIDE input dispatch (a re-entrant flush is
+# not safe); the engine delivers the buffered events at the next frame's flush.
+func _send_to_game(ev: InputEventMouse, view_pos: Vector2) -> void:
+	var root_pos: Vector2 = _game_container.get_global_transform() * view_pos
+	ev.position = root_pos
+	ev.global_position = root_pos
+	ev.set_meta(BRIDGE_EVENT_META, true)
+	Input.parse_input_event(ev)

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Iosis"
-config/version="0.12.0"
+config/version="0.13.0"
 run/main_scene="uid://cxiu0yvwwxlgo"
 config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"

--- a/tests/presentation/test_input_bridge.gd
+++ b/tests/presentation/test_input_bridge.gd
@@ -92,10 +92,11 @@ func _parse_click(screen_pos: Vector2, button: MouseButton = MOUSE_BUTTON_LEFT) 
 	Input.parse_input_event(release)
 
 
-# Deliver everything: the test's own events flush first (dispatch runs the bridge,
-# which PARSES its synthetics but never flushes mid-dispatch), then a second flush
-# delivers the bridge's events; two trailing frames let _process polls observe the
-# result (process_frame resumes coroutines BEFORE node _process — one frame is stale).
+# Deliver everything. The flush drain re-checks its queue, so the bridge's synthetics
+# (parsed mid-dispatch) are delivered by the SAME flush as the test's own events; the
+# second flush is belt-and-braces for anything a frame boundary buffered. Two trailing
+# frames let _process polls observe the result (process_frame resumes coroutines
+# BEFORE node _process — one frame is stale).
 func _pump() -> void:
 	Input.flush_buffered_events()
 	await await_idle_frame()
@@ -168,6 +169,8 @@ func test_a_modal_freeze_stops_3d_clicks_cold() -> void:
 func test_the_board_lock_refuses_bridge_clicks_natively() -> void:
 	_game.game_state = _game.GameState.AI_TURN
 	var unit := _pickable_player_unit()
+	var cam: CameraController = _game.camera_controller
+	var cam_before: Vector2 = cam.global_position
 	_parse_click(_screen_of(unit.movement.cell))
 	# RMB is the sharp clause: without game.gd's _board_locked_for_player gate an
 	# RMB would run exit_current_mode and flip the state to IDLE mid-AI-turn.
@@ -175,6 +178,9 @@ func test_the_board_lock_refuses_bridge_clicks_natively() -> void:
 	await _pump()
 	assert_object(_selected()).is_null()
 	assert_int(_game.game_state).is_equal(_game.GameState.AI_TURN)
+	# A refused click must not yank the camera either — the bridge reads the same
+	# lock before snapping, or a stray click drags the PiP off the AI's pan.
+	assert_that(cam.global_position).is_equal(cam_before)
 
 
 # --- Hover -----------------------------------------------------------------------------
@@ -182,6 +188,13 @@ func test_the_board_lock_refuses_bridge_clicks_natively() -> void:
 func test_3d_hover_drives_the_real_hover_presenter() -> void:
 	var unit := _pickable_player_unit()
 	var cell: Vector2i = unit.movement.cell
+	# Park the pointer on a different cell first: the global Input mouse position
+	# leaks across cases, and a fresh fixture synthesizes an enter-motion at it —
+	# if that pre-hovers the target cell, the presenter's dedup would swallow the
+	# signal this case exists to observe.
+	var grid: TileMapLayer = _game.grid
+	_parse_motion(_screen_of(grid.get_used_rect().position))
+	await _pump()
 	var seen: Array[Vector2i] = []
 	_game.hover_presenter.hovered_cell_changed.connect(func(c: Vector2i) -> void: seen.append(c))
 
@@ -200,7 +213,8 @@ func test_the_pip_keeps_native_resolution() -> void:
 	assert_that(Vector2(_game_view.size)).is_equal(Vector2(1280.0, 720.0))
 	assert_that(_container.scale).is_equal(Vector2(_scene.pip_scale, _scene.pip_scale))
 	var view: Vector2 = _scene.get_viewport().get_visible_rect().size
-	var expected_pos: Vector2 = view - Vector2(1280.0, 720.0) * _scene.pip_scale - _scene.pip_margin
+	var native: Vector2 = _container.custom_minimum_size   # the authored source the PiP reads
+	var expected_pos: Vector2 = view - native * _scene.pip_scale - _scene.pip_margin
 	assert_that(_container.position).is_equal(expected_pos)
 
 
@@ -245,7 +259,13 @@ func test_rmb_cancels_the_current_mode() -> void:
 	_game.enter_move_mode(unit)
 	assert_int(_game.game_state).is_equal(_game.GameState.CHOOSING_MOVE)
 
-	_parse_click(_screen_of(unit.movement.cell), MOUSE_BUTTON_RIGHT)
+	# Cancel while POINTING AT A FAR CELL is the sharp form: the far cell's mapped 2D
+	# position falls outside the container rect (the hidden camera isn't showing it),
+	# so a cancel that reuses the pointer's mapped position is silently dropped and
+	# the player is stuck in the mode — RMB must push at a position that always
+	# forwards, because game.gd's _on_right_click is position-blind anyway.
+	var grid: TileMapLayer = _game.grid
+	_parse_click(_screen_of(grid.get_used_rect().position), MOUSE_BUTTON_RIGHT)
 	await _pump()
 	assert_int(_game.game_state).is_equal(_game.GameState.IDLE)
 	assert_object(_selected()).is_null()
@@ -263,3 +283,50 @@ func test_demo_mode_forces_both_factions_ai_and_playable_does_not() -> void:
 	await await_idle_frame()
 	assert_bool(ai.is_ai_faction(Team.Faction.PLAYER)).is_true()
 	assert_bool(ai.is_ai_faction(Team.Faction.ENEMY)).is_true()
+
+
+func test_demo_mode_boots_watch_only() -> void:
+	# demo_mode must be set BEFORE the scene enters the tree — _ready is where the
+	# fork lives, which the shared fixture (playable) can never exercise.
+	var packed := load(SCENE_PATH) as PackedScene
+	var demo := packed.instantiate() as Node3D
+	demo.auto_play = false
+	demo.demo_mode = true
+	get_tree().root.add_child(demo)
+	await await_idle_frame()
+	var container: SubViewportContainer = demo.get_node("Main/GameContainer")
+	assert_bool(container.visible).is_false()
+	get_tree().root.remove_child(demo)
+	demo.free()
+
+
+func test_demo_mode_keeps_the_rig_alive_behind_a_frozen_game() -> void:
+	# 4a parity: the end-of-mission banner freezes the hidden game forever in demo
+	# mode (it is invisible and unclickable there), and the diorama's camera must
+	# survive it. The freeze is simulated at its real seam — ModalLock's whole
+	# mechanism IS game.process_mode = DISABLED.
+	var packed := load(SCENE_PATH) as PackedScene
+	var demo := packed.instantiate() as Node3D
+	demo.auto_play = false
+	demo.demo_mode = true
+	get_tree().root.add_child(demo)
+	await await_idle_frame()
+	var demo_game: Node2D = demo.game
+	demo_game.process_mode = Node.PROCESS_MODE_DISABLED
+	await await_idle_frame()
+	await await_idle_frame()
+	var rig: Node3D = demo.get_node("CameraRig")
+	assert_bool(rig.is_processing()).is_true()
+	get_tree().root.remove_child(demo)
+	demo.free()
+
+
+func test_the_playable_rig_freezes_with_the_game() -> void:
+	# The other half of the pair: in playable mode the rig's global Input polls must
+	# die with the modal freeze (typing into the report card must not pan the rig).
+	_game.process_mode = Node.PROCESS_MODE_DISABLED
+	await await_idle_frame()
+	await await_idle_frame()
+	var rig: Node3D = _scene.get_node("CameraRig")
+	assert_bool(rig.is_processing()).is_false()
+	_game.process_mode = Node.PROCESS_MODE_INHERIT

--- a/tests/presentation/test_input_bridge.gd
+++ b/tests/presentation/test_input_bridge.gd
@@ -1,0 +1,265 @@
+# The stage-4b input bridge (#220): 3D clicks/hover drive the REAL game through
+# synthetic input fed to Input.parse_input_event — the OS-driver entry, so the
+# events ride the same pipeline as physical input (root GUI -> the PiP container
+# forwards into GameView -> game.gd:192) and every gate fires natively. These are
+# the repo's first true click-through wire tests: events enter at the top of the
+# pipeline and must survive the whole chain; calling the dispatch directly would
+# test both ends and not the wire. (Viewport.push_input is a dead door against
+# handle_input_locally=false — measured; parse_input_event is what gdUnit's own
+# SceneRunner uses for headless GUI, so the engine behavior is load-bearing there.)
+extends GdUnitTestSuite
+
+const SCENE_PATH := "res://Scenes/Battle3D/Battle3D.tscn"
+const PROLOG := "res://Scenarios/missions/Prolog.tres"
+
+var _scene: Node3D
+var _game: Node2D
+var _camera3d: Camera3D
+var _overlays: BoardOverlays
+var _game_view: SubViewport
+var _container: SubViewportContainer
+
+
+func before_test() -> void:
+	get_tree().root.size = Vector2i(1280, 720)   # the project window; headless defaults can be tiny
+	var packed := load(SCENE_PATH) as PackedScene
+	_scene = packed.instantiate() as Node3D
+	_scene.auto_play = false   # no _start: the board loads explicitly below
+	get_tree().root.add_child(_scene)
+	await await_idle_frame()
+	_game = _scene.game
+	_camera3d = _scene.get_node("CameraRig/Pitch/Camera") as Camera3D
+	_overlays = _scene.get_node("BoardOverlays") as BoardOverlays
+	_game_view = _scene.get_node("Main/GameContainer/GameView") as SubViewport
+	_container = _scene.get_node("Main/GameContainer") as SubViewportContainer
+	_scene.load_mission(PROLOG)
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	get_tree().root.remove_child(_scene)
+	_scene.free()
+
+
+# --- Helpers ---------------------------------------------------------------------------
+
+func _live_units() -> Array[Unit]:
+	var live: Array[Unit] = []
+	for child in _game.units_root.get_children():
+		var unit := child as Unit
+		if unit != null:
+			live.append(unit)
+	return live
+
+
+# A player unit whose 3D screen position is clear of the PiP rect (the PiP sits on
+# top of the 3D view by design, so a click there belongs to the PiP, not the board).
+func _pickable_player_unit() -> Unit:
+	var pip: Rect2 = _container.get_global_rect()
+	for unit in _live_units():
+		if unit.get_faction() != Team.Faction.PLAYER:
+			continue
+		if not pip.has_point(_screen_of(unit.movement.cell)):
+			return unit
+	return null
+
+
+func _screen_of(cell: Vector2i) -> Vector2:
+	return _camera3d.unproject_position(BoardSpace.standing_point(Vector3i(cell.x, 0, cell.y)))
+
+
+func _parse_motion(screen_pos: Vector2) -> void:
+	var motion := InputEventMouseMotion.new()
+	motion.position = screen_pos
+	motion.global_position = screen_pos
+	Input.parse_input_event(motion)
+
+
+func _parse_click(screen_pos: Vector2, button: MouseButton = MOUSE_BUTTON_LEFT) -> void:
+	_parse_motion(screen_pos)
+	var press := InputEventMouseButton.new()
+	press.position = screen_pos
+	press.global_position = screen_pos
+	press.button_index = button
+	press.pressed = true
+	press.button_mask = MOUSE_BUTTON_MASK_LEFT if button == MOUSE_BUTTON_LEFT else MOUSE_BUTTON_MASK_RIGHT
+	Input.parse_input_event(press)
+	var release := InputEventMouseButton.new()
+	release.position = screen_pos
+	release.global_position = screen_pos
+	release.button_index = button
+	release.pressed = false
+	Input.parse_input_event(release)
+
+
+# Deliver everything: the test's own events flush first (dispatch runs the bridge,
+# which PARSES its synthetics but never flushes mid-dispatch), then a second flush
+# delivers the bridge's events; two trailing frames let _process polls observe the
+# result (process_frame resumes coroutines BEFORE node _process — one frame is stale).
+func _pump() -> void:
+	Input.flush_buffered_events()
+	await await_idle_frame()
+	Input.flush_buffered_events()
+	await await_idle_frame()
+	await await_idle_frame()
+
+
+func _selected() -> Unit:
+	# Typed read on purpose: a freed stored selection only trips a TYPED assignment (#149).
+	var unit: Unit = _game.selected_unit
+	return unit
+
+
+# --- The click wire --------------------------------------------------------------------
+
+func test_a_3d_click_selects_the_unit_it_lands_on() -> void:
+	var unit := _pickable_player_unit()
+	assert_object(unit).is_not_null()
+	_parse_click(_screen_of(unit.movement.cell))
+	await _pump()
+	assert_bool(_selected() == unit).is_true()
+
+
+func test_the_bridge_snaps_the_hidden_camera_to_the_clicked_cell() -> void:
+	var unit := _pickable_player_unit()
+	var cam: CameraController = _game.camera_controller
+	var grid: TileMapLayer = _game.grid
+	var world: Vector2 = grid.to_global(grid.map_to_local(unit.movement.cell))
+	# Derive the clamped truth through the same seam, then park the camera far away.
+	cam.snap_to_position(world)
+	var expected: Vector2 = cam.global_position
+	cam.snap_to_position(Vector2(-100000.0, -100000.0))
+	assert_bool(cam.global_position.distance_to(expected) > 1.0).is_true()
+
+	_parse_click(_screen_of(unit.movement.cell))
+	await _pump()
+	assert_that(cam.global_position).is_equal(expected)
+	assert_bool(_selected() == unit).is_true()
+
+
+# --- The gates -------------------------------------------------------------------------
+
+func test_a_modal_freeze_stops_3d_clicks_cold() -> void:
+	# Open the pause menu through the real wire: ESC parsed at the top of the pipeline.
+	var esc := InputEventKey.new()
+	esc.keycode = KEY_ESCAPE
+	esc.physical_keycode = KEY_ESCAPE
+	esc.pressed = true
+	Input.parse_input_event(esc)
+	await _pump()
+	assert_bool(ModalLock.any_open(get_tree())).is_true()
+	assert_bool(_game.can_process()).is_false()
+
+	var unit := _pickable_player_unit()
+	_parse_click(_screen_of(unit.movement.cell))
+	await _pump()
+	# The sharp clause: a gate that held never let the bridge read the click at all,
+	# so its pointer state stays virgin. The end-state asserts below are blind on
+	# their own — a pierced click grazes the pause card's button gaps (measured, twice:
+	# the gate-removed mutant survived them, and the viewport-mouse comparison is
+	# equally blind because the snap maps every click to the exact center a fresh
+	# SubViewport already reports as its mouse position).
+	assert_that(_scene._pointer_cell).is_equal(BoardSpace.NO_CELL)
+	assert_object(_selected()).is_null()
+	assert_bool(ModalLock.any_open(get_tree())).is_true()   # nothing pressed Resume
+	assert_bool(_game.can_process()).is_false()
+
+
+func test_the_board_lock_refuses_bridge_clicks_natively() -> void:
+	_game.game_state = _game.GameState.AI_TURN
+	var unit := _pickable_player_unit()
+	_parse_click(_screen_of(unit.movement.cell))
+	# RMB is the sharp clause: without game.gd's _board_locked_for_player gate an
+	# RMB would run exit_current_mode and flip the state to IDLE mid-AI-turn.
+	_parse_click(_screen_of(unit.movement.cell), MOUSE_BUTTON_RIGHT)
+	await _pump()
+	assert_object(_selected()).is_null()
+	assert_int(_game.game_state).is_equal(_game.GameState.AI_TURN)
+
+
+# --- Hover -----------------------------------------------------------------------------
+
+func test_3d_hover_drives_the_real_hover_presenter() -> void:
+	var unit := _pickable_player_unit()
+	var cell: Vector2i = unit.movement.cell
+	var seen: Array[Vector2i] = []
+	_game.hover_presenter.hovered_cell_changed.connect(func(c: Vector2i) -> void: seen.append(c))
+
+	_parse_motion(_screen_of(cell))
+	await _pump()
+
+	assert_that(_game.hover_presenter.last_hovered_cell).is_equal(cell)
+	assert_bool(seen.has(cell)).is_true()
+	assert_that(_overlays.cells_of(BoardOverlays.Layer.HOVER)).is_equal([Vector3i(cell.x, 0, cell.y)])
+
+
+# --- The PiP ---------------------------------------------------------------------------
+
+func test_the_pip_keeps_native_resolution() -> void:
+	assert_bool(_container.visible).is_true()
+	assert_that(Vector2(_game_view.size)).is_equal(Vector2(1280.0, 720.0))
+	assert_that(_container.scale).is_equal(Vector2(_scene.pip_scale, _scene.pip_scale))
+	var view: Vector2 = _scene.get_viewport().get_visible_rect().size
+	var expected_pos: Vector2 = view - Vector2(1280.0, 720.0) * _scene.pip_scale - _scene.pip_margin
+	assert_that(_container.position).is_equal(expected_pos)
+
+
+func test_the_pip_serves_a_real_button_click() -> void:
+	var end_turn: Control = _game.get_node("UILayer/EndTurnButton")
+	end_turn.set_active(true)   # visibility is #189's own tested rule; the claim here is the wire
+	await await_idle_frame()
+	var presses: Array[bool] = []
+	end_turn.end_turn_requested.connect(func() -> void: presses.append(true))
+
+	var button: Button = end_turn.get_node("Button")
+	var inside: Vector2 = button.get_global_rect().get_center()
+	var root_pos: Vector2 = _container.get_global_transform() * inside
+	_parse_click(root_pos)
+	await _pump()
+
+	assert_int(presses.size()).is_equal(1)
+	assert_object(_selected()).is_null()   # the PiP consumed it — nothing leaked to the 3D picker
+
+
+func test_a_pip_board_click_stays_in_the_pip() -> void:
+	# A board click on the PiP is UNCONSUMED by the game and bubbles back out to the
+	# root (measured) — the bridge's PiP-rect guard must never re-read it as 3D
+	# pointing, or every PiP board click double-acts as a 3D pick.
+	var unit := _pickable_player_unit()
+	var grid: TileMapLayer = _game.grid
+	_game.camera_controller.snap_to_position(grid.to_global(grid.map_to_local(unit.movement.cell)))
+	var view_pos: Vector2 = _scene._cell_view_pos(unit.movement.cell)
+	var root_pos: Vector2 = _container.get_global_transform() * view_pos
+	_parse_click(root_pos)
+	await _pump()
+	assert_bool(_selected() == unit).is_true()                       # the 2D game acted on it
+	assert_that(_scene._pointer_cell).is_equal(BoardSpace.NO_CELL)   # the bridge never did
+	await await_idle_frame()   # the action menu's deferred _place_panel runs against a live panel
+
+
+# --- Cancel + driver -------------------------------------------------------------------
+
+func test_rmb_cancels_the_current_mode() -> void:
+	var unit := _pickable_player_unit()
+	_game.selected_unit = unit
+	_game.enter_move_mode(unit)
+	assert_int(_game.game_state).is_equal(_game.GameState.CHOOSING_MOVE)
+
+	_parse_click(_screen_of(unit.movement.cell), MOUSE_BUTTON_RIGHT)
+	await _pump()
+	assert_int(_game.game_state).is_equal(_game.GameState.IDLE)
+	assert_object(_selected()).is_null()
+
+
+func test_demo_mode_forces_both_factions_ai_and_playable_does_not() -> void:
+	var ai: AIController = _game.ai_controller
+	await _scene._start()
+	await await_idle_frame()   # each reload clear_boards the standing roster — flush the deferred frees
+	assert_bool(ai.is_ai_faction(Team.Faction.PLAYER)).is_false()
+	assert_bool(ai.is_ai_faction(Team.Faction.ENEMY)).is_true()
+
+	_scene.demo_mode = true
+	await _scene._start()
+	await await_idle_frame()
+	assert_bool(ai.is_ai_faction(Team.Faction.PLAYER)).is_true()
+	assert_bool(ai.is_ai_faction(Team.Faction.ENEMY)).is_true()

--- a/tests/presentation/test_input_bridge.gd.uid
+++ b/tests/presentation/test_input_bridge.gd.uid
@@ -1,0 +1,1 @@
+uid://te54omjnbahb


### PR DESCRIPTION
Closes nothing on merge — **#220 closes on your feel-check**, per pattern.

## What this is

Stage 4b of the #176 HD-2D overhaul: **the battle is now playable in 3D.** Clicking and hovering in the Battle3D view drive the real game; the 2D UI lives on as a corner picture-in-picture (your ruling); the player faction is human again — which is where your 4a note lands: squadding up the Prolog four is the player's own opening move now.

## The mechanism (recorded on #220 before building)

**Synthetic input, not method calls.** The bridge maps 3D pointer → cell (`BoardPicker`, its first non-LookDev consumer) → the cell's position in GameView coordinates → the PiP's screen coordinates, and feeds ordinary mouse events to `Input.parse_input_event` — the same entry physical input uses. The container forwards them into the hidden game; `game.gd:192` stays the only mouse→cell site; **`game.gd` has zero edits**; the board lock, the modal freeze, menu placement, and hover all fire natively. Hover works from both surfaces **for cells the hidden 2D camera is showing** — a far cell's mapped position falls outside the container rect and is dropped, so the PiP's hover card can lag on the last near cell while the 3D bracket stays correct (self-review finding; options for closing it are on the review comment, your call).

Three engine facts were measured on the way (probe scripts, deleted after):

1. **`Viewport.push_input` is a dead door against `handle_input_locally = false`** — pushed events into GameView never process. The container is the only live entry.
2. **Unconsumed events BUBBLE back out of the SubViewport to the root** — a PiP board click reaches Battle3D's `_unhandled_input` too. Hence the PiP-rect guard, and the pinned rule that the bridge never re-reads such events as 3D pointing.
3. **A synthetic the bridge re-reads as 3D pointing forges a self-sustaining event loop that hangs the flush** (found when a falsification mutant froze the suite twice). Every synthetic now carries a meta tag; the tag check is the loop-breaker, not hygiene.

**The camera snap**: a pushed click's position must map back to the intended cell through the live 2D camera transform, so `CameraController.snap_to_position` (instant + clamped, built from `_apply_pan_position`) fires before each mapped click. Structural consequence, by design: **the PiP recenters on every 3D click** — it tracks your action. (Discovery en route: `ActionMenuController._place_panel` already clamps menus on-screen, so the snap's payload is placement coherence + PiP tracking, not menu reachability.)

**Driver**: `demo_mode` (new export, default off) preserves the 4a AI-vs-AI diorama; `auto_play` keeps meaning "start the mission on launch". Playable mode leaves `ScenarioData.ai_factions` standing — all four `is_ai_faction` readers (board lock, End Turn visibility, the #103 concede, pacing) flip to the human path at once.

## Knobs (the tuning rule)

- `pip_scale` (default **0.35**) — PiP display size; the container keeps its native 1280×720 SIZE (GameView keeps full resolution; `custom_minimum_size` guards this too) and only the display scales.
- `pip_margin` (default 12,12) — corner inset, bottom-right.
- The hover bracket reuses `BoardOverlays`' existing `bracket_*` exports.

## Verification (honest report)

`tests/presentation/test_input_bridge.gd` — 10 cases, the repo's first true click-through wire tests: events enter at the top of the input pipeline (`parse_input_event`) and must survive the whole chain. Full suite **1358/1358, 0 orphans** (149.8s).

Every mechanism falsified (mutant in → red → restore), 11 mutants:

| Mutant | Case that went red |
|---|---|
| pick maps (x,y) not (x,z) | click wire |
| camera snap removed | snap equality (selection stayed green — the math is position-robust; the snap is the camera contract) |
| `can_process()` gate dropped | modal freeze — **after two blind clauses were caught and replaced**: end-state asserts miss a pierced click grazing the pause card's button gaps, and the viewport-mouse comparison is blind because the snap maps every click to the exact center a fresh SubViewport already reports. The clause that works: the bridge's pointer state stays virgin |
| `game.gd:188` board lock disabled | board lock (the sharp clause is RMB — for LMB the dispatch `match` is a second guard) |
| hover motion dropped | hover (presenter clause) |
| hover bracket dropped | hover (bracket clause) |
| PiP left hidden | suite-wide from case 1 — **an invisible container forwards nothing; PiP visibility is load-bearing for the whole bridge**, not just the UI |
| naive container shrink | native-resolution — only after ALSO zeroing `custom_minimum_size`: the authored minimum is a second guard that makes the naive bug a no-op on its own |
| RMB branch dropped | RMB cancel |
| unconditional both-AI | driver |
| PiP-rect guard removed | PiP board click (unconsumed PiP clicks would double-act as 3D picks) |

**What headless cannot see — your half:**
- PiP readability and feel at 0.35 scale (knob), and whether bottom-right is the corner you want.
- The click-snap camera behavior as a feel (every 3D click recenters the PiP).
- Real-mouse 3D picking feel; menus opening inside the PiP.
- **WASD pans BOTH cameras** (the rig polls physical W/S/A/D, the 2D camera polls `cam_*` bound to the same keys) — declared 4b jank, self-healing on the next click; the 4d camera pass owns real arbitration.
- Esc pauses and the report card works from 3D (the modal claims ALWAYS and the PiP keeps the click path alive — the #131 architecture, untouched); typing WASD into the card no longer pans the rig (freeze-mirror, `_process`).

Deliberately not here (per plan): overlay mirroring beyond the hover bracket, z-fight fixes, unshaded conversion (4c); camera arbitration + chooser + hidden-viewport power (4d); dev F-keys in Battle3D (4d's compatibility check). Pre-existing and unchanged: the Prolog SteamRune load noise flagged on #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
