### PR TITLE
HD-2D Stage 4c PR2: the 2D game becomes the UI over the 3D view (#222, v0.15.0)

### DIFF
--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -1,40 +1,33 @@
-# The Battle3D shell (#215/#220 / #176 stage 4a+4b): the hidden-2D-game-as-authority
+# The Battle3D shell (#176 stages 4a-4c): the hidden-2D-game-as-authority
 # architecture. Hosts the REAL Main.tscn — the full sim runs untouched — while
-# BoardMirror/UnitMirror render it as an HD-2D diorama.
+# BoardMirror/UnitMirror/OverlayMirror render it as an HD-2D diorama.
 #
-# Stage 4b makes it PLAYABLE: the bridge translates the 3D pointer to 2D-viewport
-# coordinates and feeds ordinary mouse events through Input.parse_input_event,
-# positioned over the PiP — the OS-driver entry, so the container forwards them
-# into GameView exactly like physical clicks and every gate (the board lock, the
-# modal freeze, menu placement) fires natively; game.gd needs no edits. (Measured:
-# Viewport.push_input dies against handle_input_locally=false — the container is
-# the only live door, and unconsumed events BUBBLE back out to the root.)
-# The 2D UI stays usable as a corner picture-in-picture: the container keeps its
-# native 1280x720 SIZE (so GameView keeps full resolution under stretch) and only
-# the display shrinks via scale; input maps through the container transform.
+# Stage 4c's hosting (#222): the 2D game IS the UI surface. Its container covers
+# the window at native scale with a TRANSPARENT viewport and its board visuals
+# hidden, so every Control — menus, cards, the queue panel, the HUD — draws over
+# the 3D world and takes PHYSICAL clicks natively: real tooltips, real menu
+# placement at the real cursor, the ModalLock click path untouched. Only BOARD
+# clicks need translating, and those skip events entirely — the picker calls
+# game._on_left_click / _on_right_click, which ARE the dispatchers (game.gd's
+# _unhandled_input only derives a cell and calls them). Its own derivation would
+# double-act on the same physical click, so game.board_input_delegated silences
+# it: one bool, the arc's only game.gd input edit. 4b's whole synthetic-event
+# bridge (parse_input_event, the echo tag, the PiP-rect guard) is retired.
 #
-# Stage 4c (PR1) adds parity: OverlayMirror polls the 2D OverlayManager into
-# BoardOverlays/UnitMirror per frame, board swaps rebuild via ScenarioManager's
-# board_loaded signal, and HoverPresenter reads the 3D pick through pointer_source
-# — hover now reaches every cell, not just the hidden camera's window.
+# corner_view is the dev-facing debug toggle (F4): the 4b picture-in-picture, 2D
+# board visuals and all. Board input is container-independent, so 3D play works
+# in either mode.
 #
-# demo_mode = stage-4a behavior: both factions AI, no PiP, watch-only.
+# demo_mode = stage-4a behavior: both factions AI, hidden 2D, watch-only.
 extends Node3D
 
 @export var auto_play := true    # start mission_path on launch (test fixtures set false)
-@export var demo_mode := false   # true = the 4a diorama demo: AI-vs-AI, no PiP, no bridge
+@export var demo_mode := false   # true = the 4a diorama demo: AI-vs-AI, hidden 2D, no bridge
 @export var mission_path := "res://Scenarios/missions/Prolog.tres"
-# PiP knobs (aesthetics get a knob, not a guess):
+# The corner debug view's knobs (aesthetics get a knob, not a guess):
+@export var corner_view := false   # F4 in dev builds; the 4b PiP with the 2D board showing
 @export var pip_scale := 0.35
 @export var pip_margin := Vector2(12.0, 12.0)
-# Bring-up diagnostic (4b): the bridge narrates each link on the help label —
-# pointer pick, click mapping, refusals — so a live run pinpoints which link is
-# dead without a debugger. Untick to silence; drop the mechanism at 4c.
-@export var debug_readout := true
-
-# Stamped on every synthetic event so the bridge never mistakes its own echo for
-# 3D pointing (InputEvent is a Resource — meta survives in-process delivery).
-const BRIDGE_EVENT_META := &"iosis_3d_bridge"
 
 @onready var _main: Node = $Main
 @onready var _board_mirror: BoardMirror = $BoardMirror
@@ -55,7 +48,6 @@ var _pointer_cell: Vector3i = BoardSpace.NO_CELL
 # container SIZE to it (GameView keeps full resolution under stretch) and shrinks
 # only the display via scale.
 var _pip_native: Vector2 = Vector2(1280.0, 720.0)
-var _base_help: String = ""
 
 
 func _ready() -> void:
@@ -70,14 +62,16 @@ func _ready() -> void:
 		_game_container.visible = false
 		_help.text = "Battle3D mirror (demo mode, read-only)  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset"
 	else:
-		_setup_pip()
+		_apply_hosting()
 		get_viewport().size_changed.connect(_position_pip)
 		# The 3D pick IS the pointer (#222): HoverPresenter reads it instead of the
 		# hidden viewport's mouse, so hover works for every cell — not just the ones
 		# the hidden camera happens to show. flat(NO_CELL) == GridUtils.NO_CELL.
 		game.hover_presenter.pointer_source = func() -> Vector2i: return BoardSpace.flat(_pointer_cell)
-		_help.text = "Battle3D (stage 4b, playable)  |  LMB act  |  RMB cancel  |  UI in the corner PiP  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset"
-	_base_help = _help.text
+		# The 2D game stops deriving board clicks from its own viewport mouse — this
+		# node delivers the picked cell instead (see the header).
+		game.board_input_delegated = true
+		_help.text = "Battle3D (stage 4c)  |  LMB act  |  RMB cancel  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset  |  F4 corner view"
 	_board_mirror.board = $Board
 	_unit_mirror.units_root = game.units_root
 	_overlay_mirror.game = game
@@ -130,19 +124,64 @@ func _fit_camera() -> void:
 	_rig.set_zoom(maxf(float(rect.size.x), float(rect.size.y)) * 1.05)
 
 
-# --- The PiP (stage 4b) --------------------------------------------------------------
+# --- Hosting the 2D game (stage 4c) ---------------------------------------------------
 
-func _setup_pip() -> void:
+# All of this is RUNTIME, never authored into Main.tscn: the flat 2D game is a
+# shipping target of its own and must open exactly as it always has (#176's
+# presentation-effects ruling).
+func _apply_hosting() -> void:
 	_game_container.visible = true
+	if corner_view:
+		_setup_corner()
+	else:
+		_setup_fullscreen()
+
+
+# The real hosting: the 2D game covers the window at native scale over a
+# transparent viewport, with its board visuals hidden — so what shows through is
+# the 3D world with the 2D UI on top, and Controls take physical clicks directly.
+func _setup_fullscreen() -> void:
+	_game_container.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_game_container.scale = Vector2.ONE
+	_game_view.transparent_bg = true
+	_set_board_visible(false)
+
+
+# The 4b picture-in-picture, kept as a dev debug view: the 2D board renders again,
+# shrunk into the corner. The container keeps its native SIZE (GameView keeps full
+# resolution under stretch) and only the display shrinks via scale.
+func _setup_corner() -> void:
 	_game_container.set_anchors_and_offsets_preset(Control.PRESET_TOP_LEFT)
 	_game_container.size = _pip_native
 	_game_container.scale = Vector2(pip_scale, pip_scale)
+	_game_view.transparent_bg = false
+	_set_board_visible(true)
 	_position_pip()
 
 
 func _position_pip() -> void:
+	if not corner_view:
+		return
 	var view: Vector2 = get_viewport().get_visible_rect().size
 	_game_container.position = view - _pip_native * pip_scale - pip_margin
+
+
+# The board-visual set, hidden as a unit so the 2D layer reads as pure UI.
+# MEASURED (#222): `game.visible = false` is NOT the switch — OverlayManager is a
+# plain Node, which breaks CanvasItem visibility propagation to the overlay layers
+# (they stayed drawn), while the CanvasLayer UI went dark with it. Hence per-node.
+# ZoneOverlay and its highlight are skipped: they are authoring-only, owned by
+# set_zone_visibility, and a blanket restore would reveal PATROL zones in play.
+func _set_board_visible(shown: bool) -> void:
+	game.grid.visible = shown
+	game.units_root.visible = shown
+	game.cursor_controller.visible = shown
+	var overlays: OverlayManager = game.overlay_manager
+	for child in overlays.get_children():
+		var item := child as CanvasItem
+		if item == null or item == overlays.zone_overlay or item == overlays.zone_highlight_overlay:
+			continue
+		item.visible = shown
 
 
 # --- The input bridge (stage 4b) -------------------------------------------------------
@@ -161,23 +200,20 @@ func _process(_delta: float) -> void:
 
 
 func _unhandled_input(event: InputEvent) -> void:
-	if demo_mode or not game.can_process():
+	if demo_mode:
 		return
-	var mouse := event as InputEventMouse
-	if mouse == null:
+	# The view toggle sits ABOVE the freeze gate on purpose — it is a dev control,
+	# and dev controls are a layer above ModalLock (#154). This node lives outside
+	# the frozen subtree, so its callbacks run regardless.
+	if DevTools.enabled() and event.is_pressed() and event is InputEventKey \
+			and (event as InputEventKey).keycode == KEY_F4:
+		corner_view = not corner_view
+		_apply_hosting()
 		return
-	# The bridge's own synthetics BUBBLE back here when the game leaves them unconsumed
-	# (measured). Re-reading one as 3D pointing forges a self-sustaining event loop that
-	# never lets a flush drain — the tag is the loop-breaker, not hygiene.
-	if mouse.has_meta(BRIDGE_EVENT_META):
+	if not game.can_process():
 		return
-	# Real events over the PiP belong to the 2D game — the container forwards them
-	# itself, and they too bubble back when unconsumed. Never read them as 3D pointing.
-	# Load-bearing BESIDE the meta tag, not redundant with it: accumulated input can
-	# MERGE a synthetic motion into a pending physical one, which drops the tag — the
-	# rect test still catches the merged event.
-	if _game_container.get_global_rect().has_point(mouse.position):
-		return
+	# UI consumed the event before it reached here (the container forwards physical
+	# clicks into the 2D game natively). What arrives is board pointing.
 	var motion := event as InputEventMouseMotion
 	if motion != null:
 		_update_pointer(motion.position)
@@ -189,12 +225,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		_update_pointer(click.position)  # a click is also a point — robust when no motion preceded it
 		_click_pointer_cell()
 	elif click.button_index == MOUSE_BUTTON_RIGHT:
-		# Cancel is position-blind (game.gd:279 takes no cell), so push at the viewport
-		# center, which ALWAYS forwards — a far-cell hover's mapped position can fall
-		# outside the container rect and would be silently dropped, leaving the player
-		# stuck in a mode with a dead cancel.
-		_push_click(MOUSE_BUTTON_RIGHT, _pip_native * 0.5)
-		_diag("RMB cancel pushed at the viewport center")
+		_cancel()
 
 
 func _update_pointer(screen_pos: Vector2) -> void:
@@ -206,75 +237,39 @@ func _update_pointer(screen_pos: Vector2) -> void:
 		_overlays.clear(BoardOverlays.Layer.HOVER)
 		return
 	_overlays.set_cells(BoardOverlays.Layer.HOVER, [cell])
-	_diag("pointer %s" % cell)
+	# The hidden 2D camera still has one live consumer: the hover card parks itself
+	# by mapping a WORLD position through the 2D canvas transform, so the camera has
+	# to be showing the hovered cell or the card parks against a stale view. Skipped
+	# while the board is locked — an AI turn owns the camera (pan_to/follow).
+	if not game._board_locked_for_player():
+		game.camera_controller.snap_to_position(GridUtils.cell_world(game.grid, BoardSpace.flat(cell)))
 
 
+# game._on_left_click / _on_right_click ARE the dispatchers — game.gd's own
+# _unhandled_input just derives a cell and calls them, and every test in the repo
+# drives them this way (tests/README.md). Delivering the picked cell directly is
+# both simpler and exact: no viewport-mouse round trip to get wrong.
 func _click_pointer_cell() -> void:
 	if _pointer_cell == BoardSpace.NO_CELL:
-		_diag("LMB ignored: no cell under the pointer")
 		return
-	# The game refuses clicks while the board is locked (AI turn / mission over / menu
-	# — game.gd's one predicate; read it, don't re-derive it). Without this, a refused
-	# click would still yank the hidden camera off the AI's pan_to/follow. It also
-	# covers the MENU case the can_process() gate above cannot: Mission Select opts
-	# OUT of the modal lock deliberately, so the game is unfrozen behind it.
+	# The game refuses clicks while the board is locked (AI turn / mission over /
+	# menu — game.gd's one predicate; read it, don't re-derive it). Calling the
+	# dispatcher directly bypasses game.gd's own copy of this gate, so it moves here
+	# rather than disappearing. It also covers the MENU case the can_process() gate
+	# cannot: Mission Select opts OUT of the modal lock, so the game is unfrozen.
 	if game._board_locked_for_player():
-		_diag("LMB refused: board locked (state %d)" % game.game_state)
 		return
-	var cell := BoardSpace.flat(_pointer_cell)
-	# The pushed position maps back to a cell through the LIVE 2D camera transform
-	# (game.gd:192), so the hidden camera must be showing the cell first. Side
-	# effect, by design: the PiP recenters on every 3D click the game can act on.
-	var cam: CameraController = game.camera_controller
-	cam.snap_to_position(GridUtils.cell_world(game.grid, cell))
-	var view_pos := _cell_view_pos(cell)
-	_push_motion(view_pos)
-	_push_click(MOUSE_BUTTON_LEFT, view_pos)
-	_diag("LMB cell %s -> view %s -> root %s  (state %d)" % [
-		cell, view_pos.round(), (_game_container.get_global_transform() * view_pos).round(), game.game_state])
+	game._on_left_click(BoardSpace.flat(_pointer_cell))
+
+
+func _cancel() -> void:
+	if game._board_locked_for_player():
+		return
+	# Mirrors game.gd's own RMB arm: cancel is position-blind, and DEV_MODE keeps
+	# right-click for the tile brush.
+	if game.game_state != game.GameState.DEV_MODE:
+		game._on_right_click()
 
 
 func _pick(screen_pos: Vector2) -> Vector3i:
 	return BoardPicker.pick_at(_camera, screen_pos, _tops)
-
-
-# A cell's center in GameView's viewport coordinates — the space pushed events use.
-func _cell_view_pos(cell: Vector2i) -> Vector2:
-	var canvas: Transform2D = _game_view.get_canvas_transform()
-	return canvas * GridUtils.cell_world(game.grid, cell)
-
-
-func _push_motion(view_pos: Vector2) -> void:
-	_send_to_game(InputEventMouseMotion.new(), view_pos)
-
-
-func _push_click(button: MouseButton, view_pos: Vector2) -> void:
-	var press := InputEventMouseButton.new()
-	press.button_index = button
-	press.pressed = true
-	press.button_mask = MOUSE_BUTTON_MASK_LEFT if button == MOUSE_BUTTON_LEFT else MOUSE_BUTTON_MASK_RIGHT
-	_send_to_game(press, view_pos)
-	var release := InputEventMouseButton.new()
-	release.button_index = button
-	release.pressed = false
-	_send_to_game(release, view_pos)
-
-
-func _diag(msg: String) -> void:
-	if debug_readout:
-		_help.text = _base_help + "\n[bridge] " + msg
-
-
-# One door, the same one real input uses: OS-level parse, positioned over the PiP,
-# so the container forwards into GameView exactly like a physical click there.
-# Parse only, never flush — this runs INSIDE input dispatch (a re-entrant flush is
-# not safe). The drain loop re-checks its queue, so events parsed during dispatch
-# are delivered by the SAME flush — no frame boundary and no _process between the
-# camera snap and delivery, which is what makes reading the live transform at
-# parse time exact.
-func _send_to_game(ev: InputEventMouse, view_pos: Vector2) -> void:
-	var root_pos: Vector2 = _game_container.get_global_transform() * view_pos
-	ev.position = root_pos
-	ev.global_position = root_pos
-	ev.set_meta(BRIDGE_EVENT_META, true)
-	Input.parse_input_event(ev)

--- a/docs/design/presentation-effects.md
+++ b/docs/design/presentation-effects.md
@@ -2,7 +2,7 @@
 
 **Status: an idea wall plus two locked decisions.** Solicited by the dev on 2026-08-12, the day Stage 0 (#203) passed its GO gate: *"a full thought experiment, all ideas on the wall."* Nothing below the Decisions section is a commitment — it is the candidate pool for #176's stage 5 and beyond, kept so it can't evaporate from chat. The look-dev scene (`Scenes/LookDev/LookDev.tscn`) is the standing playground where any of it gets prototyped before it's real.
 
-**Canon checked through #205 (2026-08-12).**
+**Canon checked through #222 (2026-08-13).**
 
 ---
 
@@ -16,6 +16,15 @@ The HD-2D presentation (#176) is built as its own parallel stack. **The flat-2D 
 - **No formal BoardView interface up front.** The interface direction is right, the up-front project is not: an interface designed before its second implementation exists gets shaped wrong. Stages 1–4 build presentation-neutral seams (cell↔world, picker, facing, overlays), each stage leaving the sim/view boundaries it touches cleaner — by stage 4 the interface exists *de facto* and formalizing it is a rename, not a refactor. (The `HoverPresenter`/`MainActionMenu`/`OrderExecutor` extractions are the precedent: extract when the tangle earns it.)
 - **The trailer beat** — opening on the flat 2D game, then dramatically becoming HD-2D — stays achievable: a capture cut works today; the live version (both stacks reading one sim, crossfade) becomes a small job once stages 1–4 exist.
 - **Elevation in the 2D style (dev ruling, 2026-08-12):** *"a Z level is just a variable"* — 2D spritework can emulate elevation (the FFT/Tactics Ogre lineage proves it: sprite offsets, stacked tile sides, drop shadows), so rules-level elevation (#116) does **not** retire the 2D side. The honest difference is cost, not possibility: the 3D board renders height structurally for free; the 2D board pays an authored-cleverness tax per effect — and with no parity obligation, that tax is optional per feature. *"With a little bit of cleverness, any effect can work in both styles."*
+
+### The 3D view is solo-playable, and the 2D game is its UI (#222, stage 4c, 2026-08-13)
+
+Stage 4b made the 3D view playable by keeping the whole 2D render as a corner picture-in-picture — a declared crutch. 4c retires it. **The hidden 2D game is now the UI surface**: its container covers the window at native scale over a transparent viewport with its board visuals hidden, so every Control draws over the 3D world and takes physical clicks natively (real tooltips, menus placed at the real cursor, the `ModalLock` click path untouched). Consequences worth knowing:
+
+- **Board markup mirrors, it is not reimplemented.** `OverlayMirror` polls `OverlayManager`'s retained state each frame and diffs it into `BoardOverlays`/`UnitMirror` — no trigger-site hooks, and the 2D stays the one authority for every cell set, texture, tint and animation (the aim pulse is its layer modulate, polled). The parallel-stacks doctrine holds: two representations, one declared authority.
+- **Overlays render UNSHADED** (dev ruling): gameplay markup must never read as terrain, which is why fills are unshaded quads rather than Decals — a Decal's albedo modulates the lit surface by construction.
+- **Board clicks skip events entirely.** The picker calls `game._on_left_click` / `_on_right_click` (the dispatchers game.gd's own `_unhandled_input` only feeds), and `game.board_input_delegated` stands the 2D derivation down so one physical click cannot act twice. That bool is the whole arc's only game.gd input edit; unset, the flat 2D game is bit-for-bit unchanged — **all hosting mutations are runtime**, never authored into `Main.tscn`.
+- The corner PiP survives as a **dev debug view** (F4), not a player-facing mode. The launch-time chooser named above is still stage 4d.
 
 ### Conventions the art commission must carry (pending look-dev experiments)
 

--- a/game.gd
+++ b/game.gd
@@ -53,6 +53,10 @@ var game_state: GameState = GameState.IDLE
 # mission ends -- reset game_state, and the board must return to _base_state() so dev mode survives
 # them (2026-08-11: every dev-window Load silently dropped the board to IDLE under an ON toggle).
 var dev_mode_enabled := false
+# A 3D host (#222) delivers picked board cells straight to _on_left_click/_on_right_click,
+# so _unhandled_input's own cell derivation must stand down or the click acts twice. Set by
+# Battle3D at boot; false everywhere else, which is what keeps the flat 2D game untouched.
+var board_input_delegated := false
 var last_clicked_cell: Vector2i = GridUtils.NO_CELL
 # Set once at selection, never re-derived from a cell (#107). Cleared in exit_current_mode, NOT in
 # clear_selection — that runs on every menu PICK, i.e. on the way INTO a mode.
@@ -180,6 +184,14 @@ func _input(event: InputEvent) -> void:
 			_open_pause_menu()
 
 func _unhandled_input(event: InputEvent) -> void:
+	# A 3D host (#222) picks board cells itself and calls _on_left_click/_on_right_click
+	# directly, so this derivation would act a SECOND time on the same physical click --
+	# at whatever cell the hidden 2D camera happens to be showing. Set by Battle3D only;
+	# the flat 2D game never touches it. Deliberately above the dev-brush and SPACE arms:
+	# both are 2D-surface affordances, and the 3D view hides the dev overlay outright.
+	if board_input_delegated:
+		return
+
 	if game_state == GameState.DEV_MODE and dev_overlay != null and dev_overlay.tile_brush.brush_active:
 		if event is InputEventMouseButton or event is InputEventMouseMotion:
 			dev_controller.handle_tile_brush(event)

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Iosis"
-config/version="0.14.0"
+config/version="0.15.0"
 run/main_scene="uid://cxiu0yvwwxlgo"
 config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"

--- a/tests/presentation/test_input_bridge.gd
+++ b/tests/presentation/test_input_bridge.gd
@@ -1,12 +1,15 @@
-# The stage-4b input bridge (#220): 3D clicks/hover drive the REAL game through
-# synthetic input fed to Input.parse_input_event — the OS-driver entry, so the
-# events ride the same pipeline as physical input (root GUI -> the PiP container
-# forwards into GameView -> game.gd:192) and every gate fires natively. These are
-# the repo's first true click-through wire tests: events enter at the top of the
-# pipeline and must survive the whole chain; calling the dispatch directly would
-# test both ends and not the wire. (Viewport.push_input is a dead door against
-# handle_input_locally=false — measured; parse_input_event is what gdUnit's own
-# SceneRunner uses for headless GUI, so the engine behavior is load-bearing there.)
+# The Battle3D input bridge (#220 then #222): physical events enter at the top of
+# the real pipeline (Input.parse_input_event — the OS-driver entry, which is what
+# gdUnit's own SceneRunner uses for headless GUI) and must survive the whole chain.
+# These are the repo's true click-through wire tests: calling the dispatch directly
+# would test both ends and not the wire.
+#
+# Under 4c hosting the chain forks by WHAT was clicked. UI: root -> the full-screen
+# container -> GameView -> the Control, consumed natively. Board: nothing consumes
+# it, so it bubbles back OUT to the root (measured) and this node picks the cell and
+# calls game._on_left_click / _on_right_click. game.board_input_delegated silences
+# the 2D side's own cell derivation — without it the same physical click acts twice,
+# which test_the_delegation_gate_stops_the_2d_board_acting_twice pins.
 extends GdUnitTestSuite
 
 const SCENE_PATH := "res://Scenes/Battle3D/Battle3D.tscn"
@@ -53,20 +56,31 @@ func _live_units() -> Array[Unit]:
 	return live
 
 
-# A player unit whose 3D screen position is clear of the PiP rect (the PiP sits on
-# top of the 3D view by design, so a click there belongs to the PiP, not the board).
+# A player unit the 3D pointer can actually reach: under 4c the 2D game covers the
+# window, so what a board click must dodge is a VISIBLE UI Control (the inspect
+# column, the queue panel), not the retired PiP rect.
 func _pickable_player_unit() -> Unit:
-	var pip: Rect2 = _container.get_global_rect()
 	for unit in _live_units():
 		if unit.get_faction() != Team.Faction.PLAYER:
 			continue
-		if not pip.has_point(_screen_of(unit.movement.cell)):
+		if not _under_ui(_screen_of(unit.movement.cell)):
 			return unit
 	return null
 
 
+func _under_ui(screen_pos: Vector2) -> bool:
+	for node in _game.ui_layer.get_children():
+		var control := node as Control
+		if control == null or not control.is_visible_in_tree():
+			continue
+		if control.mouse_filter != Control.MOUSE_FILTER_IGNORE \
+				and control.get_global_rect().has_point(screen_pos):
+			return true
+	return false
+
+
 func _screen_of(cell: Vector2i) -> Vector2:
-	return _camera3d.unproject_position(BoardSpace.standing_point(Vector3i(cell.x, 0, cell.y)))
+	return _camera3d.unproject_position(BoardSpace.standing_point(BoardSpace.of_flat(cell)))
 
 
 func _parse_motion(screen_pos: Vector2) -> void:
@@ -122,26 +136,33 @@ func test_a_3d_click_selects_the_unit_it_lands_on() -> void:
 	assert_bool(_selected() == unit).is_true()
 
 
-func test_the_bridge_snaps_the_hidden_camera_to_the_clicked_cell() -> void:
+func test_pointing_snaps_the_hidden_camera_to_the_hovered_cell() -> void:
+	# The hidden 2D camera has one live consumer left: the hover card parks itself by
+	# mapping a world position through the 2D canvas transform, so the camera must be
+	# showing whatever the 3D pointer is on. (4b snapped on CLICK because the click's
+	# cell was derived from the viewport mouse; delivery is direct now, so the snap
+	# moved to the pointer write and serves only the card.)
 	var unit := _pickable_player_unit()
 	var cam: CameraController = _game.camera_controller
-	var grid: TileMapLayer = _game.grid
-	var world: Vector2 = grid.to_global(grid.map_to_local(unit.movement.cell))
+	var world: Vector2 = GridUtils.cell_world(_game.grid, unit.movement.cell)
 	# Derive the clamped truth through the same seam, then park the camera far away.
 	cam.snap_to_position(world)
 	var expected: Vector2 = cam.global_position
 	cam.snap_to_position(Vector2(-100000.0, -100000.0))
 	assert_bool(cam.global_position.distance_to(expected) > 1.0).is_true()
 
-	_parse_click(_screen_of(unit.movement.cell))
+	_parse_motion(_screen_of(unit.movement.cell))
 	await _pump()
 	assert_that(cam.global_position).is_equal(expected)
-	assert_bool(_selected() == unit).is_true()
 
 
 # --- The gates -------------------------------------------------------------------------
 
 func test_a_modal_freeze_stops_3d_clicks_cold() -> void:
+	# Picked BEFORE the card opens: a modal is a full-rect Control on the UI layer, so
+	# _pickable_player_unit correctly finds nothing clickable once one is up.
+	var unit := _pickable_player_unit()
+	assert_object(unit).is_not_null()
 	# Open the pause menu through the real wire: ESC parsed at the top of the pipeline.
 	var esc := InputEventKey.new()
 	esc.keycode = KEY_ESCAPE
@@ -152,7 +173,6 @@ func test_a_modal_freeze_stops_3d_clicks_cold() -> void:
 	assert_bool(ModalLock.any_open(get_tree())).is_true()
 	assert_bool(_game.can_process()).is_false()
 
-	var unit := _pickable_player_unit()
 	_parse_click(_screen_of(unit.movement.cell))
 	await _pump()
 	# The sharp clause: a gate that held never let the bridge read the click at all,
@@ -265,49 +285,102 @@ func test_spawn_sandbox_emits_the_same_rebuild() -> void:
 	assert_that(_scene._tops).is_equal(BoardPicker.column_tops_from(_scene.get_node("Board")))
 
 
-# --- The PiP ---------------------------------------------------------------------------
+# --- Hosting the 2D game as the UI layer (#222) ----------------------------------------
 
-func test_the_pip_keeps_native_resolution() -> void:
+func test_the_2d_game_hosts_full_screen_and_transparent() -> void:
+	# The whole mechanism in one place: the container covers the window at NATIVE
+	# scale (so Controls keep their real size and take physical clicks at real
+	# coordinates), the viewport clears transparent so the 3D world shows through,
+	# the board visuals are down, and the 2D side has stood down from board input.
 	assert_bool(_container.visible).is_true()
-	assert_that(Vector2(_game_view.size)).is_equal(Vector2(1280.0, 720.0))
-	assert_that(_container.scale).is_equal(Vector2(_scene.pip_scale, _scene.pip_scale))
-	var view: Vector2 = _scene.get_viewport().get_visible_rect().size
-	var native: Vector2 = _container.custom_minimum_size   # the authored source the PiP reads
-	var expected_pos: Vector2 = view - native * _scene.pip_scale - _scene.pip_margin
-	assert_that(_container.position).is_equal(expected_pos)
+	assert_that(_container.scale).is_equal(Vector2.ONE)
+	assert_that(_container.anchor_right).is_equal(1.0)
+	assert_that(_container.anchor_bottom).is_equal(1.0)
+	assert_that(_container.get_global_rect().size).is_equal(_scene.get_viewport().get_visible_rect().size)
+	assert_bool(_game_view.transparent_bg).is_true()
+	assert_bool(_game.board_input_delegated).is_true()
+	assert_bool((_game.grid as TileMapLayer).is_visible_in_tree()).is_false()
 
 
-func test_the_pip_serves_a_real_button_click() -> void:
+func test_the_board_hide_spares_the_ui_and_the_authoring_layer() -> void:
+	# The probe this mechanism stands on. MEASURED (#222): `game.visible = false` is
+	# NOT the switch — OverlayManager is a plain Node, which breaks CanvasItem
+	# visibility propagation to the overlay layers (they stayed drawn), while the
+	# CanvasLayer UI went dark WITH it. Hence the per-node helper.
+	var unit := _pickable_player_unit()
 	var end_turn: Control = _game.get_node("UILayer/EndTurnButton")
-	end_turn.set_active(true)   # visibility is #189's own tested rule; the claim here is the wire
+	end_turn.set_active(true)   # its own visibility is #189's rule, not this claim's
+	await await_idle_frame()
+
+	assert_bool(unit.visuals.sprite.is_visible_in_tree()).is_false()
+	assert_bool((_game.overlay_manager.move_overlay as TileMapLayer).is_visible_in_tree()).is_false()
+	assert_bool(end_turn.is_visible_in_tree()).is_true()
+
+	_scene._set_board_visible(true)
+	assert_bool((_game.grid as TileMapLayer).is_visible_in_tree()).is_true()
+	# The restore must not reveal the authoring-only zone layer (set_zone_visibility owns it).
+	assert_bool((_game.overlay_manager.zone_overlay as TileMapLayer).visible).is_false()
+
+
+func test_a_ui_click_over_the_3d_board_stays_in_the_ui() -> void:
+	# The payoff: a Control is clicked at its REAL screen rect (identity transform —
+	# no container math), the 2D consumes it, and nothing leaks to the 3D picker.
+	var end_turn: Control = _game.get_node("UILayer/EndTurnButton")
+	end_turn.set_active(true)
 	await await_idle_frame()
 	var presses: Array[bool] = []
 	end_turn.end_turn_requested.connect(func() -> void: presses.append(true))
 
 	var button: Button = end_turn.get_node("Button")
-	var inside: Vector2 = button.get_global_rect().get_center()
-	var root_pos: Vector2 = _container.get_global_transform() * inside
-	_parse_click(root_pos)
+	_parse_click(button.get_global_rect().get_center())
 	await _pump()
 
 	assert_int(presses.size()).is_equal(1)
-	assert_object(_selected()).is_null()   # the PiP consumed it — nothing leaked to the 3D picker
+	assert_object(_selected()).is_null()   # the UI consumed it; the picker never acted
 
 
-func test_a_pip_board_click_stays_in_the_pip() -> void:
-	# A board click on the PiP is UNCONSUMED by the game and bubbles back out to the
-	# root (measured) — the bridge's PiP-rect guard must never re-read it as 3D
-	# pointing, or every PiP board click double-acts as a 3D pick.
+func test_the_delegation_gate_stops_the_2d_board_acting_twice() -> void:
+	# THE gate regression. A board click is unconsumed by the 2D game, so it bubbles
+	# back out to the root and this node picks the cell — but game.gd's own
+	# _unhandled_input saw the SAME physical event first, and its cell derivation
+	# reads the viewport mouse against the hidden 2D camera, which is aimed somewhere
+	# else entirely. Without board_input_delegated the click acts twice, and the 2D's
+	# wrong cell wins because it runs FIRST and consumes the mode.
+	#
+	# Asserted on the QUEUE, never on the end-state selection: a second dispatch would
+	# simply overwrite the selection and the case would read green through the bug.
 	var unit := _pickable_player_unit()
-	var grid: TileMapLayer = _game.grid
-	_game.camera_controller.snap_to_position(grid.to_global(grid.map_to_local(unit.movement.cell)))
-	var view_pos: Vector2 = _scene._cell_view_pos(unit.movement.cell)
-	var root_pos: Vector2 = _container.get_global_transform() * view_pos
-	_parse_click(root_pos)
+	var destination := unit.movement.cell + Vector2i(1, 0)
+	assert_bool(_game.grid.get_cell_tile_data(destination) != null).is_true()   # fixture sanity
+	_game.selected_unit = unit
+	_game.enter_move_mode(unit)
+
+	_parse_click(_screen_of(destination))
 	await _pump()
-	assert_bool(_selected() == unit).is_true()                       # the 2D game acted on it
-	assert_that(_scene._pointer_cell).is_equal(BoardSpace.NO_CELL)   # the bridge never did
-	await await_idle_frame()   # the action menu's deferred _place_panel runs against a live panel
+
+	var move: MoveAction = _game.overlay_manager.planned_move_by_unit.get(unit)
+	assert_object(move).override_failure_message("the 3D click queued no move at all").is_not_null()
+	assert_that(move.destination) \
+		.override_failure_message("the move went to the 2D camera's cell, not the clicked one") \
+		.is_equal(destination)
+
+
+func test_the_corner_debug_view_restores_the_2d_board() -> void:
+	# F4's view, kept for debugging: the 4b geometry with the 2D board drawn again.
+	# Board input stays container-independent (direct cell calls), so play survives it.
+	_scene.corner_view = true
+	_scene._apply_hosting()
+	assert_that(_container.scale).is_equal(Vector2(_scene.pip_scale, _scene.pip_scale))
+	assert_that(Vector2(_game_view.size)).is_equal(Vector2(1280.0, 720.0))
+	assert_bool(_game_view.transparent_bg).is_false()
+	assert_bool((_game.grid as TileMapLayer).is_visible_in_tree()).is_true()
+	var view: Vector2 = _scene.get_viewport().get_visible_rect().size
+	assert_that(_container.position).is_equal(view - _scene._pip_native * _scene.pip_scale - _scene.pip_margin)
+
+	_scene.corner_view = false
+	_scene._apply_hosting()
+	assert_that(_container.scale).is_equal(Vector2.ONE)
+	assert_bool((_game.grid as TileMapLayer).is_visible_in_tree()).is_false()
 
 
 # --- Cancel + driver -------------------------------------------------------------------


### PR DESCRIPTION
## Stage 4c, PR 2 of 2: the PiP is retired — the 2D game becomes the UI (#222, v0.15.0)

**Stacked on PR #223. Merge that one first** (see the merge note at the bottom).

PR 1 made the 3D view show everything. This one makes it the only view you need. The hidden 2D game now covers the window at native scale over a **transparent viewport with its board visuals hidden** — so its Controls draw over the 3D world and take **physical clicks natively**. Menus open at the real cursor, tooltips are real tooltips, the queue-panel drag works, and the whole `ModalLock` click path is untouched, because none of it was rerouted: the 2D UI is still the 2D UI, just full-size with the board switched off underneath it.

### Board clicks stopped being events

4b forged synthetic mouse events because the UI lived in the PiP and needed real clicks at PiP coordinates. That reason is gone, so the machinery is gone with it. The picker now calls `game._on_left_click(cell)` / `_on_right_click()` — which **are** the dispatchers (`game.gd`'s own `_unhandled_input` does nothing but derive a cell and call them, and 30+ tests already drive them exactly this way, per `tests/README.md`).

That leaves one hazard, and it's the whole reason this PR touches `game.gd`: the same physical click still reaches the 2D side first, where its own derivation reads the viewport mouse against the **hidden** camera and lands on a different cell. `game.board_input_delegated` stands that derivation down. One bool, default false, set only by Battle3D — the flat 2D game is bit-for-bit unchanged, and **all hosting mutations are runtime**, never authored into `Main.tscn`.

Deleted: `BRIDGE_EVENT_META` + its echo guard, the PiP-rect guard, `_push_motion`/`_push_click`/`_send_to_game`, `_cell_view_pos`, the snap-on-click pair, the RMB centre push, `debug_readout`/`_diag`, `_setup_pip`. Roughly half the bridge's input section.

### Two measured things worth knowing

- **`game.visible = false` does not work, in both directions.** I expected a one-switch board hide. Measured: `OverlayManager` is a plain `Node`, which breaks CanvasItem visibility propagation — the overlay layers stayed drawn — while the CanvasLayer UI *did* go dark with it, which is the opposite of what you want. So the hide is per-node (`_set_board_visible`), and it deliberately skips the authoring-only zone layers so a restore can't reveal PATROL zones mid-battle. The probe case pins the mechanism that actually won.
- **The camera snap moved from click-time to pointer-time.** Its only surviving consumer is the hover card, which parks itself by mapping a world position through the 2D canvas transform — so the hidden camera has to be showing the hovered cell. It's skipped while the board is locked, so it can't fight the AI's `pan_to`.

### F4: the PiP as a debug view

The corner picture-in-picture is still there behind `DevTools.enabled()`, with the 2D board drawn again — useful for seeing what the sim thinks is happening. Board input is container-independent now, so the 3D stays playable in either mode.

### Verification

- Full suite **1385/1385 green, zero orphans**.
- **Seven falsification mutants**, each reddening its own case: the delegation gate, the overlay-hide loop, the zone-layer exemption, the pointer snap, `transparent_bg`, the corner toggle, and direct delivery.
- The gate case is asserted **on the queued move's destination, never on the end-state selection** — a second dispatch would simply overwrite the selection and the case would read green straight through the bug. (That's the same blindness that made two 4b falsifications survive; worth stating out loud.)
- Headless can't see: the actual compositing of 2D UI over the 3D render. **That's the one thing to look at first** — if the transparency reads wrong, F4 gives you the old view immediately and it's a contained fix.

### Feel-check list

1. UI over the diorama: does the alpha composite cleanly, and does the HUD read against a busy 3D background?
2. Menus/cards at full size over 3D — placement, and the inspect column's left dock.
3. Clicking: does the cell you click in 3D feel like the cell that acts?
4. F4 corner view in and out.

### Merge order (stacked — the #195→#201 lesson)

This branch's base is PR #223's branch. **Merge #223 into main first, delete its head branch, then confirm this PR retargets `main` before merging.** Out of order, this lands in #223's branch instead of main and `main` silently misses v0.15.0.

### Not in this PR (4d)

Camera arbitration / WASD in 3D, the launch-time 2D/3D chooser, hidden-view power reduction, overlay ramp conformance, path arrows on slopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
