### PR TITLE
Fire is no longer swallowed by a body lying in it

### DIFF
--- a/Classes/presentation/BoardMirror.gd
+++ b/Classes/presentation/BoardMirror.gd
@@ -11,7 +11,9 @@ class_name BoardMirror
 # Fire-state cells (BURNING / BLAZE) get a flame billboard + a real OmniLight —
 # the torch recipe, and the dev's "fire casts light" wish. refresh_states() is
 # re-read each turn: a declared v1 approximation (mid-pass ignitions appear at
-# the next turn boundary).
+# the next turn boundary). That cadence is also why a flame that renders WRONG
+# appears to "come back at the end of the turn" — the marker is rebuilt, not the
+# state; nothing here ever frees a marker mid-turn (pinned by test_board_mirror).
 
 # NONE is the one declared skip: an authored tile with no kind still renders
 # ground via FALLBACK_ITEM rather than a hole.
@@ -25,6 +27,13 @@ const KIND_TO_ITEM: Dictionary[Terrain.Kind, int] = {
 }
 const FALLBACK_ITEM := 3  # dirt
 const FLAME_TEXTURE_PATH := "res://Art/LookDev/torch_flame.png"
+
+# Flame knobs (aesthetics get a knob, not a guess). Height and size are the two levers
+# for the reported "a body lying in the fire hides it" case — see _make_fire.
+@export var flame_lift := 0.35
+@export var flame_size := Vector2(0.5, 0.7)
+@export var flame_light_energy := 2.0
+@export var flame_light_range := 4.0
 
 var board: GridMap
 
@@ -67,9 +76,15 @@ func _make_fire(cell: Vector3i) -> Node3D:
 
 	var flame := MeshInstance3D.new()
 	var quad := QuadMesh.new()
-	quad.size = Vector2(0.5, 0.7)
+	quad.size = flame_size
 	var material := StandardMaterial3D.new()
-	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	# DEPTH_PRE_PASS, not plain ALPHA: unit sprites are ALPHA_CUT_OPAQUE_PREPASS, so they
+	# write depth and a pure-alpha flame is drawn afterwards and depth-TESTED against them.
+	# A standing sprite is cut-out air around its feet so the flame showed through; a DOWNED
+	# body is solid coverage at exactly ground level and swallowed it whole (reported in play
+	# 2026-08-14 — the marker was never freed, only hidden). Matching the discipline puts both
+	# in the same per-pixel sort.
+	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA_DEPTH_PRE_PASS
 	material.albedo_color = Color(0, 0, 0, 1)
 	material.albedo_texture = load(FLAME_TEXTURE_PATH) as Texture2D
 	material.emission_enabled = true
@@ -80,14 +95,14 @@ func _make_fire(cell: Vector3i) -> Node3D:
 	material.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST
 	quad.material = material
 	flame.mesh = quad
-	flame.position = Vector3(0, 0.35, 0)
+	flame.position = Vector3(0, flame_lift, 0)
 	flame.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 	root.add_child(flame)
 
 	var light := OmniLight3D.new()
 	light.light_color = Color(1, 0.62, 0.3)
-	light.light_energy = 2.0
-	light.omni_range = 4.0
+	light.light_energy = flame_light_energy
+	light.omni_range = flame_light_range
 	light.position = Vector3(0, 0.6, 0)
 	root.add_child(light)
 	return root

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Iosis"
-config/version="0.17.1"
+config/version="0.17.2"
 run/main_scene="uid://cxiu0yvwwxlgo"
 config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"

--- a/tests/presentation/test_board_mirror.gd
+++ b/tests/presentation/test_board_mirror.gd
@@ -69,6 +69,46 @@ func test_fire_markers_match_the_games_own_state_dict() -> void:
 	assert_bool(expected > 0).is_true()  # Prolog authors BLAZE content; a zero here means the load broke
 
 
+func test_a_unit_going_down_on_fire_does_not_take_the_flame_with_it() -> void:
+	# Reported in play: a unit downed while standing in fire makes that fire vanish for the
+	# rest of the turn, returning at the next turn boundary. This isolates WHICH half is
+	# wrong — the marker being freed, or the marker still existing and being drawn under the
+	# downed sprite (both flame and unit are transparent quads at the same standing point).
+	# A held count means the node is alive and it is a render-order question, not a logic one.
+	_scene.load_mission(PROLOG)
+	await await_idle_frame()
+	var mirror := _scene.get_node("BoardMirror") as BoardMirror
+	var states: Dictionary = _game.terrain_states.to_state_dict()
+	var fire_cell := Vector2i(-9999, -9999)
+	for cell: Vector2i in states.keys():
+		for state in states[cell]:
+			if (state as Terrain.TileState) in Terrain.FIRE_STATES:
+				fire_cell = cell
+				break
+		if fire_cell.x != -9999:
+			break
+	assert_bool(fire_cell.x != -9999).override_failure_message(
+			"Prolog authored no fire; the case is vacuous").is_true()
+
+	var unit: Unit = null
+	for child in _game.units_root.get_children():
+		var candidate := child as Unit
+		if candidate != null:
+			unit = candidate
+			break
+	assert_object(unit).is_not_null()
+	unit.movement.set_cell(fire_cell)   # teleport onto the burning tile
+	await await_idle_frame()
+	var before := mirror.fire_marker_count()
+	assert_int(before).override_failure_message("no flame to lose; the case is vacuous").is_greater(0)
+
+	unit._go_downed(false)
+	await await_idle_frame()
+	await await_idle_frame()
+	assert_int(mirror.fire_marker_count()).override_failure_message(
+			"the flame marker was FREED when the unit went down").is_equal(before)
+
+
 func test_rebuild_tracks_the_authority_after_clear_board() -> void:
 	_scene.load_mission(PROLOG)
 	await await_idle_frame()


### PR DESCRIPTION
Fixes the fire-vanishes-under-a-downed-unit report.

## The probe settles it: this was never a logic bug

`fire_marker_count()` is **unchanged** across the downing. The terrain state is intact, the marker still exists, nothing in the sim or the mirror frees it. The new case in `test_board_mirror.gd` pins that, and it is the one that would catch a genuine logic regression here later.

## What it actually was

A render-sort asymmetry between two things sitting at the same standing point:

- `UnitSprite3D` is `ALPHA_CUT_OPAQUE_PREPASS` — it **writes depth**, so it occludes per-pixel.
- The flame was plain `TRANSPARENCY_ALPHA` — no depth write, drawn *after* the sprites and depth-**tested** against what they wrote.

A **standing** sprite is cut-out air around its feet, so the flame showed through beside the legs. A **downed** body is solid coverage at exactly ground level — right where the flame lives — so it swallowed it whole.

And the "it comes back at the end of the turn" half is `refresh_states` rebuilding every marker at the turn boundary. That cadence was *masking* the symptom, not causing it — which is why the bug looked stateful when it wasn't.

## Fix

`TRANSPARENCY_ALPHA_DEPTH_PRE_PASS` on the flame material, so flame and sprite land in the same per-pixel sort instead of one being a second-class citizen of the other's depth buffer.

`flame_lift`, `flame_size`, `flame_light_energy` and `flame_light_range` are now `@export` knobs — per the tuning rule, and specifically so the flame height can be nudged clear of a body without another round trip through me.

## What I could NOT verify

**Whether it now draws correctly.** Headless cannot see a sort order, so I am not going to claim it looks right — the suite proves the marker survives, and that is all it proves. This one needs your eyes.

If it still reads wrong: `flame_lift` is the first knob to try. The fallback is `ALPHA_SCISSOR` — hard pixel edges, cheapest, matches the sprites exactly, at the cost of the flame's soft glow. Say which way it looks and I will follow it.

Suite **1413/1413**, 0 orphans. v0.17.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
