### PR TITLE
Restore the 3D boot scene, and pin it

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Iosis"
 config/version="0.18.2"
-run/main_scene="uid://cxiu0yvwwxlgo"
+run/main_scene="res://Scenes/Battle3D/Battle3D.tscn"
 config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"
 

--- a/tests/law/test_boot_scene.gd
+++ b/tests/law/test_boot_scene.gd
@@ -1,0 +1,36 @@
+# The boot scene is a LAW here, not a preference: the game ships booting into the 3D view
+# (#176 stage 4d, dev ruling 2026-08-14).
+#
+# WHY THIS EXISTS: nothing else in the suite exercises run/main_scene. Every test
+# instantiates its scenes explicitly, so 1415 green cases were structurally blind to it --
+# and the setting was SILENTLY REVERTED by a merge-conflict resolution the same day it
+# landed. config/version sits on the adjacent line in [application], so resolving a version
+# collision dragged this one back with it; everything merged green and the game quietly
+# booted into 2D again.
+extends GdUnitTestSuite
+
+const BOOT_SCENE := "res://Scenes/Battle3D/Battle3D.tscn"
+
+
+func test_the_game_boots_into_the_3d_view() -> void:
+	var setting := str(ProjectSettings.get_setting("application/run/main_scene", ""))
+	assert_str(setting).override_failure_message("run/main_scene is unset").is_not_empty()
+
+	# Compare the RESOLVED path, never the literal: Godot rewrites res:// paths to uid://
+	# whenever the project is saved in the editor, and the dev's live session does that
+	# routinely. Pinning the spelling would red on a no-op resave.
+	var resolved := setting
+	if setting.begins_with("uid://"):
+		resolved = ResourceUID.get_id_path(ResourceUID.text_to_id(setting))
+	assert_str(resolved).override_failure_message(
+			"run/main_scene resolves to '%s' — the game no longer boots into the 3D view" % resolved
+			).is_equal(BOOT_SCENE)
+
+
+func test_the_boot_scene_exists_and_loads() -> void:
+	# Guards the constant itself: a rename would otherwise red the case above with a
+	# misleading "no longer boots into 3D" when the truth is "that file moved".
+	assert_bool(ResourceLoader.exists(BOOT_SCENE)).override_failure_message(
+			"%s does not exist — update BOOT_SCENE, it moved" % BOOT_SCENE).is_true()
+	var packed := load(BOOT_SCENE) as PackedScene
+	assert_object(packed).is_not_null()


### PR DESCRIPTION
The game was booting into 2D again. `run/main_scene` on main had gone back to `uid://cxiu0yvwwxlgo` (Main.tscn) — #237's change was **silently reverted by a merge-conflict resolution**, hours after it landed.

## Mechanism

`config/version` and `run/main_scene` are **adjacent lines** in `[application]`. #237 changed both; #238 changed only the version. Resolving the version collision dragged the neighbouring line back with it.

Nothing failed. Nothing conflicted afterwards. The suite stayed green — because **nothing pinned the boot scene.** Every test instantiates its scenes explicitly, so 1415 green cases were structurally blind to the one setting that decides what the player actually launches into.

I also got the advice wrong when I flagged the collision: I said *"one line to resolve, take the higher number."* The adjacent line riding along is exactly what I failed to account for.

## The fix

The reverted line was the symptom; **the blindness is the defect.** `tests/law/test_boot_scene.gd`:

- the resolved `main_scene` is `Battle3D.tscn`
- it compares the **resolved** path, never the literal — Godot rewrites `res://` to `uid://` on any editor save, and your live session does that routinely, so pinning the spelling would red on a no-op resave
- a second case guards the constant itself, so a file move reds with *"that file moved"* rather than a misleading *"no longer boots into 3D"*

Falsified: set `run/main_scene` back to Main.tscn and the first case reds.

## Audited the rest, rather than trusting the one symptom

If one line of #237 was lost, others might have been. Verified present and correct on main:

- **#235** — both mirror fixes (`visuals.projected`, the modulate product)
- **#236** — the flame depth prepass and its knobs
- **#237** — the relative dev-overlay path, `auto_play = false`, the fixture change, the CLAUDE.md note
- **#238** — the sort table and `UNIT_RENDER_PRIORITY`, plus the sprite wiring

The single `main_scene` line was the only casualty.

## Notes

No version bump — #239 landed, the Action owns that now. Which also means this class of conflict is already gone going forward; the pin is for everything *else* that might quietly revert a project setting.

Suite **1419/1419**, 0 orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
