### PR TITLE
HD-2D Stage 4c PR1: 3D overlay parity + the load seam (#222, v0.14.0)

### DIFF
--- a/Classes/board/HoverPresenter.gd
+++ b/Classes/board/HoverPresenter.gd
@@ -23,6 +23,11 @@ signal hovered_unit_changed(previous_unit: Unit, new_unit: Unit)
 
 var game   # the Game coordinator (Node2D); set by game._ready()
 
+# Injectable pointer-cell source (#222, the board_source shape): a host whose pointer
+# is NOT this viewport's mouse (the 3D picker) supplies the hovered cell directly.
+# Unset = the mouse derivation below, i.e. the flat 2D game is untouched.
+var pointer_source: Callable
+
 var last_hovered_cell: Vector2i = GridUtils.NO_CELL
 
 var _highlighted_queue_units: Array[Unit] = []
@@ -33,8 +38,12 @@ func _ready() -> void:
 	hovered_cell_changed.connect(update_hover_visuals)
 
 func _process(_delta: float) -> void:
-	var mouse_world: Vector2 = game.get_global_mouse_position()
-	var hovered_cell: Vector2i = game.grid.local_to_map(game.grid.to_local(mouse_world))
+	var hovered_cell: Vector2i
+	if pointer_source.is_valid():
+		hovered_cell = pointer_source.call()
+	else:
+		var mouse_world: Vector2 = game.get_global_mouse_position()
+		hovered_cell = game.grid.local_to_map(game.grid.to_local(mouse_world))
 
 	if hovered_cell == last_hovered_cell:   # everything below only runs on a CELL change
 		return
@@ -276,7 +285,7 @@ func _show_hover_panel(hovered: Unit, cell: Vector2i) -> void:
 	var icon: Texture2D = GridUtils.tile_sprite(source, game.grid.get_cell_atlas_coords(cell))
 	var tile_lines: Array[String] = _tile_readout_lines(cell)
 	var world_pos: Vector2 = hovered.global_position if hovered != null \
-		else game.grid.to_global(game.grid.map_to_local(cell))
+		else GridUtils.cell_world(game.grid, cell)
 	if game.unit_info_panel.is_showing():
 		if hovered != null and game.unit_info_panel.is_showing_unit(hovered):
 			game.hover_info_panel.clear()

--- a/Classes/board/OverlayManager.gd
+++ b/Classes/board/OverlayManager.gd
@@ -1,6 +1,12 @@
 extends Node
 class_name OverlayManager
 
+# All 2D board visuals: the tile-layer fills (move/attack/hover/squad/zones), path
+# arrows, selection icons, projected-unit ghosts, knockback + terrain previews, and
+# the target-pulse channel. Every draw is RETAINED — the layers hold their cells and
+# the dicts below hold their sprites — which is what lets the 3D OverlayMirror poll
+# full parity off this manager with zero trigger hooks (#222).
+
 @onready var move_overlay = $MoveOverlay
 @onready var attack_overlay = $AttackOverlay
 @onready var hover_overlay = $HoverOverlay
@@ -249,7 +255,7 @@ func show_terrain_preview(deposits: Array) -> void:
 		var cell: Vector2i = deposit["cell"]
 		var sprite := Sprite2D.new()
 		sprite.texture = TERRAIN_STATE_ICONS[state]
-		sprite.global_position = board_tilemap.to_global(board_tilemap.map_to_local(cell))
+		sprite.global_position = GridUtils.cell_world(board_tilemap, cell)
 		sprite.z_index = TERRAIN_Z_INDEX
 		sprite.modulate = TERRAIN_PREVIEW_MODULATE
 		icon_overlay.add_child(sprite)
@@ -296,7 +302,7 @@ func show_knockback_preview(shoves: Array) -> void:
 		knockback_hidden_units.append(unit)
 		var ghost := Sprite2D.new()
 		ghost.texture = unit.get_move_texture()
-		ghost.global_position = board_tilemap.to_global(board_tilemap.map_to_local(final_cell[target]))
+		ghost.global_position = GridUtils.cell_world(board_tilemap, final_cell[target])
 		ghost.z_index = Unit.BASE_SPRITE_INDEX
 		ghost.modulate = PROJECTED_MODULATE
 		ghost.offset = Vector2i(0, -8)
@@ -430,7 +436,7 @@ func redraw_terrain_live(states: TerrainStateManager) -> void:
 		for cell in states.cells_with(state):
 			var sprite := Sprite2D.new()
 			sprite.texture = icon
-			sprite.global_position = board_tilemap.to_global(board_tilemap.map_to_local(cell))
+			sprite.global_position = GridUtils.cell_world(board_tilemap, cell)
 			sprite.z_index = TERRAIN_Z_INDEX
 			icon_overlay.add_child(sprite)
 			terrain_live_sprites.append(sprite)
@@ -559,7 +565,7 @@ func _create_arrow_sprite(cell: Vector2i, texture: Texture2D, tint: Color) -> Sp
 	var sprite := Sprite2D.new()
 	sprite.texture = texture
 	sprite.z_index = MoveAction.ARROW_BASE_Z_INDEX
-	sprite.global_position = board_tilemap.to_global(board_tilemap.map_to_local(cell))
+	sprite.global_position = GridUtils.cell_world(board_tilemap, cell)
 	sprite.modulate = tint
 	arrow_icon_overlay.add_child(sprite)
 	return sprite
@@ -583,7 +589,7 @@ func show_projected_unit(unit: Unit, cell: Vector2i):
 	
 	var sprite := Sprite2D.new()
 	sprite.texture = unit.get_move_texture()
-	sprite.global_position = board_tilemap.to_global(board_tilemap.map_to_local(cell))
+	sprite.global_position = GridUtils.cell_world(board_tilemap, cell)
 	sprite.z_index = Unit.BASE_SPRITE_INDEX
 	
 	#Planning sprite modulation

--- a/Classes/core/GridUtils.gd
+++ b/Classes/core/GridUtils.gd
@@ -78,6 +78,12 @@ static func authored_tile_display_name(data: TileData) -> String:
 	var raw: String = data.get_custom_data("terrain_name")
 	return raw.capitalize()
 
+# A cell's center in the grid's GLOBAL space -- the one spelling of
+# to_global(map_to_local(cell)), consolidated from 7 copies (#222). Callers assigning
+# a LOCAL position keep the bare map_to_local half-form on purpose (different space).
+static func cell_world(grid: TileMapLayer, cell: Vector2i) -> Vector2:
+	return grid.to_global(grid.map_to_local(cell))
+
 # The tile's own sprite, cut from its atlas sheet -- what the palette rows and the hover card
 # draw. Rect2-wrapped: the getter returns Rect2i and AtlasTexture.region is Rect2, and Variant
 # equality across the two is FALSE, which bites anything comparing regions later.

--- a/Classes/flow/ScenarioManager.gd
+++ b/Classes/flow/ScenarioManager.gd
@@ -5,6 +5,13 @@ class_name ScenarioManager
 # live unit into a ScenarioUnitEntry/ScenarioData, and rebuilds the board from a saved one.
 # Since #87 a save is a true mid-battle snapshot, battle-scoped layer included. Player save
 # slots (#144) live here too: same capture/apply pair, wrapped in a SaveGame under user://.
+# board_loaded (#222) fires once per board build, after the last settle step.
+
+# Every board swap crosses apply_scenario (begin_mission, Load Game, F2/Restart, the dev
+# Scenario tab) EXCEPT game.spawn_sandbox, which emits this itself after TestBoard.spawn.
+# turn_started deliberately never fires on menu arrivals (#144), so the load funnel speaks
+# for itself — the 3D mirror rebuilds on it.
+signal board_loaded
 
 const SCENARIO_DIR := "res://Scenarios/"
 
@@ -221,6 +228,7 @@ func apply_scenario(scenario: ScenarioData) -> void:
 	# this one). set_objectives refreshed it mid-load, BEFORE units spawned, so extraction read its
 	# progress off an empty board and the stale answer sat until the first turn event.
 	game.refresh_mission_status()
+	board_loaded.emit()
 
 func reload_current():
 	if last_loaded_path == "":

--- a/Classes/presentation/BoardMirror.gd
+++ b/Classes/presentation/BoardMirror.gd
@@ -36,7 +36,7 @@ func rebuild(grid: TileMapLayer, states: Dictionary) -> void:
 	for cell in grid.get_used_cells():
 		var kind := GridUtils.get_terrain_kind_at_cell(grid, cell)
 		var item: int = KIND_TO_ITEM.get(kind, FALLBACK_ITEM)
-		board.set_cell_item(Vector3i(cell.x, 0, cell.y), item)
+		board.set_cell_item(BoardSpace.of_flat(cell), item)
 	refresh_states(states)
 
 
@@ -46,7 +46,7 @@ func refresh_states(states: Dictionary) -> void:
 	_fire_markers.clear()
 	for cell: Vector2i in states.keys():
 		if _has_fire(states[cell]):
-			_fire_markers.append(_make_fire(Vector3i(cell.x, 0, cell.y)))
+			_fire_markers.append(_make_fire(BoardSpace.of_flat(cell)))
 
 
 func fire_marker_count() -> int:

--- a/Classes/presentation/BoardOverlays.gd
+++ b/Classes/presentation/BoardOverlays.gd
@@ -1,20 +1,31 @@
 extends Node3D
 class_name BoardOverlays
 
-# The 3D presentation stack's board markup (#213 / #176 stage 3): the one owner of
-# per-cell overlay layers. FILL layers are pooled Decals projecting straight down,
-# so fills conform to ramp slopes structurally (the dev's stage-1 requirement);
-# HOVER is a voxel corner-bracket mesh (the dev's stage-2 requirement, "just the
-# corners of the specific voxel"). Layer colors deliberately mirror the 2D
-# OverlayManager's constants — one declared representation per presentation stack
-# (the parallel-stacks doctrine); change a color in both places or say why not.
+# The 3D presentation stack's board markup (#213 / #176 stages 3+4c): the one owner
+# of per-cell overlay layers. Four marker kinds — FILL (pooled unshaded quads lying
+# on the cell's top face; the dev's ruling that gameplay markup must never read as
+# terrain, which a lit Decal cannot honor), BRACKET (the voxel corner-bracket
+# pointer), SPRITE (a ground quad with per-marker texture+tint — path arrows,
+# knockback trails, terrain icons, pick markers), BILLBOARD (a camera-facing
+# Sprite3D above the cell — selection icons). Layer colors deliberately mirror the
+# 2D OverlayManager's constants — one declared representation per presentation
+# stack (the parallel-stacks doctrine); change a color in both places or say why not.
 #
-# The mask contract: fill decals paint WORLD_RENDER_LAYER only, and UnitSprite3D
-# lives on UNIT_RENDER_LAYER, so a fill never tints a sprite. Both constants live
-# HERE; a drift test pins them disjoint.
+# Contract: a dumb idempotent sink. set_cells/set_markers replace a layer wholesale
+# and are cheap ONLY when the caller diffs first (OverlayMirror does); marker pos is
+# the cell's top-face ANCHOR (the mirror's geometry), and the LAYER adds its own
+# lift — board shape stays the caller's business.
+#
+# The mask contract: fill/sprite quads render on WORLD_RENDER_LAYER only, and
+# UnitSprite3D lives on UNIT_RENDER_LAYER. Both constants live HERE; a drift test
+# pins them disjoint.
 
-enum Layer { MOVE, ATTACK, ZONE_CAPTURE, ZONE_EXTRACTION, HOVER }
-enum Kind { FILL, BRACKET }
+enum Layer {
+	MOVE, ATTACK, ZONE_CAPTURE, ZONE_EXTRACTION, HOVER,
+	INVALID_MOVE, SQUAD, SQUAD_RANGE, AIM,
+	TARGET_PICK, PATH_ARROWS, KNOCKBACK, TERRAIN, TERRAIN_PREVIEW, ICONS,
+}
+enum Kind { FILL, BRACKET, SPRITE, BILLBOARD }
 
 const WORLD_RENDER_LAYER := 1  # bit for layer index 0 — the board and props
 const UNIT_RENDER_LAYER := 2   # bit for layer index 1 — UnitSprite3D sets this
@@ -25,20 +36,39 @@ const LAYERS: Dictionary[Layer, Dictionary] = {
 	Layer.ZONE_CAPTURE: {"color": Color(0.3, 0.9, 1, 0.5), "sort": -2, "kind": Kind.FILL},
 	Layer.ZONE_EXTRACTION: {"color": Color(0.4, 1, 0.5, 0.5), "sort": -2, "kind": Kind.FILL},
 	Layer.HOVER: {"color": Color(1, 0.9, 0.3, 0.9), "sort": 2, "kind": Kind.BRACKET},
+	Layer.INVALID_MOVE: {"color": Color(0.5, 0.36, 0.4, 0.5), "sort": 0, "kind": Kind.FILL},
+	Layer.SQUAD: {"color": Color(1, 0.5, 0, 0.5), "sort": -1, "kind": Kind.FILL},
+	Layer.SQUAD_RANGE: {"color": Color(1, 0.5, 0, 0.5), "sort": -1, "kind": Kind.FILL},
+	Layer.AIM: {"color": Color(1, 1, 0, 1), "sort": 3, "kind": Kind.FILL},
+	Layer.TARGET_PICK: {"color": Color.WHITE, "sort": 4, "kind": Kind.SPRITE},
+	Layer.PATH_ARROWS: {"color": Color.WHITE, "sort": 5, "kind": Kind.SPRITE},
+	Layer.KNOCKBACK: {"color": Color.WHITE, "sort": 5, "kind": Kind.SPRITE},
+	Layer.TERRAIN: {"color": Color.WHITE, "sort": 6, "kind": Kind.SPRITE},
+	Layer.TERRAIN_PREVIEW: {"color": Color.WHITE, "sort": 6, "kind": Kind.SPRITE},
+	Layer.ICONS: {"color": Color.WHITE, "sort": 0, "kind": Kind.BILLBOARD},
 }
 
 const FILL_TEXTURE_PATH := "res://Art/LookDev/cell_fill.png"
+# The 2D art's metric: a 16px texture covers exactly one board cell.
+const ART_PIXELS_PER_CELL := 16.0
 
-# Bracket proportions — eye-knobs (the tuning rule); read when the mesh first builds.
+# Eye-knobs (the tuning rule); read when markers build/place.
 @export var bracket_arm := 0.22
 @export var bracket_thickness := 0.04
 @export var bracket_scale := 1.02
+@export var fill_lift := 0.02          # quad height above the top face — the z-fight gap
+@export var lift_step := 0.004         # per-sort spacing so stacked layers never coincide
+@export var billboard_lift := 1.1      # icon height above the cell's top face
+@export var billboard_pixel_size := 1.0 / 32.0
 
 var fill_texture: Texture2D
 
-var _markers: Dictionary[Layer, Array] = {}
-var _cells: Dictionary[Layer, Array] = {}
+var _markers: Dictionary[Layer, Array] = {}       # layer -> node pool (all kinds)
+var _cells: Dictionary[Layer, Array] = {}         # set_cells layers: the current cell list
+var _marker_data: Dictionary[Layer, Array] = {}   # set_markers layers: the current entries
+var _layer_colors: Dictionary[Layer, Color] = {}  # runtime fill colors (set_layer_modulate)
 var _bracket_mesh: ArrayMesh
+var _quad_mesh: PlaneMesh
 
 
 func _ready() -> void:
@@ -48,14 +78,16 @@ func _ready() -> void:
 
 # Replaces the layer's cells wholesale (idempotent — calling twice with the same
 # set changes nothing; extras from a previous, larger set are hidden, not leaked).
+# FILL/BRACKET layers only — variant layers go through set_markers.
 func set_cells(layer: Layer, cells: Array[Vector3i]) -> void:
+	var spec: Dictionary = LAYERS[layer]
+	if spec["kind"] != Kind.FILL and spec["kind"] != Kind.BRACKET:
+		push_error("set_cells on a %s layer — use set_markers" % Kind.keys()[spec["kind"]])
+		return
 	_cells[layer] = cells.duplicate()
-	if not _markers.has(layer):
-		_markers[layer] = []
-	var pool: Array = _markers[layer]
+	var pool: Array = _pool_for(layer)
 	while pool.size() < cells.size():
 		pool.append(_make_marker(layer))
-	var spec: Dictionary = LAYERS[layer]
 	for i in pool.size():
 		var marker := pool[i] as Node3D
 		if i < cells.size():
@@ -65,8 +97,48 @@ func set_cells(layer: Layer, cells: Array[Vector3i]) -> void:
 			marker.visible = false
 
 
+# Replaces a variant layer wholesale: one entry per marker, {"pos": Vector3 (the
+# cell's top-face anchor), "texture": Texture2D, "modulate": Color}. Same
+# idempotent-pool contract as set_cells. SPRITE/BILLBOARD layers only.
+func set_markers(layer: Layer, markers: Array[Dictionary]) -> void:
+	var spec: Dictionary = LAYERS[layer]
+	if spec["kind"] != Kind.SPRITE and spec["kind"] != Kind.BILLBOARD:
+		push_error("set_markers on a %s layer — use set_cells" % Kind.keys()[spec["kind"]])
+		return
+	_marker_data[layer] = markers.duplicate()
+	var pool: Array = _pool_for(layer)
+	while pool.size() < markers.size():
+		pool.append(_make_marker(layer))
+	for i in pool.size():
+		var node := pool[i] as Node3D
+		if i < markers.size():
+			node.visible = true
+			_apply_marker(spec, node, markers[i])
+		else:
+			node.visible = false
+
+
+# Runtime recolor of a FILL layer's pool (the heal-green reach, the aim pulse —
+# colors the 2D layer modulates live). Skip-if-equal so a per-frame poll is free.
+func set_layer_modulate(layer: Layer, color: Color) -> void:
+	var spec: Dictionary = LAYERS[layer]
+	if spec["kind"] != Kind.FILL:
+		push_error("set_layer_modulate is for FILL layers")
+		return
+	if _layer_colors.get(layer, spec["color"]) == color:
+		return
+	_layer_colors[layer] = color
+	for node: Node3D in _pool_for(layer):
+		var material := (node as MeshInstance3D).material_override as StandardMaterial3D
+		material.albedo_color = color
+
+
 func clear(layer: Layer) -> void:
-	set_cells(layer, [])
+	var spec: Dictionary = LAYERS[layer]
+	if spec["kind"] == Kind.SPRITE or spec["kind"] == Kind.BILLBOARD:
+		set_markers(layer, [])
+	else:
+		set_cells(layer, [])
 
 
 func clear_all() -> void:
@@ -80,6 +152,16 @@ func cells_of(layer: Layer) -> Array[Vector3i]:
 	return current
 
 
+func markers_of(layer: Layer) -> Array[Dictionary]:
+	var current: Array[Dictionary] = []
+	current.assign(_marker_data.get(layer, []))
+	return current
+
+
+func layer_modulate(layer: Layer) -> Color:
+	return _layer_colors.get(layer, LAYERS[layer]["color"])
+
+
 func marker_count(layer: Layer) -> int:
 	var pool: Array = _markers.get(layer, [])
 	var visible_count := 0
@@ -91,31 +173,91 @@ func marker_count(layer: Layer) -> int:
 
 # --- Marker construction -----------------------------------------------------------
 
+func _pool_for(layer: Layer) -> Array:
+	if not _markers.has(layer):
+		_markers[layer] = []
+	return _markers[layer]
+
+
 func _marker_position(spec: Dictionary, cell: Vector3i) -> Vector3:
 	if spec["kind"] == Kind.BRACKET:
 		return BoardSpace.cell_center(cell)
-	# The decal box straddles the cell's top: tall enough to catch a full ramp slope,
-	# normal-faded so it barely touches vertical walls.
-	return BoardSpace.cell_center(cell) + Vector3(0.0, 0.4 * BoardSpace.CELL_SIZE, 0.0)
+	return BoardSpace.standing_point(cell) + Vector3(0.0, _lift_of(spec), 0.0)
+
+
+# Per-sort spacing keeps coplanar stacked fills apart; render_priority (set at
+# construction) keeps the alpha blend order stable regardless.
+func _lift_of(spec: Dictionary) -> float:
+	return fill_lift + spec["sort"] * lift_step
+
+
+func _apply_marker(spec: Dictionary, node: Node3D, marker: Dictionary) -> void:
+	var pos: Vector3 = marker["pos"]
+	var texture: Texture2D = marker["texture"]
+	var tint: Color = marker.get("modulate", Color.WHITE)
+	if spec["kind"] == Kind.BILLBOARD:
+		var sprite := node as Sprite3D
+		sprite.position = pos + Vector3(0.0, billboard_lift, 0.0)
+		sprite.texture = texture
+		sprite.modulate = tint
+		return
+	var quad := node as MeshInstance3D
+	quad.position = pos + Vector3(0.0, _lift_of(spec), 0.0)
+	var material := quad.material_override as StandardMaterial3D
+	material.albedo_texture = texture
+	material.albedo_color = tint
+	if texture != null:
+		var art: Vector2 = texture.get_size() / ART_PIXELS_PER_CELL
+		quad.scale = Vector3(art.x, 1.0, art.y)
 
 
 func _make_marker(layer: Layer) -> Node3D:
 	var spec: Dictionary = LAYERS[layer]
-	if spec["kind"] == Kind.BRACKET:
-		return _make_bracket(spec)
-	return _make_fill(spec)
+	match spec["kind"] as Kind:
+		Kind.BRACKET:
+			return _make_bracket(spec)
+		Kind.BILLBOARD:
+			return _make_billboard(spec)
+		Kind.SPRITE:
+			return _make_quad(spec, null, Color.WHITE)
+		_:
+			return _make_quad(spec, fill_texture, _layer_colors.get(layer, spec["color"]))
 
 
-func _make_fill(spec: Dictionary) -> Decal:
-	var decal := Decal.new()
-	decal.texture_albedo = fill_texture
-	decal.modulate = spec["color"]
-	decal.size = Vector3(1.0, 2.0, 1.0) * BoardSpace.CELL_SIZE
-	decal.cull_mask = WORLD_RENDER_LAYER
-	decal.sorting_offset = spec["sort"]
-	decal.normal_fade = 0.3
-	add_child(decal)
-	return decal
+# The one fill/sprite recipe: an unshaded alpha quad lying on the cell's top face —
+# markup, never terrain (the dev's unshaded ruling; a Decal's albedo modulates the
+# lit surface, which is why 4c retired decals).
+func _make_quad(spec: Dictionary, texture: Texture2D, color: Color) -> MeshInstance3D:
+	if _quad_mesh == null:
+		_quad_mesh = PlaneMesh.new()
+		_quad_mesh.size = Vector2.ONE * BoardSpace.CELL_SIZE
+	var instance := MeshInstance3D.new()
+	instance.mesh = _quad_mesh
+	var material := StandardMaterial3D.new()
+	material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	material.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST
+	material.albedo_texture = texture
+	material.albedo_color = color
+	material.render_priority = spec["sort"]
+	instance.material_override = material
+	instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	instance.layers = WORLD_RENDER_LAYER
+	add_child(instance)
+	return instance
+
+
+func _make_billboard(spec: Dictionary) -> Sprite3D:
+	var sprite := Sprite3D.new()
+	sprite.billboard = BaseMaterial3D.BILLBOARD_FIXED_Y
+	sprite.pixel_size = billboard_pixel_size
+	sprite.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST
+	sprite.shaded = false
+	sprite.render_priority = spec["sort"]
+	sprite.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	sprite.layers = WORLD_RENDER_LAYER
+	add_child(sprite)
+	return sprite
 
 
 func _make_bracket(spec: Dictionary) -> MeshInstance3D:

--- a/Classes/presentation/BoardPicker.gd
+++ b/Classes/presentation/BoardPicker.gd
@@ -23,12 +23,18 @@ const _MAX_STEPS := 4096
 static func column_tops_from(board: GridMap) -> Dictionary[Vector2i, int]:
 	var tops: Dictionary[Vector2i, int] = {}
 	for cell in board.get_used_cells():
-		var column := Vector2i(cell.x, cell.z)
+		var column := BoardSpace.flat(cell)
 		var top := cell.y + 1
 		var existing: int = tops.get(column, 0)
 		if top > existing:
 			tops[column] = top
 	return tops
+
+
+# Ray-pair convenience: the cell under a camera's screen point. Every live caller
+# built the same origin/normal pair by hand (#222 collapsed three copies).
+static func pick_at(camera: Camera3D, screen_pos: Vector2, tops: Dictionary[Vector2i, int]) -> Vector3i:
+	return pick_cell(camera.project_ray_origin(screen_pos), camera.project_ray_normal(screen_pos), tops)
 
 
 # The cell under a ray, or BoardSpace.NO_CELL on a miss.

--- a/Classes/presentation/BoardSpace.gd
+++ b/Classes/presentation/BoardSpace.gd
@@ -34,3 +34,15 @@ static func cell_of(position: Vector3) -> Vector3i:
 		floori(position.y / CELL_SIZE),
 		floori(position.z / CELL_SIZE)
 	)
+
+
+# The flat-board bridge (#222): sim cells are 2D (x, y), mirror cells are (x, 0, y)
+# until real elevation arrives — the ONE spelling of that pair. Not for columns with
+# a real height (BoardPicker._top_cell keeps its own y). flat(NO_CELL) equals
+# GridUtils.NO_CELL by value — pinned, the pointer source relies on it.
+static func flat(cell: Vector3i) -> Vector2i:
+	return Vector2i(cell.x, cell.z)
+
+
+static func of_flat(cell: Vector2i) -> Vector3i:
+	return Vector3i(cell.x, 0, cell.y)

--- a/Classes/presentation/OverlayMirror.gd
+++ b/Classes/presentation/OverlayMirror.gd
@@ -1,0 +1,209 @@
+extends Node
+class_name OverlayMirror
+
+# The 4c observer (#222): polls the 2D OverlayManager's retained state every frame
+# and diffs it into BoardOverlays / UnitMirror — board markup parity with ZERO
+# trigger-site hooks (the alternative was ~40 sites across 9 files; UnitMirror's
+# poll-don't-wire precedent, applied to overlays). The 2D stays the ONE authority:
+# every cell set, texture, tint and animation arrives by copy — the aim pulse IS
+# hover_overlay.modulate, polled; arrow textures arrive pre-picked on the retained
+# preview sprites; validity tints arrive pre-applied. Value-diff before every push
+# (fills compare SORTED — get_used_cells/Dictionary orderings aren't frame-stable),
+# so a static board costs comparisons, not writes.
+#
+# Deliberately NOT mirrored: the 2D hover layer's POINTER role (battle3d's bracket
+# is the 3D pointer; AIM covers the footprint role), CursorController, ZONE_PATROL
+# + the brush highlight + dev ghosts (dev authoring stays on the 2D surface).
+
+const PX := float(GridUtils.TILE_SIZE)   # 16 — the art metric (UnitMirror's ÷16)
+const TOP := UnitMirror.COLUMN_TOP       # flat mirror boards: anchors at y 1.0
+
+var game: Node2D            # the hidden Game coordinator; set by battle3d._ready
+var overlays: BoardOverlays
+var unit_mirror: UnitMirror
+
+var _last_cells: Dictionary[BoardOverlays.Layer, Array] = {}
+var _last_markers: Dictionary[BoardOverlays.Layer, Array] = {}
+var _last_ghosts: Array[Dictionary] = []
+var _pick_texture: Texture2D   # the (3,0) "pick this unit" tile art, cut lazily
+
+
+func _process(_delta: float) -> void:
+	if game == null or overlays == null:
+		return
+	var om: OverlayManager = game.overlay_manager
+
+	_fill(BoardOverlays.Layer.MOVE, om.move_overlay.get_used_cells())
+	_fill(BoardOverlays.Layer.INVALID_MOVE, om.invalidmove_overlay.get_used_cells())
+	_fill(BoardOverlays.Layer.SQUAD, om.squad_overlay.get_used_cells())
+	_fill(BoardOverlays.Layer.SQUAD_RANGE, om.squadrange_overlay.get_used_cells())
+	_fill(BoardOverlays.Layer.ZONE_CAPTURE, om.capture_overlay.get_used_cells())
+	_fill(BoardOverlays.Layer.ZONE_EXTRACTION, om.extraction_overlay.get_used_cells())
+
+	# The aim footprint pulses by layer modulate in 2D — the animation rides the poll.
+	_fill(BoardOverlays.Layer.AIM, om.hover_overlay.get_used_cells())
+	overlays.set_layer_modulate(BoardOverlays.Layer.AIM, om.hover_overlay.modulate)
+
+	_attack(om)
+	_arrows(om)
+
+	var kb_trails: Array[Dictionary] = []
+	var kb_ghosts: Array[Dictionary] = []
+	_split_knockback(om, kb_trails, kb_ghosts)
+	_markers(BoardOverlays.Layer.KNOCKBACK, kb_trails)
+
+	_icons(om)
+	_terrain(om)
+	_ghost_sync(om, kb_ghosts)
+
+
+# --- Fills -------------------------------------------------------------------------
+
+func _fill(layer: BoardOverlays.Layer, used: Array[Vector2i]) -> void:
+	var cells: Array[Vector3i] = []
+	for cell in used:
+		cells.append(BoardSpace.of_flat(cell))
+	cells.sort()
+	if _last_cells.get(layer, Array()) == cells:
+		return
+	_last_cells[layer] = cells
+	overlays.set_cells(layer, cells)
+
+
+# ATTACK is dual-use in 2D: reach fill at (0,0), target-pick markers at (3,0) on the
+# same layer — split by atlas coords; the heal-green arrives as the layer modulate.
+func _attack(om: OverlayManager) -> void:
+	var reach: Array[Vector3i] = []
+	var picks: Array[Dictionary] = []
+	for cell: Vector2i in om.attack_overlay.get_used_cells():
+		if om.attack_overlay.get_cell_atlas_coords(cell) == OverlayManager.TARGET_ATLAS_COORDS:
+			picks.append(_marker(_anchor(cell), _target_pick_texture(om), Color.WHITE))
+		else:
+			reach.append(BoardSpace.of_flat(cell))
+	reach.sort()
+	if _last_cells.get(BoardOverlays.Layer.ATTACK, Array()) != reach:
+		_last_cells[BoardOverlays.Layer.ATTACK] = reach
+		overlays.set_cells(BoardOverlays.Layer.ATTACK, reach)
+	overlays.set_layer_modulate(BoardOverlays.Layer.ATTACK, om.attack_overlay.modulate)
+	_markers(BoardOverlays.Layer.TARGET_PICK, picks)
+
+
+func _target_pick_texture(om: OverlayManager) -> Texture2D:
+	if _pick_texture == null:
+		var source := om.attack_overlay.tile_set.get_source(OverlayManager.SOURCE_ID) as TileSetAtlasSource
+		_pick_texture = GridUtils.tile_sprite(source, OverlayManager.TARGET_ATLAS_COORDS)
+	return _pick_texture
+
+
+# --- Sprite channels ---------------------------------------------------------------
+
+# Planned + hover + group-preview path arrows: the retained preview Sprite2Ds carry
+# the already-picked texture (14 authored variants) and the already-computed
+# validity tint — copy, never re-derive.
+func _arrows(om: OverlayManager) -> void:
+	var entries: Array[Dictionary] = []
+	var moves: Array = om.planned_move_by_unit.values()
+	if om.hover_move_preview != null:
+		moves.append(om.hover_move_preview)
+	moves.append_array(om.hover_move_previews)
+	for move in moves:
+		var action := move as MoveAction
+		if action == null:
+			continue
+		for sprite: Sprite2D in action.preview:
+			if not is_instance_valid(sprite) or sprite.texture == null:
+				continue
+			entries.append(_marker(_anchor_px(sprite.global_position), sprite.texture, sprite.modulate))
+	_markers(BoardOverlays.Layer.PATH_ARROWS, entries)
+
+
+# knockback_preview_sprites holds BOTH halves of the preview; the parent says which:
+# arrow trail under ArrowIconOverlay, landing ghost under ProjectedUnitOverlay.
+func _split_knockback(om: OverlayManager, trails: Array[Dictionary], ghosts: Array[Dictionary]) -> void:
+	for node in om.knockback_preview_sprites:
+		if not is_instance_valid(node):
+			continue
+		var sprite := node as Sprite2D
+		if sprite == null or sprite.texture == null:
+			continue
+		var entry := _marker(_anchor_px(sprite.global_position), sprite.texture, sprite.modulate)
+		if sprite.get_parent() == om.arrow_icon_overlay:
+			trails.append(entry)
+		elif sprite.get_parent() == om.projected_unit_overlay:
+			ghosts.append(entry)
+
+
+# Selection icons (crown / squadmember / target / …): anchored to the icon's own
+# authored target_cell; a small per-type height stagger keeps co-celled billboards
+# from z-fighting (2D overlaps them by pixel offsets instead).
+func _icons(om: OverlayManager) -> void:
+	var entries: Array[Dictionary] = []
+	for unit in om.icons_by_unit:
+		var by_type: Dictionary = om.icons_by_unit[unit]
+		for type in by_type:
+			var icon := by_type[type] as OverlayIcon
+			if icon == null or not is_instance_valid(icon):
+				continue
+			var pos := _anchor(icon.target_cell) + Vector3(0.0, float(type) * 0.02, 0.0)
+			entries.append(_marker(pos, icon.sprite.texture, icon.sprite.modulate))
+	_markers(BoardOverlays.Layer.ICONS, entries)
+
+
+# Terrain live icons (FROZEN / COVER) + plan-time preview ghosts. Fire is skipped on
+# the LIVE channel — BoardMirror's flame + light IS fire's 3D form (#174: one Fire
+# texture covers BURNING and BLAZE) — but kept on the PREVIEW channel, where no 3D
+# flame preview exists and the ghosted icon is the only warning.
+func _terrain(om: OverlayManager) -> void:
+	var fire: Texture2D = OverlayManager.TERRAIN_STATE_ICONS[Terrain.TileState.BURNING]
+	var live: Array[Dictionary] = []
+	for sprite in om.terrain_live_sprites:
+		if not is_instance_valid(sprite) or sprite.texture == fire:
+			continue
+		live.append(_marker(_anchor_px(sprite.global_position), sprite.texture, sprite.modulate))
+	_markers(BoardOverlays.Layer.TERRAIN, live)
+	var preview: Array[Dictionary] = []
+	for sprite in om.terrain_preview_sprites:
+		if not is_instance_valid(sprite):
+			continue
+		preview.append(_marker(_anchor_px(sprite.global_position), sprite.texture, sprite.modulate))
+	_markers(BoardOverlays.Layer.TERRAIN_PREVIEW, preview)
+
+
+# Move-projection ghosts + knockback landing ghosts -> UnitMirror's ghost pool.
+func _ghost_sync(om: OverlayManager, kb_ghosts: Array[Dictionary]) -> void:
+	var entries: Array[Dictionary] = []
+	for sprite in om.projected_unit_sprites.values():
+		if not is_instance_valid(sprite):
+			continue
+		var ghost := sprite as Sprite2D
+		if ghost == null or ghost.texture == null:
+			continue
+		entries.append(_marker(_anchor_px(ghost.global_position), ghost.texture, ghost.modulate))
+	entries.append_array(kb_ghosts)
+	if _last_ghosts == entries:
+		return
+	_last_ghosts = entries
+	unit_mirror.set_ghosts(entries)
+
+
+# --- Shared ------------------------------------------------------------------------
+
+func _markers(layer: BoardOverlays.Layer, entries: Array[Dictionary]) -> void:
+	if _last_markers.get(layer, Array()) == entries:
+		return
+	_last_markers[layer] = entries
+	overlays.set_markers(layer, entries)
+
+
+func _marker(pos: Vector3, texture: Texture2D, tint: Color) -> Dictionary:
+	return {"pos": pos, "texture": texture, "modulate": tint}
+
+
+# A cell's top-face center — the marker anchor convention.
+func _anchor(cell: Vector2i) -> Vector3:
+	return Vector3(cell.x + 0.5, TOP, cell.y + 0.5)
+
+
+# A 2D world position's top-face anchor (the ÷16 metric; sprites sit at cell centers).
+func _anchor_px(px: Vector2) -> Vector3:
+	return Vector3(px.x / PX, TOP, px.y / PX)

--- a/Classes/presentation/OverlayMirror.gd.uid
+++ b/Classes/presentation/OverlayMirror.gd.uid
@@ -1,0 +1,1 @@
+uid://bxgelre76vn41

--- a/Classes/presentation/UnitMirror.gd
+++ b/Classes/presentation/UnitMirror.gd
@@ -7,7 +7,9 @@ class_name UnitMirror
 # already the one animation authority — position is unit.position / 16 (the
 # map_to_local metric), so the 3D sprite glides exactly as the 2D one does.
 # Keyed by instance id, never by object ref (#149: a freed Unit in a typed slot
-# dies on the type-check before any null guard runs).
+# dies on the type-check before any null guard runs). Since #222 it also hosts the
+# planning-ghost pool (set_ghosts) and copies each 2D sprite's own visible/modulate
+# per frame — pulse, highlight and projected-hide parity by copy.
 
 const PIXELS_PER_CELL := float(GridUtils.TILE_SIZE)  # 16 — grid.map_to_local's metric
 const COLUMN_TOP := 1.0  # flat mirror boards: every column is one cell tall
@@ -15,6 +17,7 @@ const COLUMN_TOP := 1.0  # flat mirror boards: every column is one cell tall
 var units_root: Node2D
 
 var _mirrored: Dictionary[int, UnitSprite3D] = {}
+var _ghosts: Array[UnitSprite3D] = []
 
 
 func _process(_delta: float) -> void:
@@ -49,6 +52,35 @@ func sprite_for(unit: Unit) -> UnitSprite3D:
 	return _mirrored.get(unit.get_instance_id())
 
 
+# Planning ghosts (#222): the 2D projected/knockback stand-ins, mirrored as pooled
+# UnitSprite3Ds. One entry per ghost: {"pos": Vector3, "texture": Texture2D,
+# "modulate": Color} — texture and tint arrive by copy, the 2D stays the authority.
+# Wholesale replace, same pool contract as BoardOverlays (extras hidden, not freed).
+func set_ghosts(ghosts: Array[Dictionary]) -> void:
+	while _ghosts.size() < ghosts.size():
+		var ghost := UnitSprite3D.new()
+		ghost.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF  # a translucent stand-in casts no shadow
+		add_child(ghost)
+		_ghosts.append(ghost)
+	for i in _ghosts.size():
+		var ghost: UnitSprite3D = _ghosts[i]
+		if i < ghosts.size():
+			ghost.visible = true
+			ghost.position = ghosts[i]["pos"]
+			ghost.texture = ghosts[i]["texture"]
+			ghost.modulate = ghosts[i]["modulate"]
+		else:
+			ghost.visible = false
+
+
+func ghost_count() -> int:
+	var visible_count := 0
+	for ghost in _ghosts:
+		if ghost.visible:
+			visible_count += 1
+	return visible_count
+
+
 func _sync(unit: Unit, sprite: UnitSprite3D) -> void:
 	var previous := sprite.position
 	sprite.position = Vector3(
@@ -60,6 +92,13 @@ func _sync(unit: Unit, sprite: UnitSprite3D) -> void:
 		sprite.set_downed(downed)
 	if not downed:
 		sprite.set_walking_visual(unit.movement.moving)
+
+	# Pulse / highlight / projected-hide parity (#222): copy the 2D sprite's OWN
+	# flags, never is_visible_in_tree — 3D hosting hides the whole board subtree,
+	# which must not read as every unit hidden. The 2D tween stays the one
+	# animation authority; this is a per-frame copy of its output.
+	sprite.visible = unit.visuals.sprite.visible
+	sprite.modulate = unit.visuals.sprite.modulate
 
 	var step := sprite.position - previous
 	if Vector2(step.x, step.z).length_squared() > 0.000001:

--- a/Scenes/Battle3D/Battle3D.tscn
+++ b/Scenes/Battle3D/Battle3D.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3]
+[gd_scene load_steps=13 format=3]
 
 [ext_resource type="Script" path="res://Scenes/Battle3D/battle3d.gd" id="1"]
 [ext_resource type="Script" path="res://Classes/presentation/BoardMirror.gd" id="2"]
@@ -7,6 +7,7 @@
 [ext_resource type="Script" path="res://Classes/presentation/BoardOverlays.gd" id="5"]
 [ext_resource type="MeshLibrary" path="res://Scenes/LookDev/lookdev_meshlib.tres" id="6"]
 [ext_resource type="PackedScene" path="res://Scenes/Main.tscn" id="7"]
+[ext_resource type="Script" path="res://Classes/presentation/OverlayMirror.gd" id="8"]
 
 [sub_resource type="ProceduralSkyMaterial" id="sky_mat"]
 sky_top_color = Color(0.32, 0.5, 0.78, 1)
@@ -62,6 +63,9 @@ script = ExtResource("2")
 
 [node name="UnitMirror" type="Node3D" parent="."]
 script = ExtResource("3")
+
+[node name="OverlayMirror" type="Node" parent="."]
+script = ExtResource("8")
 
 [node name="CameraRig" type="Node3D" parent="."]
 position = Vector3(0, 1, 0)

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -13,6 +13,11 @@
 # native 1280x720 SIZE (so GameView keeps full resolution under stretch) and only
 # the display shrinks via scale; input maps through the container transform.
 #
+# Stage 4c (PR1) adds parity: OverlayMirror polls the 2D OverlayManager into
+# BoardOverlays/UnitMirror per frame, board swaps rebuild via ScenarioManager's
+# board_loaded signal, and HoverPresenter reads the 3D pick through pointer_source
+# — hover now reaches every cell, not just the hidden camera's window.
+#
 # demo_mode = stage-4a behavior: both factions AI, no PiP, watch-only.
 extends Node3D
 
@@ -34,6 +39,7 @@ const BRIDGE_EVENT_META := &"iosis_3d_bridge"
 @onready var _main: Node = $Main
 @onready var _board_mirror: BoardMirror = $BoardMirror
 @onready var _unit_mirror: UnitMirror = $UnitMirror
+@onready var _overlay_mirror: OverlayMirror = $OverlayMirror
 @onready var _overlays: BoardOverlays = $BoardOverlays
 @onready var _rig: Node3D = $CameraRig
 @onready var _camera: Camera3D = $CameraRig/Pitch/Camera
@@ -66,11 +72,19 @@ func _ready() -> void:
 	else:
 		_setup_pip()
 		get_viewport().size_changed.connect(_position_pip)
+		# The 3D pick IS the pointer (#222): HoverPresenter reads it instead of the
+		# hidden viewport's mouse, so hover works for every cell — not just the ones
+		# the hidden camera happens to show. flat(NO_CELL) == GridUtils.NO_CELL.
+		game.hover_presenter.pointer_source = func() -> Vector2i: return BoardSpace.flat(_pointer_cell)
 		_help.text = "Battle3D (stage 4b, playable)  |  LMB act  |  RMB cancel  |  UI in the corner PiP  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset"
 	_base_help = _help.text
 	_board_mirror.board = $Board
 	_unit_mirror.units_root = game.units_root
+	_overlay_mirror.game = game
+	_overlay_mirror.overlays = _overlays
+	_overlay_mirror.unit_mirror = _unit_mirror
 	game.turn_manager.turn_started.connect(_on_turn_started)
+	game.scenario_manager.board_loaded.connect(_on_board_loaded)
 	if auto_play:
 		_start.call_deferred()
 
@@ -86,9 +100,18 @@ func _start() -> void:
 
 
 func load_mission(path: String) -> void:
-	game.mission_controller.begin_mission(path)
+	game.mission_controller.begin_mission(path)  # board_loaded does the rest
+
+
+# Every board swap lands here via ScenarioManager.board_loaded (#222): mission load,
+# Load Game (any mission), F2/Restart, Mission Select, sandbox. Rebuild the mirror
+# world and drop pointer state aimed at the dead board — _update_pointer's dedup
+# would otherwise eat the first repaint on a same-coordinate cell.
+func _on_board_loaded() -> void:
 	rebuild()
 	_fit_camera()
+	_pointer_cell = BoardSpace.NO_CELL
+	_overlays.clear_all()
 
 
 func rebuild() -> void:
@@ -183,7 +206,6 @@ func _update_pointer(screen_pos: Vector2) -> void:
 		_overlays.clear(BoardOverlays.Layer.HOVER)
 		return
 	_overlays.set_cells(BoardOverlays.Layer.HOVER, [cell])
-	_push_motion(_cell_view_pos(_flat(cell)))
 	_diag("pointer %s" % cell)
 
 
@@ -199,12 +221,12 @@ func _click_pointer_cell() -> void:
 	if game._board_locked_for_player():
 		_diag("LMB refused: board locked (state %d)" % game.game_state)
 		return
-	var cell := _flat(_pointer_cell)
+	var cell := BoardSpace.flat(_pointer_cell)
 	# The pushed position maps back to a cell through the LIVE 2D camera transform
 	# (game.gd:192), so the hidden camera must be showing the cell first. Side
 	# effect, by design: the PiP recenters on every 3D click the game can act on.
 	var cam: CameraController = game.camera_controller
-	cam.snap_to_position(_cell_world_2d(cell))
+	cam.snap_to_position(GridUtils.cell_world(game.grid, cell))
 	var view_pos := _cell_view_pos(cell)
 	_push_motion(view_pos)
 	_push_click(MOUSE_BUTTON_LEFT, view_pos)
@@ -213,27 +235,13 @@ func _click_pointer_cell() -> void:
 
 
 func _pick(screen_pos: Vector2) -> Vector3i:
-	return BoardPicker.pick_cell(
-		_camera.project_ray_origin(screen_pos),
-		_camera.project_ray_normal(screen_pos),
-		_tops
-	)
-
-
-func _flat(cell: Vector3i) -> Vector2i:
-	return Vector2i(cell.x, cell.z)  # boards are flat; the mirror paints (x, 0, y)
-
-
-# A cell's center in the 2D game's canvas (world) coordinates.
-func _cell_world_2d(cell: Vector2i) -> Vector2:
-	var grid: TileMapLayer = game.grid
-	return grid.to_global(grid.map_to_local(cell))
+	return BoardPicker.pick_at(_camera, screen_pos, _tops)
 
 
 # A cell's center in GameView's viewport coordinates — the space pushed events use.
 func _cell_view_pos(cell: Vector2i) -> Vector2:
 	var canvas: Transform2D = _game_view.get_canvas_transform()
-	return canvas * _cell_world_2d(cell)
+	return canvas * GridUtils.cell_world(game.grid, cell)
 
 
 func _push_motion(view_pos: Vector2) -> void:

--- a/Scenes/LookDev/cell_picker_demo.gd
+++ b/Scenes/LookDev/cell_picker_demo.gd
@@ -19,8 +19,7 @@ func _ready() -> void:
 
 func _process(_delta: float) -> void:
 	var mouse := get_viewport().get_mouse_position()
-	var cell := BoardPicker.pick_cell(
-		_camera.project_ray_origin(mouse), _camera.project_ray_normal(mouse), _tops)
+	var cell := BoardPicker.pick_at(_camera, mouse, _tops)
 	if cell == BoardSpace.NO_CELL:
 		_overlays.clear(BoardOverlays.Layer.HOVER)
 		_readout.text = ""

--- a/Scenes/LookDev/unit_walk_demo.gd
+++ b/Scenes/LookDev/unit_walk_demo.gd
@@ -56,9 +56,7 @@ func _unhandled_input(event: InputEvent) -> void:
 	var click := event as InputEventMouseButton
 	if click == null or not click.pressed or click.button_index != MOUSE_BUTTON_LEFT:
 		return
-	var cell := BoardPicker.pick_cell(
-			_camera.project_ray_origin(click.position),
-			_camera.project_ray_normal(click.position), _tops)
+	var cell := BoardPicker.pick_at(_camera, click.position, _tops)
 	if cell == BoardSpace.NO_CELL:
 		return
 	var clicked_unit := _unit_at(cell)
@@ -96,7 +94,7 @@ static func ramp_exits_from(board: GridMap, ramp_item: int) -> Dictionary[Vector
 	for cell in board.get_used_cells():
 		if board.get_cell_item(cell) != ramp_item:
 			continue
-		var column := Vector2i(cell.x, cell.z)
+		var column := BoardSpace.flat(cell)
 		var basis := board.get_basis_with_orthogonal_index(board.get_cell_item_orientation(cell))
 		var high_dir := basis * Vector3(0, 0, -1)
 		var high_step := Vector2i(roundi(high_dir.x), roundi(high_dir.z))
@@ -109,8 +107,8 @@ static func ramp_exits_from(board: GridMap, ramp_item: int) -> Dictionary[Vector
 # high- and low-side neighbors.
 static func find_path(from_cell: Vector3i, to_cell: Vector3i, tops: Dictionary[Vector2i, int],
 		blocked: Dictionary[Vector2i, bool], ramp_exits: Dictionary[Vector2i, Array]) -> Array[Vector3i]:
-	var from_col := Vector2i(from_cell.x, from_cell.z)
-	var to_col := Vector2i(to_cell.x, to_cell.z)
+	var from_col := BoardSpace.flat(from_cell)
+	var to_col := BoardSpace.flat(to_cell)
 	if not tops.has(from_col) or not tops.has(to_col):
 		return []
 	if blocked.has(to_col):
@@ -145,7 +143,7 @@ static func find_path(from_cell: Vector3i, to_cell: Vector3i, tops: Dictionary[V
 # Bounded reachability under the same ruling — the MOVE fill's demo data source.
 static func find_reachable(from_cell: Vector3i, max_steps: int, tops: Dictionary[Vector2i, int],
 		blocked: Dictionary[Vector2i, bool], ramp_exits: Dictionary[Vector2i, Array]) -> Array[Vector3i]:
-	var from_col := Vector2i(from_cell.x, from_cell.z)
+	var from_col := BoardSpace.flat(from_cell)
 	if not tops.has(from_col):
 		return []
 	var depth: Dictionary[Vector2i, int] = {from_col: 0}
@@ -203,7 +201,7 @@ func _spawn_cast() -> void:
 # below the flat convention (dev feel-check 2026-08-12: units floated over slopes).
 func _surface_point(cell: Vector3i) -> Vector3:
 	var point := BoardSpace.standing_point(cell)
-	if _ramp_exits.has(Vector2i(cell.x, cell.z)):
+	if _ramp_exits.has(BoardSpace.flat(cell)):
 		point.y -= BoardSpace.CELL_SIZE * 0.5
 	return point
 
@@ -215,7 +213,7 @@ func _top_cell(column: Vector2i) -> Vector3i:
 
 func _unit_at(cell: Vector3i) -> UnitSprite3D:
 	for unit in _units:
-		if Vector2i(unit.cell.x, unit.cell.z) == Vector2i(cell.x, cell.z):
+		if BoardSpace.flat(unit.cell) == BoardSpace.flat(cell):
 			return unit
 	return null
 
@@ -245,7 +243,7 @@ func _blocked_for(mover: UnitSprite3D) -> Dictionary[Vector2i, bool]:
 	var blocked: Dictionary[Vector2i, bool] = {}
 	for unit in _units:
 		if unit != mover:
-			blocked[Vector2i(unit.cell.x, unit.cell.z)] = true
+			blocked[BoardSpace.flat(unit.cell)] = true
 	return blocked
 
 
@@ -256,7 +254,7 @@ func _refresh_selection_overlays() -> void:
 	_overlays.set_cells(BoardOverlays.Layer.MOVE, find_reachable(
 			_selected.cell, MOVE_RANGE_CAP, _tops, _blocked_for(_selected), _ramp_exits))
 	var ring: Array[Vector3i] = []
-	var center := Vector2i(_selected.cell.x, _selected.cell.z)
+	var center := BoardSpace.flat(_selected.cell)
 	for dx in range(-DEMO_ATTACK_RANGE, DEMO_ATTACK_RANGE + 1):
 		for dz in range(-DEMO_ATTACK_RANGE, DEMO_ATTACK_RANGE + 1):
 			var col := center + Vector2i(dx, dz)

--- a/game.gd
+++ b/game.gd
@@ -809,6 +809,7 @@ func spawn_sandbox() -> void:
 	scenario_manager.clear_board()
 	scenario_manager.last_loaded_path = ""
 	TestBoard.spawn(self)
+	scenario_manager.board_loaded.emit()  # the one board build outside apply_scenario (#222)
 
 # Returns null when the cell can't take a unit. NB: UnitFactory.create_unit already instantiated
 # the node, so every refusal path has to free it — an un-parented Unit is an orphan nothing else

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Iosis"
-config/version="0.13.0"
+config/version="0.14.0"
 run/main_scene="uid://cxiu0yvwwxlgo"
 config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"

--- a/tests/presentation/test_board_overlays.gd
+++ b/tests/presentation/test_board_overlays.gd
@@ -1,9 +1,9 @@
-# BoardOverlays (#213): the layer table's completeness (law-style), set_cells'
-# replace semantics (idempotent, no accumulation), the mask contract between fill
-# decals and UnitSprite3D render layers (the drift test), the hover bracket, the
-# ruling-respecting reachable set, and the demo wire in the real scene. Colors,
-# sorts and bracket proportions are feel values — asserted present, never pinned
-# to numbers.
+# BoardOverlays (#213 / #222): the layer table's completeness (law-style), the
+# unshaded ruling on every quad and billboard (the dev's markup-is-not-terrain
+# call), set_cells/set_markers replace semantics (idempotent, no accumulation),
+# the render-layer mask contract, the hover bracket, the ruling-respecting
+# reachable set, and the demo wire in the real scene. Colors, sorts, lifts and
+# bracket proportions are feel values — asserted present, never pinned to numbers.
 extends GdUnitTestSuite
 
 const SCENE_PATH := "res://Scenes/LookDev/LookDev.tscn"
@@ -36,18 +36,42 @@ func test_every_layer_is_declared_in_the_table() -> void:
 		assert_bool(spec.has("color") and spec.has("sort") and spec.has("kind")).is_true()
 
 
-func test_fill_decals_never_paint_the_unit_render_layer() -> void:
+func test_every_fill_and_marker_material_is_unshaded() -> void:
+	# The dev's ruling (#214/#222): gameplay markup must never read as terrain, so
+	# every quad is UNSHADED and every billboard unshaded — lighting cannot touch it.
+	var overlays := _overlays()
+	overlays.set_cells(BoardOverlays.Layer.MOVE, [Vector3i(2, 0, 2)])
+	overlays.set_markers(BoardOverlays.Layer.TERRAIN,
+			[{"pos": Vector3(2.5, 1.0, 2.5), "texture": GridUtils.ERROR_ICON, "modulate": Color.WHITE}])
+	overlays.set_markers(BoardOverlays.Layer.ICONS,
+			[{"pos": Vector3(2.5, 1.0, 2.5), "texture": GridUtils.ERROR_ICON, "modulate": Color.WHITE}])
+	var quads := 0
+	var billboards := 0
+	for child in overlays.get_children():
+		if child is Sprite3D:
+			billboards += 1
+			assert_bool((child as Sprite3D).shaded).is_false()
+			continue
+		var quad := child as MeshInstance3D
+		if quad != null and quad.material_override is StandardMaterial3D:
+			quads += 1
+			var material := quad.material_override as StandardMaterial3D
+			assert_int(material.shading_mode).is_equal(BaseMaterial3D.SHADING_MODE_UNSHADED)
+	assert_bool(quads > 0 and billboards > 0).is_true()
+
+
+func test_fill_quads_never_render_on_the_unit_layer() -> void:
 	# The drift test: either side moving its layer bit reds this.
 	var overlays := _overlays()
 	overlays.set_cells(BoardOverlays.Layer.MOVE, [Vector3i(2, 0, 2)])
 	var sprite: UnitSprite3D = auto_free(UnitSprite3D.new())
-	var decal_seen := false
+	var quad_seen := false
 	for child in overlays.get_children():
-		var decal := child as Decal
-		if decal != null and decal.visible:
-			decal_seen = true
-			assert_int(decal.cull_mask & sprite.layers).is_equal(0)
-	assert_bool(decal_seen).is_true()
+		var quad := child as MeshInstance3D
+		if quad != null and quad.visible and quad.material_override is StandardMaterial3D:
+			quad_seen = true
+			assert_int(int(quad.layers) & int(sprite.layers)).is_equal(0)
+	assert_bool(quad_seen).is_true()
 
 
 # --- set_cells semantics -----------------------------------------------------------
@@ -61,9 +85,57 @@ func test_set_cells_places_tinted_fills_at_the_cells() -> void:
 	assert_that(overlays.cells_of(BoardOverlays.Layer.MOVE)).is_equal(cells)
 	var expected_color: Color = BoardOverlays.LAYERS[BoardOverlays.Layer.MOVE]["color"]
 	for child in overlays.get_children():
-		var decal := child as Decal
-		if decal != null and decal.visible:
-			assert_that(decal.modulate).is_equal(expected_color)
+		var quad := child as MeshInstance3D
+		if quad != null and quad.visible and quad.material_override is StandardMaterial3D:
+			assert_that((quad.material_override as StandardMaterial3D).albedo_color).is_equal(expected_color)
+
+
+func test_set_markers_replaces_wholesale_and_carries_the_variant() -> void:
+	var overlays := _overlays()
+	var arrow := GridUtils.ERROR_ICON
+	var first: Array[Dictionary] = [
+		{"pos": Vector3(2.5, 1.0, 2.5), "texture": arrow, "modulate": Color(1, 0.25, 0.25, 0.85)},
+		{"pos": Vector3(3.5, 1.0, 2.5), "texture": arrow, "modulate": Color.WHITE},
+	]
+	overlays.set_markers(BoardOverlays.Layer.PATH_ARROWS, first)
+	assert_int(overlays.marker_count(BoardOverlays.Layer.PATH_ARROWS)).is_equal(2)
+	assert_that(overlays.markers_of(BoardOverlays.Layer.PATH_ARROWS)).is_equal(first)
+	# The pool re-tints and re-textures on replace — a shrunk set hides extras, not leaks them.
+	var second: Array[Dictionary] = [
+		{"pos": Vector3(5.5, 1.0, 5.5), "texture": arrow, "modulate": Color(0.4, 1, 0.45, 0.9)},
+	]
+	overlays.set_markers(BoardOverlays.Layer.PATH_ARROWS, second)
+	assert_int(overlays.marker_count(BoardOverlays.Layer.PATH_ARROWS)).is_equal(1)
+	var tinted := 0
+	for child in overlays.get_children():
+		var quad := child as MeshInstance3D
+		if quad != null and quad.visible and quad.material_override is StandardMaterial3D:
+			var material := quad.material_override as StandardMaterial3D
+			if material.albedo_texture == arrow:
+				tinted += 1
+				assert_that(material.albedo_color).is_equal(Color(0.4, 1, 0.45, 0.9))
+	assert_int(tinted).is_equal(1)
+
+
+func test_set_layer_modulate_recolors_a_fill_pool_live() -> void:
+	# The heal-green reach / aim pulse channel: the 2D layer's live modulate arrives
+	# as a runtime recolor, never a rebuild.
+	var overlays := _overlays()
+	overlays.set_cells(BoardOverlays.Layer.ATTACK, [Vector3i(2, 0, 2), Vector3i(3, 0, 2)])
+	var green := Color(0, 1, 0, 0.5)
+	overlays.set_layer_modulate(BoardOverlays.Layer.ATTACK, green)
+	assert_that(overlays.layer_modulate(BoardOverlays.Layer.ATTACK)).is_equal(green)
+	# A marker created AFTER the recolor joins at the live color, not the table's.
+	overlays.set_cells(BoardOverlays.Layer.ATTACK,
+			[Vector3i(2, 0, 2), Vector3i(3, 0, 2), Vector3i(4, 0, 2), Vector3i(5, 0, 2)])
+	var seen := 0
+	for child in overlays.get_children():
+		var quad := child as MeshInstance3D
+		if quad != null and quad.visible and quad.material_override is StandardMaterial3D:
+			var material := quad.material_override as StandardMaterial3D
+			if material.albedo_color == green:
+				seen += 1
+	assert_int(seen).is_equal(4)
 
 
 func test_a_smaller_set_replaces_the_previous_one() -> void:
@@ -94,10 +166,10 @@ func test_hover_is_a_bracket_mesh_at_the_cell() -> void:
 	var bracket_seen := false
 	for child in overlays.get_children():
 		var bracket := child as MeshInstance3D
-		if bracket != null and bracket.visible:
+		# Brackets are the code-built ArrayMesh; fill/sprite quads share a PlaneMesh.
+		if bracket != null and bracket.visible and bracket.mesh is ArrayMesh:
 			bracket_seen = true
 			assert_that(bracket.position).is_equal(BoardSpace.cell_center(cell))
-			assert_object(bracket.mesh).is_not_null()
 	assert_bool(bracket_seen).is_true()
 
 

--- a/tests/presentation/test_board_picker.gd
+++ b/tests/presentation/test_board_picker.gd
@@ -96,6 +96,18 @@ func test_unproject_round_trip_finds_the_cell_at_every_yaw_snap() -> void:
 			assert_that(picked).is_equal(cell)
 
 
+func test_pick_at_is_the_ray_pair_spelled_once() -> void:
+	# Delegation equality against a live camera — and not vacuously, on a real hit.
+	var board := _scene.get_node("Board") as GridMap
+	var camera := _scene.get_node("CameraRig/Pitch/Camera") as Camera3D
+	var tops := BoardPicker.column_tops_from(board)
+	var screen := camera.unproject_position(BoardSpace.standing_point(Vector3i(8, 2, 3)) + Vector3(0.0, -0.02, 0.0))
+	var direct := BoardPicker.pick_cell(
+			camera.project_ray_origin(screen), camera.project_ray_normal(screen), tops)
+	assert_that(direct).is_not_equal(BoardSpace.NO_CELL)
+	assert_that(BoardPicker.pick_at(camera, screen, tops)).is_equal(direct)
+
+
 func test_occluded_cell_yields_the_blocker_not_the_hidden_cell() -> void:
 	# From the default camera (south, pitched down), ground cell (8, 0, 0) hides behind
 	# the 3-tall hill. Aiming at its standing point must pick a hill cell instead —

--- a/tests/presentation/test_board_space.gd
+++ b/tests/presentation/test_board_space.gd
@@ -33,3 +33,15 @@ func test_negative_coordinates_floor_not_truncate() -> void:
 
 func test_no_cell_sits_outside_any_real_board() -> void:
 	assert_bool(BoardSpace.NO_CELL.y < -100).is_true()
+
+
+func test_flat_and_of_flat_bridge_the_flat_board_convention() -> void:
+	assert_that(BoardSpace.flat(Vector3i(5, 2, 8))).is_equal(Vector2i(5, 8))
+	assert_that(BoardSpace.of_flat(Vector2i(5, 8))).is_equal(Vector3i(5, 0, 8))
+	assert_that(BoardSpace.flat(BoardSpace.of_flat(Vector2i(-3, 7)))).is_equal(Vector2i(-3, 7))
+
+
+func test_flat_maps_the_no_cell_sentinel_onto_the_2d_one() -> void:
+	# The injected pointer source hands HoverPresenter flat(_pointer_cell) raw — a 3D
+	# miss must read as the 2D "no cell" by VALUE, never as a real coordinate.
+	assert_that(BoardSpace.flat(BoardSpace.NO_CELL)).is_equal(GridUtils.NO_CELL)

--- a/tests/presentation/test_input_bridge.gd
+++ b/tests/presentation/test_input_bridge.gd
@@ -11,6 +11,7 @@ extends GdUnitTestSuite
 
 const SCENE_PATH := "res://Scenes/Battle3D/Battle3D.tscn"
 const PROLOG := "res://Scenarios/missions/Prolog.tres"
+const LEVEL_1 := "res://Scenarios/missions/Level_1.tres"
 
 var _scene: Node3D
 var _game: Node2D
@@ -204,6 +205,64 @@ func test_3d_hover_drives_the_real_hover_presenter() -> void:
 	assert_that(_game.hover_presenter.last_hovered_cell).is_equal(cell)
 	assert_bool(seen.has(cell)).is_true()
 	assert_that(_overlays.cells_of(BoardOverlays.Layer.HOVER)).is_equal([Vector3i(cell.x, 0, cell.y)])
+
+
+func test_hover_reaches_cells_the_hidden_camera_cannot_see() -> void:
+	# The 4b gap made native (#222): the old mechanism pushed a synthetic motion at
+	# the cell's mapped viewport position, so any cell outside the hidden camera's
+	# window was silently dropped. The injected pointer source has no window.
+	var grid: TileMapLayer = _game.grid
+	var far: Vector2i = grid.get_used_rect().position   # the corner the pinned camera never shows
+	var near := _pickable_player_unit()
+	_parse_motion(_screen_of(near.movement.cell))   # park elsewhere first (cross-case Input leak)
+	await _pump()
+	var seen: Array[Vector2i] = []
+	_game.hover_presenter.hovered_cell_changed.connect(func(c: Vector2i) -> void: seen.append(c))
+
+	_parse_motion(_screen_of(far))
+	await _pump()
+
+	assert_that(_game.hover_presenter.last_hovered_cell).is_equal(far)
+	assert_bool(seen.has(far)).is_true()
+	assert_that(_overlays.cells_of(BoardOverlays.Layer.HOVER)).is_equal([BoardSpace.of_flat(far)])
+
+
+# --- board_loaded (#222) ---------------------------------------------------------------
+
+func test_a_board_swap_rebuilds_the_mirror_through_the_load_funnel() -> void:
+	# Load Game / Mission Select from ANOTHER mission is the real failure this seam
+	# closes: turn_started never fires on menu arrivals (#144), so before #222 the
+	# mirror, picker and pointer state stayed aimed at the dead board.
+	_scene._pointer_cell = Vector3i(0, 0, 0)   # stale pointer state aimed at Prolog
+	_overlays.set_cells(BoardOverlays.Layer.MOVE, [Vector3i(0, 0, 0)])
+	_game.mission_controller.begin_mission(LEVEL_1)
+	await await_idle_frame()   # the swap's clear_board queue_frees the old roster
+	await await_idle_frame()
+	var board: GridMap = _scene.get_node("Board")
+	var mirrored: Array[Vector3i] = []
+	mirrored.assign(board.get_used_cells())
+	mirrored.sort()
+	var expected: Array[Vector3i] = []
+	for cell: Vector2i in _game.grid.get_used_cells():
+		expected.append(BoardSpace.of_flat(cell))
+	expected.sort()
+	assert_that(mirrored).is_equal(expected)   # the 3D board IS the new 2D board
+	assert_that(_scene._tops).is_equal(BoardPicker.column_tops_from(board))
+	assert_that(_scene._pointer_cell).is_equal(BoardSpace.NO_CELL)
+	assert_int(_overlays.marker_count(BoardOverlays.Layer.MOVE)).is_equal(0)
+
+
+func test_spawn_sandbox_emits_the_same_rebuild() -> void:
+	# The one board build outside apply_scenario — reachable from the 3D view via the
+	# hidden Mission Select's Sandbox row, so it must speak the same signal.
+	_scene._pointer_cell = Vector3i(0, 0, 0)
+	_overlays.set_cells(BoardOverlays.Layer.MOVE, [Vector3i(0, 0, 0)])
+	_game.spawn_sandbox()
+	await await_idle_frame()
+	await await_idle_frame()
+	assert_that(_scene._pointer_cell).is_equal(BoardSpace.NO_CELL)
+	assert_int(_overlays.marker_count(BoardOverlays.Layer.MOVE)).is_equal(0)
+	assert_that(_scene._tops).is_equal(BoardPicker.column_tops_from(_scene.get_node("Board")))
 
 
 # --- The PiP ---------------------------------------------------------------------------

--- a/tests/presentation/test_overlay_mirror.gd
+++ b/tests/presentation/test_overlay_mirror.gd
@@ -1,0 +1,303 @@
+# OverlayMirror (#222): 2D-to-3D overlay parity, driven through the REAL 2D
+# triggers (the documented direct-call idiom — mode entries, hover branches, the
+# production draw seams) and asserted on BoardOverlays/UnitMirror state. Every
+# expectation is hand-derived from the 2D layers (the independent spelling, never
+# the mirror's own helpers). Colors and textures are asserted as COPIES of the 2D
+# values — the parallel-stacks doctrine — not pinned to numbers here.
+#
+# Fixture is the Battle3D scene with a hand-built board, the attack-visuals shape:
+# clear the boot board, spawn known units, drive a trigger, settle two frames
+# (process_frame resumes coroutines BEFORE node _process — one frame is stale).
+extends GdUnitTestSuite
+
+const SCENE_PATH := "res://Scenes/Battle3D/Battle3D.tscn"
+const H := preload("res://tests/support/squad_fixtures.gd")
+
+const PLAYER := Team.Faction.PLAYER
+const ENEMY := Team.Faction.ENEMY
+
+var _scene: Node3D
+var game: Node2D
+var _overlays: BoardOverlays
+var _unit_mirror: UnitMirror
+var _mirror: OverlayMirror
+
+
+func before_test() -> void:
+	get_tree().root.size = Vector2i(1280, 720)
+	var packed := load(SCENE_PATH) as PackedScene
+	_scene = packed.instantiate() as Node3D
+	_scene.auto_play = false
+	get_tree().root.add_child(_scene)
+	await await_idle_frame()
+	game = _scene.game
+	_overlays = _scene.get_node("BoardOverlays") as BoardOverlays
+	_unit_mirror = _scene.get_node("UnitMirror") as UnitMirror
+	_mirror = _scene.get_node("OverlayMirror") as OverlayMirror
+	game.scenario_manager.clear_board()
+	game.game_state = game.GameState.IDLE
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	get_tree().root.remove_child(_scene)
+	_scene.free()
+
+
+func _settle() -> void:
+	await await_idle_frame()
+	await await_idle_frame()
+
+
+func _om() -> OverlayManager:
+	return game.overlay_manager
+
+
+# The independent expectation: the 2D layer's cells, hand-lifted to flat-3D, sorted.
+func _lifted(layer_2d: TileMapLayer) -> Array[Vector3i]:
+	var cells: Array[Vector3i] = []
+	for cell: Vector2i in layer_2d.get_used_cells():
+		cells.append(Vector3i(cell.x, 0, cell.y))
+	cells.sort()
+	return cells
+
+
+func _sorted_3d(layer: BoardOverlays.Layer) -> Array[Vector3i]:
+	var cells := _overlays.cells_of(layer)
+	cells.sort()
+	return cells
+
+
+func _spawn(faction: Team.Faction, cell: Vector2i, overrides: Dictionary = {}) -> Unit:
+	var unit: Unit = game.spawn_unit(H.make_unit_data(overrides, faction), cell)
+	assert_object(unit).is_not_null()   # fixture setup, not the claim under test
+	return unit
+
+
+func _squad_pair() -> Array[Unit]:
+	var leader := _spawn(PLAYER, Vector2i(2, 2))
+	var member := _spawn(PLAYER, Vector2i(5, 2))
+	game.squad_manager.join_squad(member, leader.squad)
+	return [leader, member]
+
+
+# --- Fills -------------------------------------------------------------------------
+
+func test_move_and_invalid_fills_mirror_the_2d_layers() -> void:
+	var pair := _squad_pair()
+	game.enter_move_mode(pair[1])   # the member: cohesion clips its range -> both layers paint
+	await _settle()
+	assert_bool(_om().move_overlay.get_used_cells().size() > 0).is_true()
+	assert_bool(_om().invalidmove_overlay.get_used_cells().size() > 0).is_true()
+	assert_that(_sorted_3d(BoardOverlays.Layer.MOVE)).is_equal(_lifted(_om().move_overlay))
+	assert_that(_sorted_3d(BoardOverlays.Layer.INVALID_MOVE)).is_equal(_lifted(_om().invalidmove_overlay))
+
+
+func test_group_move_paints_green_and_red_in_both_worlds() -> void:
+	# A fast leader and a slow member: far leader destinations are unfollowable, so
+	# the split genuinely paints both colors (an even pair paints no red at all).
+	var leader := _spawn(PLAYER, Vector2i(2, 2), {Stats.Stat.DEX: 40})
+	var member := _spawn(PLAYER, Vector2i(5, 2), {Stats.Stat.DEX: 1})
+	game.squad_manager.join_squad(member, leader.squad)
+	game.enter_group_move_mode(leader)
+	await _settle()
+	assert_bool(_om().move_overlay.get_used_cells().size() > 0).is_true()
+	assert_bool(_om().invalidmove_overlay.get_used_cells().size() > 0).is_true()   # the unfollowable red
+	assert_that(_sorted_3d(BoardOverlays.Layer.MOVE)).is_equal(_lifted(_om().move_overlay))
+	assert_that(_sorted_3d(BoardOverlays.Layer.INVALID_MOVE)).is_equal(_lifted(_om().invalidmove_overlay))
+
+
+func test_attack_reach_mirrors_cells_and_heal_color() -> void:
+	var attacker := _spawn(PLAYER, Vector2i(2, 2))
+	attacker.equipped_weapon = H.make_weapon(3)
+	game.enter_attack_mode(attacker)
+	await _settle()
+	assert_bool(_om().attack_overlay.get_used_cells().size() > 0).is_true()
+	assert_that(_sorted_3d(BoardOverlays.Layer.ATTACK)).is_equal(_lifted(_om().attack_overlay))
+	assert_that(_overlays.layer_modulate(BoardOverlays.Layer.ATTACK)).is_equal(_om().attack_overlay.modulate)
+
+	game.exit_current_mode()
+	attacker.get_equipped_weapon().template.main_attack.heals = true
+	game.enter_attack_mode(attacker)
+	await _settle()
+	# The heal-green arrives as the 2D layer's own modulate, copied — never re-derived.
+	assert_that(_om().attack_overlay.modulate).is_equal(OverlayManager.HEAL_ATTACK_MODULATE)
+	assert_that(_overlays.layer_modulate(BoardOverlays.Layer.ATTACK)).is_equal(OverlayManager.HEAL_ATTACK_MODULATE)
+
+
+func test_target_pick_markers_split_from_the_reach_fill() -> void:
+	var rescuer := _spawn(PLAYER, Vector2i(2, 2))
+	var body := _spawn(PLAYER, Vector2i(3, 2))
+	var candidates: Array[Unit] = [body]
+	game.enter_target_pick_mode(candidates, func(_u: Unit) -> void: pass)
+	await _settle()
+	assert_object(rescuer).is_not_null()
+	# The 2D draws picks on the ATTACK layer with a different atlas tile; the mirror
+	# must split them — markers on TARGET_PICK, nothing on the reach fill.
+	var picks := _overlays.markers_of(BoardOverlays.Layer.TARGET_PICK)
+	assert_int(picks.size()).is_equal(1)
+	assert_that(picks[0]["pos"]).is_equal(Vector3(3.5, 1.0, 2.5))
+	assert_object(picks[0]["texture"]).is_not_null()
+	assert_int(_overlays.cells_of(BoardOverlays.Layer.ATTACK).size()).is_equal(0)
+
+
+func test_aim_footprint_and_tile_pulse_ride_the_poll() -> void:
+	var attacker := _spawn(PLAYER, Vector2i(2, 2))
+	var foe := _spawn(ENEMY, Vector2i(3, 2))
+	attacker.equipped_weapon = H.make_weapon(3)
+	attacker.get_equipped_weapon().template.main_attack.targets = EquippableData.TargetMode.BOTH
+	game.enter_attack_mode(attacker)
+	game.selected_unit = attacker
+	game.hover_presenter._hover_attack_targeting(foe.movement.cell)
+	await _settle()
+	assert_bool(_om().hover_overlay.get_used_cells().size() > 0).is_true()
+	assert_that(_sorted_3d(BoardOverlays.Layer.AIM)).is_equal(_lifted(_om().hover_overlay))
+	# The pulse is the 2D layer's live modulate, polled — no 3D tween. Drive one poll
+	# synchronously so the copy and the read see the same tween frame.
+	assert_object(_om()._tile_pulse).is_not_null()
+	var live: Color = _om().hover_overlay.modulate
+	_mirror._process(0.0)
+	assert_that(_overlays.layer_modulate(BoardOverlays.Layer.AIM)).is_equal(live)
+
+
+# --- Units -------------------------------------------------------------------------
+
+func test_unit_pulse_reaches_the_mirrored_sprite() -> void:
+	var attacker := _spawn(PLAYER, Vector2i(2, 2))
+	var foe := _spawn(ENEMY, Vector2i(3, 2))
+	attacker.equipped_weapon = H.make_weapon(3)
+	game.enter_attack_mode(attacker)
+	game.selected_unit = attacker
+	game.hover_presenter._hover_attack_targeting(foe.movement.cell)
+	await _settle()
+	assert_object(foe.visuals.pulse_tween).is_not_null()   # the 2D pulse is live
+	var live: Color = foe.visuals.sprite.modulate
+	_unit_mirror.reconcile()
+	var sprite: UnitSprite3D = _unit_mirror.sprite_for(foe)
+	assert_that(sprite.modulate).is_equal(live)
+
+
+func test_a_queued_move_mirrors_ghost_hide_and_arrows() -> void:
+	var unit := _spawn(PLAYER, Vector2i(2, 2))
+	game.enter_move_mode(unit)
+	game.selected_unit = unit
+	game._on_left_click(Vector2i(3, 2))   # the documented dispatcher idiom: queue the move
+	await _settle()
+	var move: MoveAction = _om().planned_move_by_unit.get(unit)
+	assert_object(move).is_not_null()
+	# Ghost at the destination, tinted exactly as 2D tints it; the real sprite hides.
+	assert_int(_unit_mirror.ghost_count()).is_equal(1)
+	assert_bool(_unit_mirror.sprite_for(unit).visible).is_false()
+	# One arrow marker per retained preview sprite, same texture REF, same tint.
+	var markers := _overlays.markers_of(BoardOverlays.Layer.PATH_ARROWS)
+	assert_int(markers.size()).is_equal(move.preview.size())
+	assert_bool(markers.size() > 0).is_true()
+	assert_that(markers[0]["texture"]).is_equal(move.preview[0].texture)
+	assert_that(markers[0]["modulate"]).is_equal(move.preview[0].modulate)
+
+
+func test_hover_path_preview_mirrors_while_sweeping() -> void:
+	var unit := _spawn(PLAYER, Vector2i(2, 2))
+	game.enter_move_mode(unit)
+	game.selected_unit = unit
+	game.hover_presenter._hover_choosing_move(Vector2i(4, 2))
+	await _settle()
+	var preview: MoveAction = _om().hover_move_preview
+	assert_object(preview).is_not_null()
+	var markers := _overlays.markers_of(BoardOverlays.Layer.PATH_ARROWS)
+	assert_int(markers.size()).is_equal(preview.preview.size())
+	assert_bool(markers.size() > 0).is_true()
+	var first: Sprite2D = preview.preview[0]
+	assert_that(markers[0]["pos"]).is_equal(Vector3(
+			first.global_position.x / 16.0, 1.0, first.global_position.y / 16.0))
+
+
+func test_knockback_preview_mirrors_trail_and_landing_ghost() -> void:
+	var foe := _spawn(ENEMY, Vector2i(3, 2))
+	var shoves: Array = [{"target": foe, "from": Vector2i(3, 2), "to": Vector2i(5, 2)}]
+	_om().show_knockback_preview(shoves)   # the one draw seam every shove preview crosses
+	await _settle()
+	var trails := _overlays.markers_of(BoardOverlays.Layer.KNOCKBACK)
+	assert_bool(trails.size() > 0).is_true()
+	# The landing ghost joins the unit-mirror pool; the real sprite hides behind it.
+	assert_int(_unit_mirror.ghost_count()).is_equal(1)
+	assert_bool(_unit_mirror.sprite_for(foe).visible).is_false()
+
+
+# --- Squad + board channels --------------------------------------------------------
+
+func test_squad_fills_and_icons_mirror() -> void:
+	var pair := _squad_pair()
+	game.draw_squad_leader_range(pair[0].squad, pair[0].movement.cell)
+	_om().redraw_squad_unit_icons(pair[0].squad)
+	await _settle()
+	assert_bool(_om().squadrange_overlay.get_used_cells().size() > 0).is_true()
+	assert_that(_sorted_3d(BoardOverlays.Layer.SQUAD_RANGE)).is_equal(_lifted(_om().squadrange_overlay))
+	# One billboard per 2D icon (crown + squadmember), textures copied.
+	var icon_count := 0
+	var textures: Array = []
+	for unit in _om().icons_by_unit:
+		for type in _om().icons_by_unit[unit]:
+			icon_count += 1
+			textures.append((_om().icons_by_unit[unit][type] as OverlayIcon).sprite.texture)
+	assert_bool(icon_count >= 2).is_true()
+	var markers := _overlays.markers_of(BoardOverlays.Layer.ICONS)
+	assert_int(markers.size()).is_equal(icon_count)
+	for marker in markers:
+		assert_bool(textures.has(marker["texture"])).is_true()
+
+
+func test_zone_fills_mirror_and_captured_zones_drop() -> void:
+	var zones := {
+		"cap": {"kind": ZoneManager.Kind.CAPTURE, "cells": [Vector2i(1, 1), Vector2i(2, 1)]},
+		"ext": {"kind": ZoneManager.Kind.EXTRACTION, "cells": [Vector2i(6, 6)]},
+	}
+	game.zone_manager.load_dict(zones)
+	_om().redraw_zones(game.zone_manager)
+	await _settle()
+	assert_that(_sorted_3d(BoardOverlays.Layer.ZONE_CAPTURE)) \
+		.is_equal([Vector3i(1, 0, 1), Vector3i(2, 0, 1)] as Array[Vector3i])
+	assert_that(_sorted_3d(BoardOverlays.Layer.ZONE_EXTRACTION)) \
+		.is_equal([Vector3i(6, 0, 6)] as Array[Vector3i])
+	# A captured zone stops glowing in 2D (redraw_zones' hidden list) — and therefore in 3D.
+	_om().redraw_zones(game.zone_manager, ["cap"])
+	await _settle()
+	assert_int(_overlays.cells_of(BoardOverlays.Layer.ZONE_CAPTURE).size()).is_equal(0)
+	assert_int(_overlays.cells_of(BoardOverlays.Layer.ZONE_EXTRACTION).size()).is_equal(1)
+
+
+func test_terrain_icons_mirror_with_the_fire_exception() -> void:
+	game.terrain_states.load_state_dict({
+		Vector2i(1, 1): [Terrain.TileState.FROZEN],
+		Vector2i(2, 1): [Terrain.TileState.BURNING],
+	})
+	_om().redraw_terrain_live(game.terrain_states)
+	await _settle()
+	# FROZEN mirrors as an icon; fire does NOT — BoardMirror's flame + light IS
+	# fire's 3D form (#174: one Fire texture covers BURNING and BLAZE).
+	var fire: Texture2D = OverlayManager.TERRAIN_STATE_ICONS[Terrain.TileState.BURNING]
+	var ice: Texture2D = OverlayManager.TERRAIN_STATE_ICONS[Terrain.TileState.FROZEN]
+	var live := _overlays.markers_of(BoardOverlays.Layer.TERRAIN)
+	assert_int(live.size()).is_equal(1)
+	assert_that(live[0]["texture"]).is_equal(ice)
+	# The PREVIEW keeps its fire: a pending ignite has no 3D flame preview, so the
+	# ghosted icon is the only warning the player gets.
+	_om().show_terrain_preview([{"cell": Vector2i(3, 1), "state": Terrain.TileState.BURNING}])
+	await _settle()
+	var preview := _overlays.markers_of(BoardOverlays.Layer.TERRAIN_PREVIEW)
+	assert_int(preview.size()).is_equal(1)
+	assert_that(preview[0]["texture"]).is_equal(fire)
+	assert_that(preview[0]["modulate"]).is_equal(OverlayManager.TERRAIN_PREVIEW_MODULATE)
+
+
+func test_exit_current_mode_clears_the_mirrored_layers() -> void:
+	var pair := _squad_pair()
+	game.enter_move_mode(pair[1])
+	await _settle()
+	assert_bool(_overlays.cells_of(BoardOverlays.Layer.MOVE).size() > 0).is_true()
+	game.exit_current_mode()
+	await _settle()
+	assert_int(_overlays.cells_of(BoardOverlays.Layer.MOVE).size()).is_equal(0)
+	assert_int(_overlays.cells_of(BoardOverlays.Layer.INVALID_MOVE).size()).is_equal(0)
+	assert_int(_overlays.cells_of(BoardOverlays.Layer.AIM).size()).is_equal(0)
+	assert_int(_overlays.markers_of(BoardOverlays.Layer.TARGET_PICK).size()).is_equal(0)

--- a/tests/presentation/test_overlay_mirror.gd.uid
+++ b/tests/presentation/test_overlay_mirror.gd.uid
@@ -1,0 +1,1 @@
+uid://cekd110u441rx


### PR DESCRIPTION
## Stage 4c, PR 1 of 2: everything you SEE moves to the 3D side (#222, v0.14.0)

Per the approved plan: 4c retires the corner PiP in two never-degrading steps. This is the parity half — the 3D view now shows every overlay channel the 2D board draws, while 4b's PiP input keeps working exactly as before. PR 2 (stacked on this branch) will re-host the UI full-screen over the 3D and delete the synthetic-event machinery.

### The observer (the plan's fork 1, decided)

`OverlayMirror` polls the 2D OverlayManager's **retained** state per frame and value-diffs it into BoardOverlays/UnitMirror — zero trigger-site hooks (the alternative was ~40 sites across 9 files). The 2D game stays the one authority: every texture, tint and animation arrives **by copy** — the aim pulse is literally `hover_overlay.modulate` polled per frame, path arrows arrive with their 14 authored textures and validity tints already picked on the retained preview sprites, and the heal-green reach is the 2D layer's own modulate. Channels mirrored: move/invalid fills, group-move green/red split, attack reach + heal color, target-pick markers (split from reach by atlas tile), aim footprint + tile pulse, squad + squad-range fills, capture/extraction zones (captured-zone hiding inherited), planned + hover path arrows, knockback trails + landing ghosts, selection icons as billboards, terrain state icons (FROZEN/COVER — fire deliberately stays BoardMirror's flame+light, #174), projected ghosts, and unit pulse/highlight/projected-hide.

### Fills went unshaded quads (your ruling, landing)

The old fill Decals structurally **cannot** honor "gameplay markup must not read as terrain" — a Decal's albedo modulates the lit surface. Fills are now pooled `MeshInstance3D` quads: UNSHADED, alpha, nearest, no shadow, lying just above the top face. This also deletes the 512-clustered-decal cap risk outright. Knobs per the tuning rule: `fill_lift`, `lift_step`, `billboard_lift`, `billboard_pixel_size` on BoardOverlays.

### The `board_loaded` seam

ScenarioManager's first signal, emitted at `apply_scenario`'s settle point (after the #189/#134 HUD re-push) plus after `TestBoard.spawn` in `spawn_sandbox` — the one board build outside the funnel. Battle3D rebuilds the mirror board, picker tops, and pointer state on it. This fixes a real 4b bug: loading a save from **another mission** (or Mission Select → other mission) left the 3D mirror and picker aimed at the dead board, because `turn_started` deliberately never fires on menu arrivals (#144).

### Hover injection

`HoverPresenter.pointer_source` (the `board_source` Callable shape): the 3D pick feeds hover directly instead of routing through the hidden camera's window, so **hover now works for every cell** — the 4b far-cell gap is a green test case now. The flat 2D game is untouched (source unset = the old mouse derivation). One behavior note: with the 3D pick as the pointer, board hover inside the corner PiP no longer tracks the PiP-local mouse (PiP **clicks** are unaffected). That surface retires next PR; flagging it for completeness.

### Riding along

The #221 review consolidations: `BoardSpace.flat/of_flat` (~14 hand-spellings), `GridUtils.cell_world` (7 full-form copies), `BoardPicker.pick_at` (3 ray-pairs).

### Verification

- Full suite **1383/1383 green, zero orphans** (+22 cases).
- Every new clause falsified (mutant in → red → restore): 19 mutants — the flat-axis swap, the NO_CELL sentinel drift, the pick_at stub, the PER_PIXEL shading flip, dropped marker tint, dropped modulate-pool walk, late-joiner-at-table-color, both `board_loaded` emits individually, the handler's stale-state resets, the unassigned pointer source, and one per mirror channel (skipped MOVE, swapped MOVE/INVALID, dropped ATTACK modulate, removed atlas split, frozen AIM pulse, removed sprite-flag copy, dropped arrows, knockback parents filtered out, skipped icons, wrong zone layer, removed fire-skip, fills-never-clear).
- Headless can't see: how the quads/billboards/ghosts actually **look**. Your feel-check list: quad-fill look + `fill_lift`/`lift_step`, `billboard_lift` + icon size, ghost readability (shaded, no shadow, 2D tint copied), arrow orientation on the ground quads (if arrows read mirrored/rotated, it's a one-line fix — say the word).

### Merge order (stacked PRs — the #195→#201 lesson)

PR 2 stacks on this branch. **Merge this one first, delete its head branch, and make sure PR 2 retargets `main`** before merging it — merging out of order lands PR 2 into this branch instead of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
