### PR TITLE
A tile state needs a tile under it (#245)

### DIFF
--- a/Classes/board/BoardContext.gd
+++ b/Classes/board/BoardContext.gd
@@ -57,6 +57,12 @@ func projected_unit_at_cell(cell: Vector2i) -> Unit:
 func terrain_kind_at(cell: Vector2i) -> Terrain.Kind:
 	return GridUtils.get_terrain_kind_at_cell(grid, cell)
 
+# The rules' single read-point for "is there ground here" (#245) — sibling of terrain_kind_at,
+# same rationale: a method, not an inline grid read, so a fixture board can stub it. A tile state
+# modifies what happens when a unit WALKS on a tile, so a cell with no tile has nothing to modify.
+func has_ground(cell: Vector2i) -> bool:
+	return GridUtils.has_ground(grid, cell)
+
 # The rules' single read-point for a cell's terrain DEF (#84): a Burrow-dug COVER tile shelters
 # whoever stands on it. Sibling of terrain_kind_at, same rationale — the resolver's mitigation
 # stage and the inspect panel's DEF readout both come through here, so they can't drift.

--- a/Classes/board/CursorController.gd
+++ b/Classes/board/CursorController.gd
@@ -26,8 +26,14 @@ func _ready() -> void:
 func set_cursor_pos(cell: Vector2i):
 	sprite.position = board_tilemap.map_to_local(cell)
 
-func set_state(state: CursorState):
-	sprite.texture = CURSOR_TEXTURES[state]
+# The last state set. STORED, because the 3D bracket mirrors this answer instead of re-deriving
+# "is the thing under the pointer valid" for itself -- two derivations of one question is exactly
+# the #232 shape. This used to swap the texture and throw the fact away.
+var state: CursorState = CursorState.DEFAULT
+
+func set_state(new_state: CursorState):
+	state = new_state
+	sprite.texture = CURSOR_TEXTURES[new_state]
 
 func hide_cursor():
 	sprite.visible = false

--- a/Classes/core/GridUtils.gd
+++ b/Classes/core/GridUtils.gd
@@ -56,6 +56,17 @@ static func cardinal_direction_i_between(from_cell: Vector2i, to_cell: Vector2i)
 	var dir := cardinal_direction_between(from_cell, to_cell)
 	return Vector2i(int(dir.x), int(dir.y))
 
+# Is there a tile here AT ALL (#245)? The one implementation of the question; BoardContext.has_ground
+# is the rules layer's read-point onto it and TerrainStateManager's ground_source is wired from it.
+# Deliberately the SOURCE id, not get_cell_tile_data: a headless fixture grid has cells placed but no
+# TileSet to read custom data from, so the tile-data form would call every fixture cell groundless.
+# A null grid cannot judge, so it does not — no board means no forbid, which is what keeps the
+# bare-store terrain suites honest.
+static func has_ground(grid: TileMapLayer, cell: Vector2i) -> bool:
+	if grid == null:
+		return true
+	return grid.get_cell_source_id(cell) != -1
+
 static func get_terrain_kind_at_cell(grid: TileMapLayer, cell: Vector2i) -> Terrain.Kind:
 	var data := grid.get_cell_tile_data(cell)
 	if data == null or not data.has_custom_data("terrain_type"):

--- a/Classes/dev/DevController.gd
+++ b/Classes/dev/DevController.gd
@@ -237,6 +237,10 @@ func _paint_tile(cell: Vector2i) -> void:
 
 func _erase_tile(cell: Vector2i) -> void:
 	game.grid.erase_cell(cell)
+	# The states go with the ground (#245). The forbid in TerrainStateManager stops NEW deposits on a
+	# groundless cell, but says nothing about ones already sitting there when the tile is taken away
+	# -- without this, erasing under a FROZEN tile leaves it frozen, floating and still walkable.
+	game.terrain_states.clear_cell(cell)
 	game.camera_controller.refresh_bounds(game.grid)
 
 func _paint_zone(cell: Vector2i) -> void:

--- a/Classes/dev/DevController.gd
+++ b/Classes/dev/DevController.gd
@@ -237,10 +237,12 @@ func _paint_tile(cell: Vector2i) -> void:
 
 func _erase_tile(cell: Vector2i) -> void:
 	game.grid.erase_cell(cell)
-	# The states go with the ground (#245). The forbid in TerrainStateManager stops NEW deposits on a
-	# groundless cell, but says nothing about ones already sitting there when the tile is taken away
-	# -- without this, erasing under a FROZEN tile leaves it frozen, floating and still walkable.
-	game.terrain_states.clear_cell(cell)
+	# The states go with the ground (#245). The forbid stops NEW deposits on a groundless cell but
+	# says nothing about ones already sitting there when the tile is taken away. The REDRAW is not
+	# optional either: without it the store is correct and the icon stays on screen, which is how
+	# this shipped broken the first time -- the 3D mirror then faithfully mirrors a stale sprite.
+	if game.terrain_states.prune_groundless():
+		game.overlay_manager.redraw_terrain_live(game.terrain_states)
 	game.camera_controller.refresh_bounds(game.grid)
 
 func _paint_zone(cell: Vector2i) -> void:
@@ -291,5 +293,9 @@ func resize_map(width: int, height: int, fill_source: int, fill_tile: Vector2i) 
 	for x in range(width):
 		for y in range(height):
 			game.grid.set_cell(Vector2i(x, y), fill_source, fill_tile)
+	# The SECOND way to take ground away (#245), and the one a per-cell clear at the erase site
+	# would have missed: shrinking strands every state that sat outside the new rectangle.
+	if game.terrain_states.prune_groundless():
+		game.overlay_manager.redraw_terrain_live(game.terrain_states)
 	game.camera_controller.refresh_bounds(game.grid)
 	

--- a/Classes/presentation/BoardMirror.gd
+++ b/Classes/presentation/BoardMirror.gd
@@ -202,6 +202,11 @@ func _make_fire(cell: Vector3i) -> Node3D:
 	material.emission_texture = material.albedo_texture
 	material.billboard_mode = BaseMaterial3D.BILLBOARD_FIXED_Y
 	material.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST
+	# Above every overlay layer, structurally rather than by luck. Unset, this was 0 while
+	# Layer.TERRAIN sorts at 2, so a frost icon painted onto a burning tile drew over the flame
+	# and the fire read as ERASED (#245, found in play). Transparent materials draw in priority
+	# order and this one does not write depth, so the sort IS the whole answer here.
+	material.render_priority = BoardOverlays.FLAME_RENDER_PRIORITY
 	quad.material = material
 	flame.mesh = quad
 	flame.position = Vector3(0, flame_base_lift(), 0)

--- a/Classes/presentation/BoardOverlays.gd
+++ b/Classes/presentation/BoardOverlays.gd
@@ -75,6 +75,10 @@ const ART_PIXELS_PER_CELL := 16.0
 @export var lift_step := 0.004         # per-sort spacing so stacked layers never coincide
 @export var billboard_lift := 1.1      # icon height above the cell's top face
 @export var billboard_pixel_size := 1.0 / 32.0
+# What the hover bracket turns when the pointer is over something the 2D calls INVALID (#245).
+# A knob because there is nothing to mirror here: 2D says "invalid" with a negative-icon TEXTURE,
+# and a bracket has no texture to swap, so the colour is a fresh aesthetic call.
+@export var invalid_bracket_color := Color(1.0, 0.3, 0.3, 0.9)
 
 var fill_texture: Texture2D
 
@@ -133,12 +137,15 @@ func set_markers(layer: Layer, markers: Array[Dictionary]) -> void:
 			node.visible = false
 
 
-# Runtime recolor of a FILL layer's pool (the heal-green reach, the aim pulse —
-# colors the 2D layer modulates live). Skip-if-equal so a per-frame poll is free.
+# Runtime recolor of a FILL or BRACKET layer's pool (the heal-green reach, the aim pulse —
+# colors the 2D layer modulates live; and the hover bracket's invalid red, #245). Skip-if-equal
+# so a per-frame poll is free. Both kinds are a MeshInstance3D with a StandardMaterial3D
+# override, which is why one loop serves them; SPRITE/BILLBOARD carry per-marker tints instead
+# and would need their entry data rewritten, not their pool.
 func set_layer_modulate(layer: Layer, color: Color) -> void:
 	var spec: Dictionary = LAYERS[layer]
-	if spec["kind"] != Kind.FILL:
-		push_error("set_layer_modulate is for FILL layers")
+	if spec["kind"] != Kind.FILL and spec["kind"] != Kind.BRACKET:
+		push_error("set_layer_modulate is for FILL and BRACKET layers")
 		return
 	if _layer_colors.get(layer, spec["color"]) == color:
 		return
@@ -175,6 +182,14 @@ func markers_of(layer: Layer) -> Array[Dictionary]:
 
 func layer_modulate(layer: Layer) -> Color:
 	return _layer_colors.get(layer, LAYERS[layer]["color"])
+
+
+# The AUTHORED colour, ignoring any runtime override — what a layer goes back TO. Distinct from
+# layer_modulate() above, which answers what it is right NOW; a caller restoring a tint needs this
+# one, or it would "restore" to whatever it last set.
+func authored_color(layer: Layer) -> Color:
+	var color: Color = LAYERS[layer]["color"]
+	return color
 
 
 func marker_count(layer: Layer) -> int:
@@ -230,7 +245,9 @@ func _make_marker(layer: Layer) -> Node3D:
 	var spec: Dictionary = LAYERS[layer]
 	match spec["kind"] as Kind:
 		Kind.BRACKET:
-			return _make_bracket(spec)
+			# The runtime colour, not the authored one: a bracket built AFTER a set_layer_modulate
+			# (the pool grows on demand) would otherwise come back gold on a red layer.
+			return _make_bracket(_layer_colors.get(layer, spec["color"]))
 		Kind.BILLBOARD:
 			return _make_billboard(spec)
 		Kind.SPRITE:
@@ -275,7 +292,7 @@ func _make_billboard(spec: Dictionary) -> Sprite3D:
 	return sprite
 
 
-func _make_bracket(spec: Dictionary) -> MeshInstance3D:
+func _make_bracket(color: Color) -> MeshInstance3D:
 	if _bracket_mesh == null:
 		_bracket_mesh = _build_bracket_mesh()
 	var instance := MeshInstance3D.new()
@@ -283,7 +300,7 @@ func _make_bracket(spec: Dictionary) -> MeshInstance3D:
 	var material := StandardMaterial3D.new()
 	material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
 	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	material.albedo_color = spec["color"]
+	material.albedo_color = color
 	instance.material_override = material
 	instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 	add_child(instance)

--- a/Classes/presentation/BoardOverlays.gd
+++ b/Classes/presentation/BoardOverlays.gd
@@ -35,6 +35,12 @@ const UNIT_RENDER_LAYER := 2   # bit for layer index 1 — UnitSprite3D sets thi
 # Unit.BASE_SPRITE_INDEX". Must stay greater than any LAYERS "sort"; pinned by a test.
 # Without it a ghost was just render_priority 0, so arrows and terrain icons drew over it.
 const UNIT_RENDER_PRIORITY := 32
+# Fire's 3D form is a STANDING effect, not markup lying on the tile face, so it sorts above every
+# overlay layer — the same structural claim units make, one band below them so the flame-vs-sprite
+# relationship #236 argued over is untouched. Found in play (#245): the flame set no priority at
+# all, so it sat at 0 while Layer.TERRAIN sorts at 2, and painting a frost icon onto a burning
+# tile drew straight over the flame. The fire read as erased; the store was perfectly correct.
+const FLAME_RENDER_PRIORITY := 16
 
 const LAYERS: Dictionary[Layer, Dictionary] = {
 	Layer.MOVE: {"color": Color(1, 1, 0, 0.5), "sort": 0, "kind": Kind.FILL},

--- a/Classes/terrain/TerrainStateManager.gd
+++ b/Classes/terrain/TerrainStateManager.gd
@@ -10,6 +10,16 @@ const STATE_DURATIONS := {
 	Terrain.TileState.BURNING: 3,
 }
 
+# Injectable "does this cell have ground?" (#245) -- the GridUtils.has_ground shape, wired at the
+# two construction sites (game.gd and play/board_builder.gd). A tile state modifies what happens
+# when a unit WALKS on a tile, so a cell with no tile has nothing to modify (dev ruling).
+# This store is the ONE seam every deposit passes through -- three producers (PlanResolver,
+# SquadManager's Burrow COVER, the dev brush) and three appliers (OrderExecutor, PlaySession, the
+# brush) -- so the rule lives here rather than in six places that would drift.
+# Unset = no judgement, NOT "no ground": a bare store built without a board still accepts
+# everything, which is what the headless terrain fixtures rely on.
+var ground_source: Callable
+
 var _states: Dictionary = {}        # Vector2i -> Array[Terrain.TileState]
 var _state_turns: Dictionary = {}   # Vector2i -> { Terrain.TileState: turns_left }
 
@@ -25,23 +35,46 @@ func has_state(cell: Vector2i, state: Terrain.TileState) -> bool:
 # Play back one resolved cell effect (R3). Remove-then-add, mirroring how AttackAction.execute
 # applies unit state deltas. Empties are pruned so an untouched cell never holds a stale entry.
 func apply(effect: ResolvedCellEffect) -> void:
+	# Deposits onto a groundless cell are DROPPED; removals always run. The asymmetry is the point:
+	# a cell whose tile was just erased still has to be cleanable, and routing that through here
+	# keeps the timer bookkeeping below correct instead of needing a second back door.
+	var grounded := _has_ground(effect.cell)
 	var current: Array[Terrain.TileState] = []
 	if _states.has(effect.cell):
 		current.assign(_states[effect.cell])
 	for s in effect.states_removed:
 		current.erase(s)
-	for s in effect.states_added:
-		if not current.has(s):
-			current.append(s)
+	if grounded:
+		for s in effect.states_added:
+			if not current.has(s):
+				current.append(s)
 	if current.is_empty():
 		_states.erase(effect.cell)
 	else:
 		_states[effect.cell] = current
 	for s in effect.states_removed:
 		_clear_timer(effect.cell, s)
-	for s in effect.states_added:
-		if STATE_DURATIONS.has(s):
-			_start_timer(effect.cell, s)
+	if grounded:
+		for s in effect.states_added:
+			if STATE_DURATIONS.has(s):
+				_start_timer(effect.cell, s)
+
+func _has_ground(cell: Vector2i) -> bool:
+	if not ground_source.is_valid():
+		return true
+	var grounded: bool = ground_source.call(cell)   # typed local: .call() erases to Variant
+	return grounded
+
+# Drop every state at one cell, through apply() so the timers unwind the same way they would on any
+# other removal. The dev brush calls this when its erase takes the ground out from under them.
+func clear_cell(cell: Vector2i) -> void:
+	var held := states_at(cell)
+	if held.is_empty():
+		return
+	var effect := ResolvedCellEffect.new()
+	effect.cell = cell
+	effect.states_removed.assign(held)
+	apply(effect)
 
 func clear() -> void:
 	_states.clear()

--- a/Classes/terrain/TerrainStateManager.gd
+++ b/Classes/terrain/TerrainStateManager.gd
@@ -65,16 +65,23 @@ func _has_ground(cell: Vector2i) -> bool:
 	var grounded: bool = ground_source.call(cell)   # typed local: .call() erases to Variant
 	return grounded
 
-# Drop every state at one cell, through apply() so the timers unwind the same way they would on any
-# other removal. The dev brush calls this when its erase takes the ground out from under them.
-func clear_cell(cell: Vector2i) -> void:
-	var held := states_at(cell)
-	if held.is_empty():
-		return
-	var effect := ResolvedCellEffect.new()
-	effect.cell = cell
-	effect.states_removed.assign(held)
-	apply(effect)
+# Drop every state whose cell no longer has ground, through apply() so the timers unwind exactly as
+# they would on any other removal. Returns whether anything went, so a caller can skip its redraw.
+#
+# A SWEEP rather than a per-cell clear because there is more than one way to take ground away: the
+# brush erases one cell, and resize_map calls grid.clear() and repaints a whole new rectangle. A
+# targeted clear has to be remembered correctly at each site; this only has to be called.
+func prune_groundless() -> bool:
+	var doomed: Array[Vector2i] = []
+	for cell: Vector2i in _states.keys():
+		if not _has_ground(cell):
+			doomed.append(cell)
+	for cell in doomed:
+		var effect := ResolvedCellEffect.new()
+		effect.cell = cell
+		effect.states_removed.assign(states_at(cell))
+		apply(effect)
+	return not doomed.is_empty()
 
 func clear() -> void:
 	_states.clear()

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -341,6 +341,7 @@ func _process(_delta: float) -> void:
 	_poll_pointer()
 	_sync_brush_bindings()
 	_sync_brush_ghost()
+	_sync_bracket_tint()
 	_mirror_camera()
 
 
@@ -466,6 +467,21 @@ func _poll_pointer() -> void:
 		return
 	_last_polled_mouse = mouse
 	_update_pointer(mouse)
+
+
+# The hover bracket goes RED over anything the 2D calls invalid (#245, asked for in play after the
+# groundless-state forbid started refusing paints SILENTLY). It MIRRORS CursorController's state
+# rather than deciding for itself: the 2D already answers "is the thing under the pointer valid"
+# — in dev mode, unwalkable or occupied — and a groundless cell is unwalkable, which is exactly the
+# refusal that prompted this. Re-deriving it here would be a second answer free to disagree with
+# the cursor sitting right next to it, which is the #232 shape.
+func _sync_bracket_tint() -> void:
+	if demo_mode:
+		return
+	var invalid: bool = game.cursor_controller.state == CursorController.CursorState.INVALID
+	var restore: Color = _overlays.authored_color(BoardOverlays.Layer.HOVER)
+	var color: Color = _overlays.invalid_bracket_color if invalid else restore
+	_overlays.set_layer_modulate(BoardOverlays.Layer.HOVER, color)   # skip-if-equal inside
 
 
 # The 3D half of the brush preview. POLLED off the brush's own intent, never hooked at the

--- a/game.gd
+++ b/game.gd
@@ -122,6 +122,9 @@ func _build_collaborators() -> void:
 
 	terrain_states = TerrainStateManager.new()
 	terrain_states.name = "TerrainStateManager"
+	# A tile state needs a tile under it (#245). Reads `grid` live rather than capturing it, so a
+	# board swap cannot leave the rule judging against the previous scenario's terrain.
+	terrain_states.ground_source = func(cell: Vector2i) -> bool: return GridUtils.has_ground(grid, cell)
 	add_child(terrain_states)
 
 	zone_manager = ZoneManager.new()

--- a/play/board_builder.gd
+++ b/play/board_builder.gd
@@ -55,6 +55,9 @@ static func build(parent: Node, root_name := "PlayRoot") -> Dictionary:
 	# (BURNING, and Cover's DEF since #84) silently answers "nothing here".
 	var terrain_states := TerrainStateManager.new()
 	terrain_states.name = "TerrainStateManager"
+	# Same rule as the flat game's store (#245) — a tile state needs a tile under it. The parallel
+	# stacks each wire it; neither is allowed to be the one that forgets, which is how #103 happened.
+	terrain_states.ground_source = func(cell: Vector2i) -> bool: return GridUtils.has_ground(grid, cell)
 	root.add_child(terrain_states)
 
 	# Cohesion reads live terrain (#151) -- fresh BoardContext per call, mirroring game._board, with

--- a/tests/dev/test_tile_brush_states.gd
+++ b/tests/dev/test_tile_brush_states.gd
@@ -95,6 +95,21 @@ func test_erasing_a_tile_takes_its_states_with_it() -> void:
 			"the store cleared but the icon stayed — the redraw never ran").is_less(painted_icons)
 
 
+func test_painting_frozen_onto_a_burning_cell_keeps_the_fire() -> void:
+	# Reported in play, 3D only: painting FROZEN over a BURNING tile "erased" the fire. Bisecting
+	# store from render -- a cell legally holds both, so if this is green the store is innocent.
+	_brush._tile_state = Terrain.TileState.BURNING
+	game.dev_controller._paint_state(CELL)
+	_brush._tile_state = Terrain.TileState.FROZEN
+	game.dev_controller._paint_state(CELL)
+	assert_bool(game.terrain_states.has_state(CELL, Terrain.TileState.BURNING)) \
+		.override_failure_message("the frozen paint dropped the fire from the STORE").is_true()
+	assert_bool(game.terrain_states.has_state(CELL, Terrain.TileState.FROZEN)).is_true()
+	assert_array(game.terrain_states.burning_cells()) \
+		.override_failure_message("the cell fell out of burning_cells, which is what drives the 3D flame") \
+		.contains([CELL])
+
+
 func test_shrinking_the_map_drops_the_states_left_outside_it() -> void:
 	# grid.clear() inside resize_map is the SECOND way to lose ground, and it never matched a search
 	# for erase_cell — which is exactly why the rule sweeps rather than clearing one named cell.

--- a/tests/dev/test_tile_brush_states.gd
+++ b/tests/dev/test_tile_brush_states.gd
@@ -43,6 +43,59 @@ func _live_icon_count() -> int:
 	var count: int = game.overlay_manager.terrain_live_sprites.size()
 	return count
 
+# --- A state needs ground under it (#245) --------------------------------------------
+#
+# End-to-end over the REAL grid, so GridUtils.has_ground's choice of get_cell_source_id (rather
+# than get_cell_tile_data) is exercised against a board that actually has a TileSet.
+
+# Far outside any authored board. NOT merely off the row before_test paints -- clear_board() clears
+# units, zones and states but deliberately leaves the TILEMAP alone, so Main.tscn's own terrain is
+# still there and a nearby cell has ground under it. Every case below asserts that for itself.
+const VOID_CELL := Vector2i(64, 64)
+
+func _assert_void_is_void() -> void:
+	assert_bool(GridUtils.has_ground(game.grid, VOID_CELL)).override_failure_message(
+			"precondition: VOID_CELL has ground, so nothing below proves anything").is_false()
+
+
+func test_a_state_cannot_be_painted_onto_a_cell_with_no_tile() -> void:
+	# The dev ruling, verbatim: a terrain effect modifies what happens when a unit walks on a tile,
+	# so if there is no tile there should be no modifier.
+	_assert_void_is_void()
+	_brush._tile_state = Terrain.TileState.FROZEN
+	game.dev_controller._paint_state(VOID_CELL)
+	assert_bool(game.terrain_states.has_state(VOID_CELL, Terrain.TileState.FROZEN)) \
+		.override_failure_message("a state landed on a cell with no ground").is_false()
+	# Non-vacuous: the same paint on real ground still lands, so this is not just a dead brush.
+	game.dev_controller._paint_state(CELL)
+	assert_bool(game.terrain_states.has_state(CELL, Terrain.TileState.FROZEN)).is_true()
+
+
+func test_erasing_a_tile_takes_its_states_with_it() -> void:
+	# The half a forbid alone does NOT cover, and the reported bug's actual path: the state was
+	# perfectly legal when painted, and the ground went away afterwards.
+	_brush._tile_state = Terrain.TileState.FROZEN
+	game.dev_controller._paint_state(CELL)
+	assert_bool(game.terrain_states.has_state(CELL, Terrain.TileState.FROZEN)) \
+		.override_failure_message("precondition: the paint never landed").is_true()
+	game.dev_controller._erase_tile(CELL)
+	assert_bool(game.terrain_states.has_state(CELL, Terrain.TileState.FROZEN)) \
+		.override_failure_message("the state outlived the ground it was standing on").is_false()
+
+
+func test_a_groundless_cell_never_becomes_walkable_through_frozen() -> void:
+	# The severe half, and why this was never only a floating icon. BoardContext.is_walkable
+	# short-circuits on FROZEN BEFORE the tile lookup -- deliberately, since headless fixtures carry
+	# no TileSet -- so a frozen void cell read as WALKABLE and the move-range BFS would happily path
+	# a unit onto nothing.
+	_assert_void_is_void()
+	assert_bool(game._board().is_walkable(VOID_CELL)) \
+		.override_failure_message("precondition: the void cell was walkable before any freeze").is_false()
+	_brush._tile_state = Terrain.TileState.FROZEN
+	game.dev_controller._paint_state(VOID_CELL)
+	assert_bool(game._board().is_walkable(VOID_CELL)) \
+		.override_failure_message("freezing the void made it walkable").is_false()
+
 func test_painting_deposits_the_picked_state_and_draws_its_icon() -> void:
 	_brush._tile_state = Terrain.TileState.BLAZE
 	game.dev_controller._paint_state(CELL)

--- a/tests/dev/test_tile_brush_states.gd
+++ b/tests/dev/test_tile_brush_states.gd
@@ -52,6 +52,7 @@ func _live_icon_count() -> int:
 # units, zones and states but deliberately leaves the TILEMAP alone, so Main.tscn's own terrain is
 # still there and a nearby cell has ground under it. Every case below asserts that for itself.
 const VOID_CELL := Vector2i(64, 64)
+const FAR_CELL := Vector2i(6, 0)    # on the painted row, but outside a 3x3 resize
 
 func _assert_void_is_void() -> void:
 	assert_bool(GridUtils.has_ground(game.grid, VOID_CELL)).override_failure_message(
@@ -74,13 +75,36 @@ func test_a_state_cannot_be_painted_onto_a_cell_with_no_tile() -> void:
 func test_erasing_a_tile_takes_its_states_with_it() -> void:
 	# The half a forbid alone does NOT cover, and the reported bug's actual path: the state was
 	# perfectly legal when painted, and the ground went away afterwards.
+	#
+	# The ICON assertion is the one with teeth. The first version of this case checked has_state
+	# alone, went green, and shipped a build where the store was correct and the sprite stayed on
+	# screen — because _erase_tile cleared the state and never redrew, and the 3D mirror then
+	# faithfully mirrored the stale sprite. Assert the WIRE, not the two ends.
 	_brush._tile_state = Terrain.TileState.FROZEN
 	game.dev_controller._paint_state(CELL)
 	assert_bool(game.terrain_states.has_state(CELL, Terrain.TileState.FROZEN)) \
 		.override_failure_message("precondition: the paint never landed").is_true()
+	var painted_icons := _live_icon_count()
+	assert_int(painted_icons).override_failure_message(
+			"precondition: painting drew no icon, so its disappearance would prove nothing").is_greater(0)
+
 	game.dev_controller._erase_tile(CELL)
 	assert_bool(game.terrain_states.has_state(CELL, Terrain.TileState.FROZEN)) \
 		.override_failure_message("the state outlived the ground it was standing on").is_false()
+	assert_int(_live_icon_count()).override_failure_message(
+			"the store cleared but the icon stayed — the redraw never ran").is_less(painted_icons)
+
+
+func test_shrinking_the_map_drops_the_states_left_outside_it() -> void:
+	# grid.clear() inside resize_map is the SECOND way to lose ground, and it never matched a search
+	# for erase_cell — which is exactly why the rule sweeps rather than clearing one named cell.
+	_brush._tile_state = Terrain.TileState.FROZEN
+	game.dev_controller._paint_state(FAR_CELL)
+	assert_bool(game.terrain_states.has_state(FAR_CELL, Terrain.TileState.FROZEN)) \
+		.override_failure_message("precondition: the paint never landed").is_true()
+	game.dev_controller.resize_map(3, 3, GRASS_SOURCE, GRASS_ATLAS)
+	assert_bool(game.terrain_states.has_state(FAR_CELL, Terrain.TileState.FROZEN)) \
+		.override_failure_message("a state survived the board shrinking out from under it").is_false()
 
 
 func test_a_groundless_cell_never_becomes_walkable_through_frozen() -> void:

--- a/tests/presentation/test_board_mirror.gd
+++ b/tests/presentation/test_board_mirror.gd
@@ -70,6 +70,33 @@ func test_fire_markers_match_the_games_own_burning_cells() -> void:
 	assert_bool(expected > 0).is_true()  # Prolog authors BLAZE content; a zero here means the load broke
 
 
+func test_the_flame_actually_carries_the_flame_priority() -> void:
+	# Test the WIRE: a sort constant is worth nothing if no flame reads it, and this one exists
+	# because the flame read NOTHING — it sat at the default 0, below every overlay layer, so
+	# painting a frost icon onto a burning tile drew straight over the fire and it looked erased
+	# (#245, found in play). The store was correct throughout, which is why only a render-side
+	# assertion could ever have caught it.
+	_scene.load_mission(PROLOG)
+	await await_idle_frame()
+	var mirror := _scene.get_node("BoardMirror") as BoardMirror
+	var burning := _burning()
+	assert_bool(burning.size() > 0).override_failure_message(
+			"precondition: nothing is burning, so there is no flame to inspect").is_true()
+	var marker := mirror.fire_marker_at(burning[0])
+	assert_object(marker).override_failure_message("no marker for a burning cell").is_not_null()
+	var flame: MeshInstance3D = null
+	for child in marker.get_children():
+		var mesh_child := child as MeshInstance3D
+		if mesh_child != null:
+			flame = mesh_child
+			break
+	assert_object(flame).override_failure_message("the fire marker has no mesh child").is_not_null()
+	var material := (flame.mesh as QuadMesh).material as StandardMaterial3D
+	assert_int(material.render_priority).override_failure_message(
+			"the flame does not apply FLAME_RENDER_PRIORITY — the constant is inert and overlay markup draws over fire again"
+	).is_equal(BoardOverlays.FLAME_RENDER_PRIORITY)
+
+
 func test_a_unit_going_down_on_fire_does_not_take_the_flame_with_it() -> void:
 	# Reported in play: a unit downed while standing in fire makes that fire vanish for the
 	# rest of the turn, returning at the next turn boundary. This isolates WHICH half is

--- a/tests/presentation/test_board_overlays.gd
+++ b/tests/presentation/test_board_overlays.gd
@@ -27,6 +27,45 @@ func _overlays() -> BoardOverlays:
 	return _scene.get_node("BoardOverlays") as BoardOverlays
 
 
+# --- Bracket tinting (#245) ---------------------------------------------------------
+
+func test_a_bracket_layer_can_be_recoloured_at_runtime() -> void:
+	# set_layer_modulate was FILL-only and push_error'd on anything else; the invalid-hover red
+	# needs it on the BRACKET kind too. Asserted as a property (the layer took the tint, and the
+	# tint is not the authored colour) rather than against a value -- the red is a knob.
+	var overlays := _overlays()
+	var authored := overlays.authored_color(BoardOverlays.Layer.HOVER)
+	overlays.set_cells(BoardOverlays.Layer.HOVER, [Vector3i(0, 0, 0)])
+	overlays.set_layer_modulate(BoardOverlays.Layer.HOVER, overlays.invalid_bracket_color)
+	assert_that(overlays.layer_modulate(BoardOverlays.Layer.HOVER)).is_equal(overlays.invalid_bracket_color)
+	assert_bool(overlays.invalid_bracket_color == authored).override_failure_message(
+			"the invalid tint IS the authored colour, so nothing could ever look different").is_false()
+
+
+func test_a_bracket_built_after_a_tint_comes_back_tinted() -> void:
+	# The trap: the pool grows ON DEMAND, and _make_bracket read the AUTHORED colour. Tint a layer
+	# whose pool is still empty, then ask for a marker, and the fresh node came back gold on a red
+	# layer. Invisible to any case that tints a pool which already exists -- which is the only way
+	# anyone would naturally write it, so the empty-pool ordering IS the case.
+	var overlays: BoardOverlays = auto_free(BoardOverlays.new())
+	add_child(overlays)
+	var tint := overlays.invalid_bracket_color
+	overlays.set_layer_modulate(BoardOverlays.Layer.HOVER, tint)   # pool still empty
+	overlays.set_cells(BoardOverlays.Layer.HOVER, [Vector3i(0, 0, 0)])
+	var seen := false
+	for child in overlays.get_children():
+		var bracket := child as MeshInstance3D
+		if bracket == null:
+			continue
+		var material := bracket.material_override as StandardMaterial3D
+		if material == null:
+			continue
+		seen = true
+		assert_that(material.albedo_color).override_failure_message(
+				"a bracket built after the tint came back the authored colour").is_equal(tint)
+	assert_bool(seen).override_failure_message("no bracket node was built at all").is_true()
+
+
 # --- The table and the contract ----------------------------------------------------
 
 func test_every_layer_is_declared_in_the_table() -> void:

--- a/tests/presentation/test_board_overlays.gd
+++ b/tests/presentation/test_board_overlays.gd
@@ -312,6 +312,23 @@ func test_no_overlay_layer_can_sort_over_a_unit() -> void:
 				% [layer, sort]).is_less(BoardOverlays.UNIT_RENDER_PRIORITY)
 
 
+func test_no_overlay_layer_can_sort_over_the_flame() -> void:
+	# Fire's 3D form is a standing effect, not markup lying on the face (#245, found in play: a
+	# frost icon at sort 2 drew over a flame sitting at the default 0, and the fire read as
+	# erased). Structural, like the unit pin above — a new layer added above the flame reds here
+	# rather than being discovered by painting ice on a bonfire.
+	for layer: BoardOverlays.Layer in BoardOverlays.LAYERS:
+		var sort: int = BoardOverlays.LAYERS[layer]["sort"]
+		assert_int(sort).override_failure_message(
+				"layer %d sorts at %d, at or above FLAME_RENDER_PRIORITY — it would draw over fire" \
+				% [layer, sort]).is_less(BoardOverlays.FLAME_RENDER_PRIORITY)
+	# ...and the flame still sits BELOW units, so the flame-vs-sprite trade #236 argued over
+	# (and the dev reverted) is untouched by giving the flame a band of its own.
+	assert_int(BoardOverlays.FLAME_RENDER_PRIORITY).override_failure_message(
+			"the flame now sorts at or above units, which re-opens #236's swallowed-body trade") \
+			.is_less(BoardOverlays.UNIT_RENDER_PRIORITY)
+
+
 func test_a_unit_sprite_actually_carries_that_priority() -> void:
 	# Test the wire: the constant is worth nothing if no sprite reads it, and ghosts are built
 	# by UnitMirror through the same plain constructor rather than for_unit_data.

--- a/tests/terrain/test_states_need_ground.gd
+++ b/tests/terrain/test_states_need_ground.gd
@@ -50,9 +50,20 @@ func test_a_removal_on_a_groundless_cell_still_applies() -> void:
 	_wire_ground()                              # ...and now the ground is gone from under it
 	assert_bool(_states.has_state(VOID, Terrain.TileState.FROZEN)) \
 		.override_failure_message("precondition: the deposit never landed").is_true()
-	_states.clear_cell(VOID)
+	assert_bool(_states.prune_groundless()) \
+		.override_failure_message("the sweep found nothing to prune").is_true()
 	assert_bool(_states.has_state(VOID, Terrain.TileState.FROZEN)) \
 		.override_failure_message("a groundless cell cannot be cleaned up").is_false()
+
+
+func test_the_sweep_leaves_grounded_states_alone() -> void:
+	# Non-vacuous partner to the case above: a sweep that dropped everything would satisfy it just
+	# as well, and would quietly delete the board's real fire on the next map resize.
+	_wire_ground()
+	_deposit(GROUND, Terrain.TileState.FROZEN)
+	_states.prune_groundless()
+	assert_bool(_states.has_state(GROUND, Terrain.TileState.FROZEN)) \
+		.override_failure_message("the sweep took a state that still had ground under it").is_true()
 
 
 func test_an_unwired_store_judges_nothing() -> void:

--- a/tests/terrain/test_states_need_ground.gd
+++ b/tests/terrain/test_states_need_ground.gd
@@ -1,0 +1,64 @@
+# The ground rule at the STORE (#245). TerrainStateManager is the ONE seam every tile-state deposit
+# passes through -- three producers (PlanResolver, SquadManager's Burrow COVER, the dev brush) and
+# three appliers (OrderExecutor, PlaySession, the brush) -- so "a tile state needs a tile under it"
+# lives there rather than in six guards that would drift apart.
+#
+# These drive the store directly with a STUBBED ground_source, because what is under test is the
+# store's contract, not the predicate. GridUtils.has_ground against a real grid with a real TileSet
+# is covered end-to-end by tests/dev/test_tile_brush_states.gd.
+extends GdUnitTestSuite
+
+const GROUND := Vector2i(0, 0)
+const VOID := Vector2i(9, 9)
+
+var _states: TerrainStateManager
+
+
+func before_test() -> void:
+	_states = auto_free(TerrainStateManager.new()) as TerrainStateManager
+	add_child(_states)
+
+
+# Wire the rule up. Split from before_test on purpose: one case below needs the UNWIRED store.
+func _wire_ground() -> void:
+	_states.ground_source = func(cell: Vector2i) -> bool: return cell != VOID
+
+
+func _deposit(cell: Vector2i, state: Terrain.TileState) -> void:
+	var effect := ResolvedCellEffect.new()
+	effect.cell = cell
+	effect.states_added.assign([state])
+	_states.apply(effect)
+
+
+func test_a_deposit_on_a_groundless_cell_is_dropped() -> void:
+	_wire_ground()
+	_deposit(VOID, Terrain.TileState.FROZEN)
+	assert_bool(_states.has_state(VOID, Terrain.TileState.FROZEN)) \
+		.override_failure_message("a state landed on a cell with no ground").is_false()
+	# Non-vacuous: the identical deposit on real ground still lands. Without this the case would
+	# pass just as happily against a store that refused everything.
+	_deposit(GROUND, Terrain.TileState.FROZEN)
+	assert_bool(_states.has_state(GROUND, Terrain.TileState.FROZEN)).is_true()
+
+
+func test_a_removal_on_a_groundless_cell_still_applies() -> void:
+	# The asymmetry is the whole design. A state can be legal when deposited and lose its ground
+	# afterwards; if removals were forbidden alongside deposits, nothing could ever clean that up
+	# and the reported bug would survive its own fix.
+	_deposit(VOID, Terrain.TileState.FROZEN)   # unwired store: it lands
+	_wire_ground()                              # ...and now the ground is gone from under it
+	assert_bool(_states.has_state(VOID, Terrain.TileState.FROZEN)) \
+		.override_failure_message("precondition: the deposit never landed").is_true()
+	_states.clear_cell(VOID)
+	assert_bool(_states.has_state(VOID, Terrain.TileState.FROZEN)) \
+		.override_failure_message("a groundless cell cannot be cleaned up").is_false()
+
+
+func test_an_unwired_store_judges_nothing() -> void:
+	# Deliberate, and load-bearing: unset means NO JUDGEMENT, not "no ground". Every bare-store
+	# terrain fixture -- test_ice, test_douse, test_burnout -- builds TerrainStateManager.new() with
+	# no board at all and expects its deposits to land. Tightening this to a default-deny reds the
+	# lot of them, so this case exists to make that consequence visible before someone tries.
+	_deposit(VOID, Terrain.TileState.FROZEN)
+	assert_bool(_states.has_state(VOID, Terrain.TileState.FROZEN)).is_true()

--- a/tests/terrain/test_states_need_ground.gd.uid
+++ b/tests/terrain/test_states_need_ground.gd.uid
@@ -1,0 +1,1 @@
+uid://qd2n77xdh0ch


### PR DESCRIPTION
Closes #245. Dev ruling, and the spec:

> Terrain effects modify what happens when a unit walks on a tile. If there is no tile, there shouldn't be a modifier.

## This was never only a floating icon

`BoardContext.is_walkable` short-circuits on FROZEN **before** the tile lookup — deliberately, since headless fixtures carry no TileSet. So a frozen groundless cell read as **walkable**, and `is_walkable` is *"THE walkability answer for the whole game"* (#109): the move-range BFS would path a unit onto nothing. The reported icon was the visible half.

## One choke point, not six

Three things produce a `ResolvedCellEffect` (`PlanResolver`, `SquadManager`'s Burrow COVER, the dev brush) and three apply one (`OrderExecutor`, `PlaySession`, the brush). Guarding at producers meant six sites drifting apart, so the rule lives in `TerrainStateManager.apply`, which all six pass through.

The predicate has **one** implementation — `GridUtils.has_ground`, beside its sibling `get_terrain_kind_at_cell` — with `BoardContext.has_ground` as the rules layer's read-point and both stores wired from it. It asks the cell's *source id*, not `get_cell_tile_data`, because a fixture grid has cells but no TileSet.

Two deliberate asymmetries, both load-bearing:

- **Deposits are refused; removals always run.** A state can be legal when deposited and lose its ground afterwards; if removals were blocked too, nothing could clean it up and the bug would survive its own fix.
- **An unwired store judges nothing** — not "no ground". Every bare-store terrain fixture builds one with no board and expects deposits to land. A case pins that on purpose, so the consequence is visible before someone tries to tighten it.

## Three more found in play, each a different shape

1. **`_erase_tile` cleared the state and never redrew.** The store was right; the 2D sprite stayed and the 3D mirror faithfully mirrored a stale sprite. My first test asserted `has_state` alone and went green over it — it now asserts the **icon count**. Testing the two ends and skipping the wire, again.
2. **`resize_map` calls `grid.clear()`**, a second way to lose ground that never matched a search for `erase_cell`. That is why the rule is a **sweep** (`prune_groundless`) rather than a per-cell clear: a targeted clear must be remembered at each site, a sweep only has to be called.
3. **Ice rendered over fire.** `_make_fire` set no `render_priority`, so the flame sat at `0` while `Layer.TERRAIN` sorts at `2` — and the material deliberately does not write depth, so the sort is the whole answer. An unset priority is still a decision. `FLAME_RENDER_PRIORITY` now lives in `BoardOverlays` beside `UNIT_RENDER_PRIORITY`, one band **below** units so #236's flame-vs-sprite trade is untouched.

## The red hover bracket

The forbid refuses a paint silently, so the bracket now goes red over anything the 2D calls invalid. It **mirrors** `CursorController`'s state rather than deciding for itself — the 2D already answers "is this valid", and re-deriving it here would be a second answer free to disagree with the cursor next to it.

`CursorController` now stores the state it is told; `set_state` was swapping a texture and throwing the fact away. `set_layer_modulate` gained BRACKET, and `_make_bracket` now reads the runtime colour like `_make_quad` does — the pool grows on demand, so a bracket built after a tint came back gold on a red layer.

**Known and out of scope** (dev's call): that bracket also reds over rocks and occupied cells you *can* paint, because the 2D's INVALID means **spawn** validity. The mirror is faithful; the 2D predicate answers a different question than the brush asks.

## Knobs

`BoardOverlays.invalid_bracket_color` — the red. A knob because there is nothing to mirror: 2D says "invalid" with a negative-icon *texture*, and a bracket has no texture to swap. Tests assert the property (tinted ≠ authored), never the value.

## Verification

Full tree **1461/1461**, 0 errors, 0 orphans, 184.2s.

Three mutants, each on its own suite file, 3.2s–5.1s:

- drop the grounded guard → `test_a_groundless_cell_never_becomes_walkable_through_frozen` reds (three hops: store → `is_walkable` → move range)
- drop the redraw → `test_erasing_a_tile_takes_its_states_with_it` reds with *"the store cleared but the icon stayed"*
- drop the flame priority → `test_the_flame_actually_carries_the_flame_priority` reds with *"the constant is inert"*

Feel-checked in play across four rounds; the last three fixes all came out of that.
