### PR TITLE
F4 restores the flat 2D game full screen, not in the corner (#222, v0.16.0)

### DIFF
--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -14,18 +14,28 @@
 # it: one bool, the arc's only game.gd input edit. 4b's whole synthetic-event
 # bridge (parse_input_event, the echo tag, the PiP-rect guard) is retired.
 #
-# corner_view is the dev-facing debug toggle (F4): the 4b picture-in-picture, 2D
-# board visuals and all. Board input is container-independent, so 3D play works
-# in either mode.
+# Three hosting VIEWS, switched live (F4 / Shift+F4 in dev builds). FLAT_2D is the
+# real escape hatch and the embryo of #176's 2D/3D chooser: it does not merely show
+# the 2D board, it hands INPUT BACK — un-delegates board clicks, drops the injected
+# pointer source, silences this node's picker and stops the rig — because a flat 2D
+# game that cannot take its own clicks (or that pans an invisible 3D camera with
+# WASD) is not a playable fallback. CORNER is the 4b picture-in-picture, kept only
+# as a debug view.
 #
 # demo_mode = stage-4a behavior: both factions AI, hidden 2D, watch-only.
 extends Node3D
 
+enum View {
+	HD_2D,    # the 2D game as transparent full-screen UI over the 3D diorama
+	FLAT_2D,  # the flat 2D game, full-screen and opaque; the 3D stands down
+	CORNER,   # dev debug: the 4b PiP, 2D board visuals and all, 3D still driving
+}
+
 @export var auto_play := true    # start mission_path on launch (test fixtures set false)
 @export var demo_mode := false   # true = the 4a diorama demo: AI-vs-AI, hidden 2D, no bridge
 @export var mission_path := "res://Scenarios/missions/Prolog.tres"
+@export var view: View = View.HD_2D
 # The corner debug view's knobs (aesthetics get a knob, not a guess):
-@export var corner_view := false   # F4 in dev builds; the 4b PiP with the 2D board showing
 @export var pip_scale := 0.35
 @export var pip_margin := Vector2(12.0, 12.0)
 
@@ -62,16 +72,12 @@ func _ready() -> void:
 		_game_container.visible = false
 		_help.text = "Battle3D mirror (demo mode, read-only)  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset"
 	else:
+		# _apply_hosting also assigns input ownership: the 3D pick becomes the pointer
+		# source HoverPresenter reads (so hover reaches every cell, not just the ones
+		# the hidden camera shows) and the 2D game stops deriving its own board clicks.
 		_apply_hosting()
 		get_viewport().size_changed.connect(_position_pip)
-		# The 3D pick IS the pointer (#222): HoverPresenter reads it instead of the
-		# hidden viewport's mouse, so hover works for every cell — not just the ones
-		# the hidden camera happens to show. flat(NO_CELL) == GridUtils.NO_CELL.
-		game.hover_presenter.pointer_source = func() -> Vector2i: return BoardSpace.flat(_pointer_cell)
-		# The 2D game stops deriving board clicks from its own viewport mouse — this
-		# node delivers the picked cell instead (see the header).
-		game.board_input_delegated = true
-		_help.text = "Battle3D (stage 4c)  |  LMB act  |  RMB cancel  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset  |  F4 corner view"
+		_help.text = "Battle3D (stage 4c)  |  LMB act  |  RMB cancel  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset  |  F4 flat 2D  |  Shift+F4 corner"
 	_board_mirror.board = $Board
 	_unit_mirror.units_root = game.units_root
 	_overlay_mirror.game = game
@@ -131,10 +137,29 @@ func _fit_camera() -> void:
 # presentation-effects ruling).
 func _apply_hosting() -> void:
 	_game_container.visible = true
-	if corner_view:
-		_setup_corner()
+	match view:
+		View.CORNER:
+			_setup_corner()
+		View.FLAT_2D:
+			_setup_flat_2d()
+		_:
+			_setup_fullscreen()
+	_apply_input_ownership()
+
+
+# WHO owns board input, derived from the view rather than tracked separately.
+# In FLAT_2D the 2D game is the whole game again: it derives its own clicks, hovers
+# off its own mouse, and owns WASD — so the delegation gate, the injected pointer
+# source and the 3D rig all stand down together. Anywhere else the 3D picker drives.
+func _apply_input_ownership() -> void:
+	var flat: bool = view == View.FLAT_2D
+	game.board_input_delegated = not flat
+	if flat:
+		game.hover_presenter.pointer_source = Callable()
+		_pointer_cell = BoardSpace.NO_CELL
+		_overlays.clear(BoardOverlays.Layer.HOVER)
 	else:
-		_setup_fullscreen()
+		game.hover_presenter.pointer_source = func() -> Vector2i: return BoardSpace.flat(_pointer_cell)
 
 
 # The real hosting: the 2D game covers the window at native scale over a
@@ -145,6 +170,15 @@ func _setup_fullscreen() -> void:
 	_game_container.scale = Vector2.ONE
 	_game_view.transparent_bg = true
 	_set_board_visible(false)
+
+
+# The escape hatch: the flat 2D game, full-screen and OPAQUE, board and all. The
+# 3D world is still there, simply covered — nothing tears down, so F4 back is free.
+func _setup_flat_2d() -> void:
+	_game_container.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_game_container.scale = Vector2.ONE
+	_game_view.transparent_bg = false
+	_set_board_visible(true)
 
 
 # The 4b picture-in-picture, kept as a dev debug view: the 2D board renders again,
@@ -160,7 +194,7 @@ func _setup_corner() -> void:
 
 
 func _position_pip() -> void:
-	if not corner_view:
+	if view != View.CORNER:
 		return
 	var view: Vector2 = get_viewport().get_visible_rect().size
 	_game_container.position = view - _pip_native * pip_scale - pip_margin
@@ -194,7 +228,10 @@ func _set_board_visible(shown: bool) -> void:
 # (a modal inside the HIDDEN container) would otherwise freeze the diorama's camera
 # forever — 4a kept the rig alive after the battle ended, and so does demo mode.
 func _process(_delta: float) -> void:
-	var live: bool = demo_mode or game.can_process()
+	# FLAT_2D hands the camera back too: the rig is invisible behind an opaque 2D
+	# viewport, and CameraController's WASD poll is global, so leaving it alive would
+	# pan both cameras at once off one keypress.
+	var live: bool = (demo_mode or game.can_process()) and view != View.FLAT_2D
 	_rig.set_process(live)
 	_rig.set_process_unhandled_input(live)
 
@@ -202,15 +239,20 @@ func _process(_delta: float) -> void:
 func _unhandled_input(event: InputEvent) -> void:
 	if demo_mode:
 		return
-	# The view toggle sits ABOVE the freeze gate on purpose — it is a dev control,
-	# and dev controls are a layer above ModalLock (#154). This node lives outside
-	# the frozen subtree, so its callbacks run regardless.
-	if DevTools.enabled() and event.is_pressed() and event is InputEventKey \
-			and (event as InputEventKey).keycode == KEY_F4:
-		corner_view = not corner_view
+	# The view keys sit ABOVE the freeze gate on purpose — they are dev controls, and
+	# dev controls are a layer above ModalLock (#154). This node lives outside the
+	# frozen subtree, so its callbacks run regardless.
+	var key := event as InputEventKey
+	if DevTools.enabled() and key != null and key.pressed and key.keycode == KEY_F4:
+		if key.shift_pressed:
+			view = View.HD_2D if view == View.CORNER else View.CORNER
+		else:
+			view = View.HD_2D if view == View.FLAT_2D else View.FLAT_2D
 		_apply_hosting()
 		return
-	if not game.can_process():
+	# In FLAT_2D the flat game owns its own clicks — picking here would double-act,
+	# the mirror image of the bug game.board_input_delegated exists to prevent.
+	if view == View.FLAT_2D or not game.can_process():
 		return
 	# UI consumed the event before it reached here (the container forwards physical
 	# clicks into the 2D game natively). What arrives is board pointing.

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Iosis"
-config/version="0.15.0"
+config/version="0.16.0"
 run/main_scene="uid://cxiu0yvwwxlgo"
 config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"

--- a/tests/presentation/test_input_bridge.gd
+++ b/tests/presentation/test_input_bridge.gd
@@ -366,21 +366,69 @@ func test_the_delegation_gate_stops_the_2d_board_acting_twice() -> void:
 
 
 func test_the_corner_debug_view_restores_the_2d_board() -> void:
-	# F4's view, kept for debugging: the 4b geometry with the 2D board drawn again.
-	# Board input stays container-independent (direct cell calls), so play survives it.
-	_scene.corner_view = true
+	# Shift+F4's view, kept for debugging: the 4b geometry with the 2D board drawn
+	# again. Board input stays container-independent (direct cell calls), so the 3D
+	# keeps driving and play survives it.
+	_scene.view = _scene.View.CORNER
 	_scene._apply_hosting()
 	assert_that(_container.scale).is_equal(Vector2(_scene.pip_scale, _scene.pip_scale))
 	assert_that(Vector2(_game_view.size)).is_equal(Vector2(1280.0, 720.0))
 	assert_bool(_game_view.transparent_bg).is_false()
 	assert_bool((_game.grid as TileMapLayer).is_visible_in_tree()).is_true()
-	var view: Vector2 = _scene.get_viewport().get_visible_rect().size
-	assert_that(_container.position).is_equal(view - _scene._pip_native * _scene.pip_scale - _scene.pip_margin)
+	assert_bool(_game.board_input_delegated).is_true()
+	var size: Vector2 = _scene.get_viewport().get_visible_rect().size
+	assert_that(_container.position).is_equal(size - _scene._pip_native * _scene.pip_scale - _scene.pip_margin)
 
-	_scene.corner_view = false
+	_scene.view = _scene.View.HD_2D
 	_scene._apply_hosting()
 	assert_that(_container.scale).is_equal(Vector2.ONE)
 	assert_bool((_game.grid as TileMapLayer).is_visible_in_tree()).is_false()
+
+
+func test_flat_2d_shows_the_whole_board_and_hands_input_back() -> void:
+	# F4's escape hatch, and the point of it: FLAT_2D is not a picture of the 2D game,
+	# it IS the 2D game. Showing the board while the 3D still owned clicks, hover and
+	# WASD would be a fallback you cannot actually play.
+	_scene.view = _scene.View.FLAT_2D
+	_scene._apply_hosting()
+	await await_idle_frame()
+	await await_idle_frame()
+
+	# Full-screen and opaque — the 3D world is covered, not torn down.
+	assert_that(_container.scale).is_equal(Vector2.ONE)
+	assert_that(_container.get_global_rect().size).is_equal(_scene.get_viewport().get_visible_rect().size)
+	assert_bool(_game_view.transparent_bg).is_false()
+	assert_bool((_game.grid as TileMapLayer).is_visible_in_tree()).is_true()
+	# ...and every input owner handed back.
+	assert_bool(_game.board_input_delegated) \
+		.override_failure_message("the flat game still cannot derive its own board clicks").is_false()
+	assert_bool((_game.hover_presenter.pointer_source as Callable).is_valid()) \
+		.override_failure_message("hover still reads the 3D pick, not the real mouse").is_false()
+	assert_bool((_scene.get_node("CameraRig") as Node3D).is_processing()) \
+		.override_failure_message("the hidden 3D rig still pans on WASD alongside the 2D camera").is_false()
+
+	# And back: HD_2D restores 3D ownership, so the toggle is round-trippable.
+	_scene.view = _scene.View.HD_2D
+	_scene._apply_hosting()
+	await await_idle_frame()
+	await await_idle_frame()
+	assert_bool(_game.board_input_delegated).is_true()
+	assert_bool((_game.hover_presenter.pointer_source as Callable).is_valid()).is_true()
+	assert_bool((_scene.get_node("CameraRig") as Node3D).is_processing()).is_true()
+
+
+func test_flat_2d_stops_the_3d_picker_acting_on_the_same_click() -> void:
+	# The mirror image of the delegation gate: with the 2D game deriving its own
+	# clicks again, this node must NOT also pick, or every click acts twice.
+	var unit := _pickable_player_unit()
+	_scene.view = _scene.View.FLAT_2D
+	_scene._apply_hosting()
+	await await_idle_frame()
+
+	_parse_click(_screen_of(unit.movement.cell))
+	await _pump()
+	assert_that(_scene._pointer_cell) \
+		.override_failure_message("the 3D picker read a click the flat game owns").is_equal(BoardSpace.NO_CELL)
 
 
 # --- Cancel + driver -------------------------------------------------------------------


### PR DESCRIPTION
## F4 restores the flat 2D game full screen (#222, v0.16.0)

Your 4c feel-check, item 7: *"the F4 escape hatch does bring the 2D game back — but in its tiny little corner pocket. That's next to useless. Toggle should be for the whole screen."*

Correct, and my miss. I built F4 as a *debug* view (watch what the sim thinks while the 3D runs) and reused 4b's corner PiP for it. What a 2D/3D toggle is actually for is the flat game, playable, at full size — which is #176's launch-time chooser arriving early as a runtime toggle.

### What changed

Hosting is now a three-value `View` instead of a `corner_view` bool:

| View | What it is |
|---|---|
| `HD_2D` | today's default — 2D as transparent full-screen UI over the diorama |
| `FLAT_2D` | **the escape hatch** — flat 2D game, full-screen and opaque, 3D stands down |
| `CORNER` | the 4b PiP, kept for debugging only |

**F4** toggles `HD_2D` ↔ `FLAT_2D`. **Shift+F4** reaches `CORNER`.

### The part that isn't cosmetic

Showing the board is the easy half. `FLAT_2D` has to hand **input** back — all of it — or you get a fallback you can look at but not play. That's `_apply_input_ownership`, derived from the view rather than tracked in a second flag so the two can't disagree:

- `board_input_delegated` **off** → the flat game derives its own board clicks again.
- `pointer_source` **unset** → hover reads the real mouse instead of the 3D pick.
- **this node's picker silenced** → the mirror image of the delegation bug: without it the 3D would pick the same physical click the 2D just acted on, double-acting in the other direction.
- **camera rig stopped** → `CameraController`'s WASD poll is global and doesn't travel through the scene tree, so an invisible rig would otherwise pan alongside the 2D camera off one keypress.

Nothing tears down on the switch — the 3D world is *covered*, not destroyed — so toggling back is instant and free.

### Verification

- Full suite **1387/1387 green** (+2), zero orphans.
- **Four falsification mutants**, each reddening its own named clause: delegation never released, pointer source never released, rig never stopped, picker not silenced. Those four failure messages are the ones you'd actually hit in play ("I'm in 2D and clicking does nothing", "WASD moves two cameras at once"), so they're worth having pinned by name.

### Feel-check

F4 in and out a few times, and confirm the flat game is genuinely playable in `FLAT_2D` — clicks, hover, WASD. If any of those feel dead, one of the four owners above didn't hand back and the failure message will name it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
