### PR TITLE
A Look tab for the dev tools: tune the 3D stack live (#212)

### DIFF
--- a/Classes/dev/DevOverlay.gd
+++ b/Classes/dev/DevOverlay.gd
@@ -15,6 +15,7 @@ class_name DevOverlay
 @onready var spawn: SpawnTool = get_node("%Spawn")
 @onready var unit_authoring: MarginContainer = get_node("%Unit Authoring")
 @onready var scenario_tool: ScenarioTool = get_node("%Scenario")
+@onready var look_tool: LookTool = get_node("%Look")
 @onready var dev_mode_toggle: CheckButton = %DevModeToggle
 
 func _ready() -> void:
@@ -34,10 +35,20 @@ func _ready() -> void:
 	tabs.set_tab_tooltip(3, "Author attacks — Transmutation, Weapon Attack, or Family Mains (edit an established family's main in place); toggle at top.")
 	tabs.set_tab_tooltip(4, "Save / load board scenarios. F2 resets the current one.")
 	tabs.set_tab_tooltip(5, "Paint the board — Terrain, Zones, or Tile States (fire/ice/cover); left-drag paints, right-drag erases.")
+	tabs.set_tab_tooltip(6, "Tune the 3D look live — lighting, post, fog, camera, markup. Copy Values hands back what you moved.")
 	var authoring_tabs: TabContainer = %AuthoringTabs
 	authoring_tabs.tab_changed.connect(_on_authoring_tab_changed)
 	authoring_tabs.set_tab_tooltip(0, "Spawn units — configure here, then hover the board + Space to place.")
 	authoring_tabs.set_tab_tooltip(1, "Author cast characters — the Resources/Units/ files authored saves reference. Update rewrites the character everywhere; Save As or Capture creates.")
+
+# The 3D host PUSHES itself in from battle3d._ready (it already resolves this window to hide it).
+# Nothing under Game reaches up to Battle3D as a result, and a flat Main.tscn launch just never
+# calls this. A demo build has already queue_free()'d this window, so don't build 60-odd rows for it.
+func attach_look_host(host: Node3D) -> void:
+	if not DevTools.enabled():
+		return
+	look_tool.attach_host(host)
+
 
 func _on_close_requested():
 	hide()

--- a/Classes/dev/DevWidgets.gd
+++ b/Classes/dev/DevWidgets.gd
@@ -19,6 +19,63 @@ static func add_spinbox(container: Node, label_text: String, initial_value: floa
 	row.add_child(spinbox)
 	container.add_child(row)
 
+# Feel work is DRAG work: a value you sweep while watching the board, with the number beside it
+# so a landed setting can be read off. add_spinbox is the typing form; this is the hunting form.
+# Returns the slider so a caller can write a value back into the widget (LookTool's Reset).
+static func add_slider(container: Node, label_text: String, initial_value: float,
+		min_value: float, max_value: float, step: float, on_change: Callable) -> HSlider:
+	var row := HBoxContainer.new()
+	var label := Label.new()
+	label.text = label_text
+	label.custom_minimum_size = Vector2(190, 0)
+	var slider := HSlider.new()
+	slider.min_value = min_value
+	slider.max_value = max_value
+	slider.step = step
+	slider.value = initial_value
+	slider.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	slider.custom_minimum_size = Vector2(120, 0)
+	var readout := Label.new()
+	readout.custom_minimum_size = Vector2(64, 0)
+	readout.text = format_decimals(initial_value, step)
+	slider.value_changed.connect(func(v: float) -> void:
+		readout.text = format_decimals(v, step)
+		on_change.call(v))
+	row.add_child(label)
+	row.add_child(slider)
+	row.add_child(readout)
+	container.add_child(row)
+	return slider
+
+
+static func add_color(container: Node, label_text: String, initial_value: Color,
+		on_change: Callable) -> ColorPickerButton:
+	var row := HBoxContainer.new()
+	var label := Label.new()
+	label.text = label_text
+	label.custom_minimum_size = Vector2(190, 0)
+	var picker := ColorPickerButton.new()
+	picker.color = initial_value
+	picker.edit_alpha = true
+	picker.custom_minimum_size = Vector2(120, 0)
+	picker.color_changed.connect(on_change)
+	row.add_child(label)
+	row.add_child(picker)
+	container.add_child(row)
+	return picker
+
+
+# How many decimals a step implies -- 0.005 prints 3, 1.0 prints 0. Derived rather than declared
+# so a knob's precision cannot disagree with the step it moves in.
+static func format_decimals(value: float, step: float) -> String:
+	var decimals := 0
+	var remaining := absf(step)
+	while remaining > 0.0 and remaining < 1.0 and decimals < 5:
+		remaining *= 10.0
+		decimals += 1
+	return String.num(value, decimals)
+
+
 static func add_checkbox(container: Node, label_text: String, initial_value: bool, on_change: Callable, tooltip := "") -> void:
 	var checkbox := CheckBox.new()
 	checkbox.text = label_text

--- a/Classes/dev/DevWidgets.gd
+++ b/Classes/dev/DevWidgets.gd
@@ -69,29 +69,51 @@ static func add_color(container: Node, label_text: String, initial_value: Color,
 	swatch.color = initial_value
 	swatch.custom_minimum_size = Vector2(30, 0)
 	row.add_child(swatch)
-	var channels: Array[HSlider] = []
+	# The LIVE colour, boxed in a Dictionary because a GDScript lambda captures a local by VALUE --
+	# a plain Color local could not carry an edit from one channel's callback to the next. Editing
+	# one channel replaces only that component, so the untouched three keep their authored float
+	# precision instead of being re-derived through 8-bit and reading as changed.
+	var state := {"color": initial_value}
 	for i in COLOR_CHANNELS.size():
 		var tag := Label.new()
 		tag.text = COLOR_CHANNELS[i]
 		row.add_child(tag)
+		# Slider AND field both work in 0-255, the scale you read off a hex code. One scale, so
+		# typing a number and dragging the handle can never disagree about what the value is.
 		var slider := HSlider.new()
 		slider.min_value = 0.0
-		slider.max_value = 1.0
-		slider.step = 0.01
-		slider.value = initial_value[i]
-		slider.custom_minimum_size = Vector2(56, 0)
+		slider.max_value = 255.0
+		slider.step = 1.0
+		slider.value = roundi(initial_value[i] * 255.0)
+		slider.custom_minimum_size = Vector2(44, 0)
 		slider.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		row.add_child(slider)
-		channels.append(slider)
-	# Connected only once every channel exists -- each callback reads all four to rebuild the Color.
-	for slider: HSlider in channels:
-		slider.value_changed.connect(func(_v: float) -> void:
-			var picked := Color(channels[0].value, channels[1].value,
-				channels[2].value, channels[3].value)
-			swatch.color = picked
-			on_change.call(picked))
+		var field := SpinBox.new()
+		field.min_value = 0
+		field.max_value = 255
+		field.step = 1
+		field.value = slider.value
+		field.custom_minimum_size = Vector2(58, 0)
+		row.add_child(field)
+		# Each drives the other with set_value_no_signal, or the two would bounce a change back
+		# and forth forever.
+		slider.value_changed.connect(func(v: float) -> void:
+			field.set_value_no_signal(v)
+			_write_channel(state, i, v, swatch, on_change))
+		field.value_changed.connect(func(v: float) -> void:
+			slider.set_value_no_signal(v)
+			_write_channel(state, i, v, swatch, on_change))
 	container.add_child(row)
 	return row
+
+
+static func _write_channel(state: Dictionary, index: int, value_255: float,
+		swatch: ColorRect, on_change: Callable) -> void:
+	var color: Color = state["color"]
+	color[index] = value_255 / 255.0
+	state["color"] = color
+	swatch.color = color
+	on_change.call(color)
 
 
 # How many decimals a step implies -- 0.005 prints 3, 1.0 prints 0. Derived rather than declared

--- a/Classes/dev/DevWidgets.gd
+++ b/Classes/dev/DevWidgets.gd
@@ -48,21 +48,50 @@ static func add_slider(container: Node, label_text: String, initial_value: float
 	return slider
 
 
+const COLOR_CHANNELS := ["R", "G", "B", "A"]   # index == Color's own component order
+
+# NO ColorPicker, deliberately. ColorPickerButton froze the dev window solid the first time one
+# was opened (dev, 2026-08-14) -- this window is a real OS window that embeds its own subwindows
+# while the project does not, and CLAUDE.md's sharp edge #4 says prefer Control-based. A plain
+# inline ColorPicker is not the escape either: it carries its own menus for colour mode and picker
+# shape, i.e. the same family one layer down. Four component sliders plus a live swatch are
+# Control-only by construction, and they match the drag idiom the rest of the panel already uses.
+# (OptionButton popups are fine here -- every other dev tab uses them -- so this is a ban on the
+# ColorPicker family, not on popups.)
 static func add_color(container: Node, label_text: String, initial_value: Color,
-		on_change: Callable) -> ColorPickerButton:
+		on_change: Callable) -> HBoxContainer:
 	var row := HBoxContainer.new()
 	var label := Label.new()
 	label.text = label_text
 	label.custom_minimum_size = Vector2(190, 0)
-	var picker := ColorPickerButton.new()
-	picker.color = initial_value
-	picker.edit_alpha = true
-	picker.custom_minimum_size = Vector2(120, 0)
-	picker.color_changed.connect(on_change)
 	row.add_child(label)
-	row.add_child(picker)
+	var swatch := ColorRect.new()
+	swatch.color = initial_value
+	swatch.custom_minimum_size = Vector2(30, 0)
+	row.add_child(swatch)
+	var channels: Array[HSlider] = []
+	for i in COLOR_CHANNELS.size():
+		var tag := Label.new()
+		tag.text = COLOR_CHANNELS[i]
+		row.add_child(tag)
+		var slider := HSlider.new()
+		slider.min_value = 0.0
+		slider.max_value = 1.0
+		slider.step = 0.01
+		slider.value = initial_value[i]
+		slider.custom_minimum_size = Vector2(56, 0)
+		slider.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		row.add_child(slider)
+		channels.append(slider)
+	# Connected only once every channel exists -- each callback reads all four to rebuild the Color.
+	for slider: HSlider in channels:
+		slider.value_changed.connect(func(_v: float) -> void:
+			var picked := Color(channels[0].value, channels[1].value,
+				channels[2].value, channels[3].value)
+			swatch.color = picked
+			on_change.call(picked))
 	container.add_child(row)
-	return picker
+	return row
 
 
 # How many decimals a step implies -- 0.005 prints 3, 1.0 prints 0. Derived rather than declared

--- a/Classes/dev/LookTool.gd
+++ b/Classes/dev/LookTool.gd
@@ -1,0 +1,367 @@
+extends VBoxContainer
+class_name LookTool
+
+# The dev-tools Look tab (#212): the one live surface for the HD-2D stack's aesthetic values.
+# Every KNOBS entry names a property that ALREADY EXISTS on the running Battle3D world -- an
+# @export on a presentation node, or a field of a sub_resource authored in Battle3D.tscn -- and
+# both are reached the same way, via get_indexed/set_indexed. Nothing here stores a value; this
+# is a surface onto values that stay where they always lived. Adding a knob is one table line.
+#
+# The host is PUSHED in by battle3d._ready (attach_host), never looked up: no part of the game
+# subtree gains an upward path to the 3D scene, and launching Main.tscn flat -- a real shipping
+# target -- simply never attaches one, which this reports instead of crashing.
+#
+# Tuning is LIVE ONLY. Copy Values dumps whatever moved off the authored baseline as paste-ready
+# GDScript and the clipboard is the handoff (#212's own call); nothing here writes a file.
+#
+# A knob may only name a property that is authored and READ. Anything the game writes back per
+# frame -- the rig's yaw, dof_blur_near/far_distance (re-derived from focus_band_*), max_distance,
+# orbit_button, manual_input_enabled -- would give a slider that moves and silently reverts, the
+# one failure that makes a tuning panel untrustworthy. tests/dev/test_look_tool.gd pins that by
+# writing, waiting a frame, and reading back.
+
+# node = path relative to the host ("." = the host); prop = colon-joined property path.
+# A float knob carries min/max/step; bool and Color infer their widget from the live value;
+# options = an int-backed enum, labels in declaration order.
+const KNOBS: Array[Dictionary] = [
+	# --- Lighting ---
+	{"group": "Lighting", "node": "Sun", "prop": "light_energy", "label": "Sun energy", "min": 0.0, "max": 6.0, "step": 0.01},
+	{"group": "Lighting", "node": "Sun", "prop": "light_color", "label": "Sun colour"},
+	{"group": "Lighting", "node": "Sun", "prop": "rotation_degrees:x", "label": "Sun elevation", "min": -90.0, "max": 0.0, "step": 0.5},
+	{"group": "Lighting", "node": "Sun", "prop": "rotation_degrees:y", "label": "Sun azimuth", "min": -180.0, "max": 180.0, "step": 0.5},
+	{"group": "Lighting", "node": "Sun", "prop": "shadow_enabled", "label": "Shadows"},
+	# The #226 pair: units reading as hovering is most likely peter-panning, chased by eye.
+	{"group": "Lighting", "node": "Sun", "prop": "shadow_bias", "label": "Shadow bias", "min": 0.0, "max": 0.5, "step": 0.001},
+	{"group": "Lighting", "node": "Sun", "prop": "shadow_normal_bias", "label": "Shadow normal bias", "min": 0.0, "max": 4.0, "step": 0.01},
+	{"group": "Lighting", "node": "Sun", "prop": "shadow_opacity", "label": "Shadow opacity", "min": 0.0, "max": 1.0, "step": 0.01},
+	{"group": "Lighting", "node": "Sun", "prop": "directional_shadow_max_distance", "label": "Shadow draw distance", "min": 10.0, "max": 300.0, "step": 1.0},
+
+	# --- Sky ---
+	{"group": "Sky", "node": "WorldEnvironment", "prop": "environment:sky:sky_material:sky_top_color", "label": "Sky top"},
+	{"group": "Sky", "node": "WorldEnvironment", "prop": "environment:sky:sky_material:sky_horizon_color", "label": "Sky horizon"},
+	{"group": "Sky", "node": "WorldEnvironment", "prop": "environment:sky:sky_material:ground_horizon_color", "label": "Ground horizon"},
+
+	# --- Post ---
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:tonemap_mode", "label": "Tonemap", "options": ["Linear", "Reinhard", "Filmic", "ACES", "AgX"]},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:tonemap_exposure", "label": "Exposure", "min": 0.1, "max": 4.0, "step": 0.01},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:tonemap_white", "label": "White point", "min": 0.1, "max": 4.0, "step": 0.01},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:glow_enabled", "label": "Glow"},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:glow_intensity", "label": "Glow intensity", "min": 0.0, "max": 4.0, "step": 0.01},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:glow_strength", "label": "Glow strength", "min": 0.0, "max": 2.0, "step": 0.01},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:glow_bloom", "label": "Glow bloom", "min": 0.0, "max": 1.0, "step": 0.01},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:glow_hdr_threshold", "label": "Glow HDR threshold", "min": 0.0, "max": 4.0, "step": 0.01},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:ssao_enabled", "label": "SSAO"},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:ssao_radius", "label": "SSAO radius", "min": 0.1, "max": 8.0, "step": 0.05},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:ssao_intensity", "label": "SSAO intensity", "min": 0.0, "max": 8.0, "step": 0.05},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:ssao_power", "label": "SSAO power", "min": 0.1, "max": 8.0, "step": 0.05},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:adjustment_enabled", "label": "Colour adjust"},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:adjustment_brightness", "label": "Brightness", "min": 0.1, "max": 3.0, "step": 0.01},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:adjustment_contrast", "label": "Contrast", "min": 0.1, "max": 3.0, "step": 0.01},
+	{"group": "Post", "node": "WorldEnvironment", "prop": "environment:adjustment_saturation", "label": "Saturation", "min": 0.0, "max": 3.0, "step": 0.01},
+
+	# --- Fog ---
+	# The sunset preset reading as a forest fire is the case #212 was filed over.
+	{"group": "Fog", "node": "WorldEnvironment", "prop": "environment:volumetric_fog_enabled", "label": "Volumetric fog"},
+	{"group": "Fog", "node": "WorldEnvironment", "prop": "environment:volumetric_fog_density", "label": "Fog density", "min": 0.0, "max": 0.2, "step": 0.001},
+	{"group": "Fog", "node": "WorldEnvironment", "prop": "environment:volumetric_fog_albedo", "label": "Fog albedo"},
+	{"group": "Fog", "node": "WorldEnvironment", "prop": "environment:volumetric_fog_anisotropy", "label": "Fog anisotropy", "min": -0.9, "max": 0.9, "step": 0.01},
+
+	# --- Camera ---
+	{"group": "Camera", "node": "CameraRig/Pitch", "prop": "rotation_degrees:x", "label": "Board pitch", "min": -85.0, "max": -10.0, "step": 0.5},
+	{"group": "Camera", "node": "CameraRig/Pitch/Camera", "prop": "fov", "label": "FOV", "min": 12.0, "max": 70.0, "step": 0.5},
+	{"group": "Camera", "node": ".", "prop": "opening_view_cells", "label": "Opening shot (cells)", "min": 6.0, "max": 64.0, "step": 1.0},
+	{"group": "Camera", "node": "CameraRig", "prop": "min_distance", "label": "Zoom-in limit", "min": 2.0, "max": 20.0, "step": 0.25},
+	{"group": "Camera", "node": "CameraRig", "prop": "zoom_step", "label": "Zoom step", "min": 0.25, "max": 5.0, "step": 0.05},
+	{"group": "Camera", "node": "CameraRig", "prop": "smoothing", "label": "Camera smoothing", "min": 1.0, "max": 24.0, "step": 0.1},
+	{"group": "Camera", "node": "CameraRig", "prop": "pan_speed", "label": "Pan speed", "min": 1.0, "max": 30.0, "step": 0.5},
+	{"group": "Camera", "node": "CameraRig", "prop": "orbit_sensitivity", "label": "Orbit sensitivity", "min": 0.02, "max": 1.0, "step": 0.01},
+	{"group": "Camera", "node": "CameraRig", "prop": "pan_margin_cells", "label": "Pan margin (cells)", "min": 0.0, "max": 12.0, "step": 0.5},
+	{"group": "Camera", "node": "CameraRig", "prop": "fit_margin_cells", "label": "Fit margin (cells)", "min": 0.0, "max": 8.0, "step": 0.25},
+	{"group": "Camera", "node": "CameraRig", "prop": "zoom_out_slack", "label": "Zoom-out slack", "min": 0.5, "max": 3.0, "step": 0.05},
+
+	# --- Depth of field ---
+	# The BANDS are the knobs; the distances they produce are re-derived per frame off the live
+	# camera distance, which is what stopped close zooms drifting the board into the near blur.
+	{"group": "Depth of field", "node": "CameraRig", "prop": "focus_band_near", "label": "Near band", "min": 0.5, "max": 20.0, "step": 0.1},
+	{"group": "Depth of field", "node": "CameraRig", "prop": "focus_band_far", "label": "Far band", "min": 0.5, "max": 20.0, "step": 0.1},
+	{"group": "Depth of field", "node": "CameraRig/Pitch/Camera", "prop": "attributes:dof_blur_amount", "label": "Blur amount", "min": 0.0, "max": 0.5, "step": 0.005},
+	{"group": "Depth of field", "node": "CameraRig/Pitch/Camera", "prop": "attributes:dof_blur_near_enabled", "label": "Near blur"},
+	{"group": "Depth of field", "node": "CameraRig/Pitch/Camera", "prop": "attributes:dof_blur_near_transition", "label": "Near transition", "min": 0.1, "max": 20.0, "step": 0.1},
+	{"group": "Depth of field", "node": "CameraRig/Pitch/Camera", "prop": "attributes:dof_blur_far_enabled", "label": "Far blur"},
+	{"group": "Depth of field", "node": "CameraRig/Pitch/Camera", "prop": "attributes:dof_blur_far_transition", "label": "Far transition", "min": 0.1, "max": 20.0, "step": 0.1},
+
+	# --- Board markup ---
+	# fill_lift and lift_step raise every ground marker together, arrows included. A lift the
+	# ARROWS own alone (#227) needs its own export on BoardOverlays -- not in this slice.
+	{"group": "Board markup", "node": "BoardOverlays", "prop": "fill_lift", "label": "Marker lift", "min": 0.0, "max": 0.5, "step": 0.001},
+	{"group": "Board markup", "node": "BoardOverlays", "prop": "lift_step", "label": "Per-layer lift step", "min": 0.0, "max": 0.05, "step": 0.0005},
+	{"group": "Board markup", "node": "BoardOverlays", "prop": "bracket_arm", "label": "Bracket arm", "min": 0.05, "max": 0.5, "step": 0.005},
+	{"group": "Board markup", "node": "BoardOverlays", "prop": "bracket_thickness", "label": "Bracket thickness", "min": 0.005, "max": 0.2, "step": 0.001},
+	{"group": "Board markup", "node": "BoardOverlays", "prop": "bracket_scale", "label": "Bracket scale", "min": 0.9, "max": 1.3, "step": 0.005},
+	{"group": "Board markup", "node": "BoardOverlays", "prop": "invalid_bracket_color", "label": "Invalid bracket tint"},
+	{"group": "Board markup", "node": "BoardOverlays", "prop": "billboard_lift", "label": "Icon height", "min": 0.0, "max": 3.0, "step": 0.01},
+	{"group": "Board markup", "node": "BoardOverlays", "prop": "billboard_pixel_size", "label": "Icon pixel size", "min": 0.004, "max": 0.1, "step": 0.001},
+
+	# --- Effects ---
+	{"group": "Effects", "node": "BoardMirror", "prop": "flame_lift", "label": "Flame lift", "min": 0.0, "max": 2.0, "step": 0.01},
+	{"group": "Effects", "node": "BoardMirror", "prop": "flame_size:x", "label": "Flame width", "min": 0.1, "max": 2.0, "step": 0.01},
+	{"group": "Effects", "node": "BoardMirror", "prop": "flame_size:y", "label": "Flame height", "min": 0.1, "max": 2.0, "step": 0.01},
+	{"group": "Effects", "node": "BoardMirror", "prop": "flame_ground_gap", "label": "Flame ground gap", "min": 0.0, "max": 0.5, "step": 0.005},
+	{"group": "Effects", "node": "BoardMirror", "prop": "flame_writes_depth", "label": "Flame writes depth"},
+	{"group": "Effects", "node": "BoardMirror", "prop": "flame_light_energy", "label": "Flame light energy", "min": 0.0, "max": 8.0, "step": 0.05},
+	{"group": "Effects", "node": "BoardMirror", "prop": "flame_light_range", "label": "Flame light range", "min": 0.5, "max": 12.0, "step": 0.1},
+	{"group": "Effects", "node": "BoardMirror", "prop": "brush_ghost_alpha", "label": "Brush ghost alpha", "min": 0.0, "max": 1.0, "step": 0.01},
+]
+
+const HEADING_COLOR := Color(1, 0.83, 0.4, 1)   # the Scenario tab's heading gold
+
+var _host: Node3D                # the Battle3D scene; pushed in, never looked up
+var _baseline: Array = []        # the authored value per KNOBS index, read once on attach
+var _rows: VBoxContainer
+var _status: Label
+
+
+func _ready() -> void:
+	var buttons := HBoxContainer.new()
+	buttons.add_child(_button("Copy changed values",
+		"Copy every value moved off its authored setting to the clipboard, as paste-ready GDScript",
+		_on_copy_pressed))
+	buttons.add_child(_button("Reset to authored",
+		"Put every knob back to the value the scene was authored with", _on_reset_pressed))
+	buttons.add_child(_button("Re-fit camera",
+		"Pitch and FOV feed the framing maths, which only runs on a board load -- press this after moving either",
+		_on_refit_pressed))
+	add_child(buttons)
+	_status = Label.new()
+	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	add_child(_status)
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	add_child(scroll)
+	_rows = VBoxContainer.new()
+	_rows.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(_rows)
+	_rebuild()
+
+
+# Called by battle3d._ready. The 2D game boots first (Godot readies children before parents), so
+# the tab always builds its no-host state and then rebuilds here.
+func attach_host(host: Node3D) -> void:
+	_host = host
+	_baseline.clear()
+	for knob: Dictionary in KNOBS:
+		_baseline.append(read(knob))   # authored by definition: nothing has moved one yet
+	_rebuild()
+
+
+func has_host() -> bool:
+	return _host != null
+
+
+# --- Reading and writing a knob ---------------------------------------------------------
+
+func target_of(knob: Dictionary) -> Node:
+	if _host == null:
+		return null
+	var path: String = knob["node"]
+	if path == ".":
+		return _host
+	return _host.get_node_or_null(NodePath(path))
+
+
+func read(knob: Dictionary) -> Variant:
+	var target := target_of(knob)
+	if target == null:
+		return null
+	return target.get_indexed(NodePath(knob["prop"]))
+
+
+func write(knob: Dictionary, value: Variant) -> void:
+	var target := target_of(knob)
+	if target == null:
+		return
+	target.set_indexed(NodePath(knob["prop"]), value)
+
+
+func baseline_of(index: int) -> Variant:
+	if index < 0 or index >= _baseline.size():
+		return null
+	return _baseline[index]
+
+
+# --- Building the rows ------------------------------------------------------------------
+
+func _rebuild() -> void:
+	for child in _rows.get_children():
+		_rows.remove_child(child)
+		child.queue_free()
+	if _host == null:
+		DevWidgets.add_label(_rows,
+			"No 3D host attached - the flat 2D game has no look stack to tune.")
+		return
+	var group := ""
+	for knob: Dictionary in KNOBS:
+		var knob_group: String = knob["group"]
+		if knob_group != group:
+			group = knob_group
+			_add_heading(group)
+		_build_row(knob)
+
+
+func _build_row(knob: Dictionary) -> void:
+	var value: Variant = read(knob)
+	var label: String = knob["label"]
+	# An unresolved knob is a table entry pointing at a renamed or moved property. Say so on the
+	# panel AND in the log rather than drawing a row that edits nothing.
+	if typeof(value) == TYPE_NIL:
+		DevWidgets.add_label(_rows, "%s - UNRESOLVED (%s:%s)" % [label, knob["node"], knob["prop"]])
+		push_error("LookTool knob does not resolve: %s:%s" % [knob["node"], knob["prop"]])
+		return
+	if knob.has("options"):
+		var options: Array = knob["options"]
+		var current: int = int(value)
+		var current_label: String = options[current] if current >= 0 and current < options.size() else ""
+		DevWidgets.add_option(_rows, label, options, current_label,
+			func(picked: String) -> void: write(knob, options.find(picked)))
+		return
+	match typeof(value):
+		TYPE_BOOL:
+			DevWidgets.add_checkbox(_rows, label, value,
+				func(on: bool) -> void: write(knob, on))
+		TYPE_COLOR:
+			DevWidgets.add_color(_rows, label, value,
+				func(picked: Color) -> void: write(knob, picked))
+		_:
+			var low: float = knob["min"]
+			var high: float = knob["max"]
+			var step: float = knob["step"]
+			DevWidgets.add_slider(_rows, label, value, low, high, step,
+				func(moved: float) -> void: write(knob, moved))
+
+
+func _add_heading(text: String) -> void:
+	if _rows.get_child_count() > 0:
+		_rows.add_child(HSeparator.new())
+	var heading := Label.new()
+	heading.text = text
+	heading.add_theme_color_override("font_color", HEADING_COLOR)
+	_rows.add_child(heading)
+
+
+func _button(text: String, tooltip: String, on_pressed: Callable) -> Button:
+	var button := Button.new()
+	button.text = text
+	button.tooltip_text = tooltip
+	button.pressed.connect(on_pressed)
+	return button
+
+
+# --- The handoff ------------------------------------------------------------------------
+
+func _on_copy_pressed() -> void:
+	var moved := changed_values()
+	if moved.is_empty():
+		_status.text = "Nothing has moved off its authored value yet."
+		return
+	DisplayServer.clipboard_set(_format(moved))
+	_status.text = "Copied %d changed value(s) to the clipboard." % _value_count(moved)
+
+
+func _on_reset_pressed() -> void:
+	if _host == null:
+		return
+	for i in KNOBS.size():
+		var authored: Variant = baseline_of(i)
+		if typeof(authored) != TYPE_NIL:
+			write(KNOBS[i], authored)
+	_rebuild()   # redraw every widget off the restored values -- one path, every widget kind
+	_status.text = "Every knob is back at its authored value."
+
+
+func _on_refit_pressed() -> void:
+	if _host == null:
+		return
+	_host.fit_camera()
+	_status.text = "Camera re-framed on the current board."
+
+
+# Only what MOVED, keyed by where it gets pasted: header -> {property: literal}. A property path
+# that passes through a sub-resource is authored INSIDE that resource, so the header names the
+# resource and the line is what goes in it. A vector component (flame_size:x) has no resource
+# between it and the node, so the whole vector is emitted -- "x = 0.6" would mean nothing in a
+# .tscn, and it also collapses the x and y knobs into the single line they share.
+func changed_values() -> Dictionary:
+	var groups := {}
+	for i in KNOBS.size():
+		var knob: Dictionary = KNOBS[i]
+		var live: Variant = read(knob)
+		var authored: Variant = baseline_of(i)
+		if typeof(live) == TYPE_NIL or typeof(authored) == TYPE_NIL or live == authored:
+			continue
+		var split := _paste_split(knob)
+		var header: String = split[0]
+		if not groups.has(header):
+			groups[header] = {}
+		var entries: Dictionary = groups[header]
+		entries[split[1]] = split[2]
+	return groups
+
+
+func _paste_split(knob: Dictionary) -> Array:
+	var segments: PackedStringArray = String(knob["prop"]).split(":")
+	var current: Object = target_of(knob)
+	var owner_bits: PackedStringArray = PackedStringArray()
+	var i := 0
+	# Walk to the DEEPEST object in the chain: that is the thing the value is authored on.
+	while i < segments.size() - 1:
+		var next: Variant = current.get(segments[i])
+		if not (next is Object):
+			break
+		owner_bits.append(segments[i])
+		current = next as Object
+		i += 1
+	var node_path: String = knob["node"]
+	var header := "Battle3D.tscn -> %s" % ("Battle3D" if node_path == "." else node_path)
+	if owner_bits.size() > 0:
+		header += ".%s" % ".".join(owner_bits)
+	return [header, segments[i], literal_for(current.get(segments[i]))]
+
+
+func _format(groups: Dictionary) -> String:
+	var out: PackedStringArray = PackedStringArray()
+	for header: String in groups:
+		out.append("# %s" % header)
+		var entries: Dictionary = groups[header]
+		for prop: String in entries:
+			out.append("%s = %s" % [prop, entries[prop]])
+		out.append("")
+	return "\n".join(out).strip_edges()
+
+
+func _value_count(groups: Dictionary) -> int:
+	var total := 0
+	for header: String in groups:
+		var entries: Dictionary = groups[header]
+		total += entries.size()
+	return total
+
+
+static func literal_for(value: Variant) -> String:
+	match typeof(value):
+		TYPE_BOOL:
+			return "true" if value else "false"
+		TYPE_FLOAT:
+			return String.num(value, 4)
+		TYPE_COLOR:
+			var color: Color = value
+			return "Color(%s, %s, %s, %s)" % [String.num(color.r, 4), String.num(color.g, 4),
+				String.num(color.b, 4), String.num(color.a, 4)]
+		TYPE_VECTOR2:
+			var vec2: Vector2 = value
+			return "Vector2(%s, %s)" % [String.num(vec2.x, 4), String.num(vec2.y, 4)]
+		TYPE_VECTOR3:
+			var vec3: Vector3 = value
+			return "Vector3(%s, %s, %s)" % [String.num(vec3.x, 4), String.num(vec3.y, 4),
+				String.num(vec3.z, 4)]
+	return str(value)

--- a/Classes/dev/LookTool.gd
+++ b/Classes/dev/LookTool.gd
@@ -297,7 +297,7 @@ func changed_values() -> Dictionary:
 		var knob: Dictionary = KNOBS[i]
 		var live: Variant = read(knob)
 		var authored: Variant = baseline_of(i)
-		if typeof(live) == TYPE_NIL or typeof(authored) == TYPE_NIL or live == authored:
+		if typeof(live) == TYPE_NIL or typeof(authored) == TYPE_NIL or same_value(live, authored):
 			continue
 		var split := _paste_split(knob)
 		var header: String = split[0]
@@ -345,6 +345,26 @@ func _value_count(groups: Dictionary) -> int:
 		var entries: Dictionary = groups[header]
 		total += entries.size()
 	return total
+
+
+# "Has this moved?" -- approximate for floats, because a value written and read straight back is
+# not always bit-identical: engine properties store single-precision, and a euler component
+# round-trips through a basis. Exact compare reported the sun and board pitch as still changed
+# immediately after Reset had put them back, and would do the same to a slider dragged out and
+# returned. Every slider step here is orders of magnitude coarser than these tolerances.
+static func same_value(a: Variant, b: Variant) -> bool:
+	if typeof(a) != typeof(b):
+		return false
+	match typeof(a):
+		TYPE_FLOAT:
+			return is_equal_approx(a, b)
+		TYPE_COLOR:
+			return (a as Color).is_equal_approx(b)
+		TYPE_VECTOR2:
+			return (a as Vector2).is_equal_approx(b)
+		TYPE_VECTOR3:
+			return (a as Vector3).is_equal_approx(b)
+	return a == b
 
 
 static func literal_for(value: Variant) -> String:

--- a/Classes/dev/LookTool.gd.uid
+++ b/Classes/dev/LookTool.gd.uid
@@ -1,0 +1,1 @@
+uid://bcbffqpluylnk

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -96,6 +96,10 @@ func _ready() -> void:
 	var dev_overlay: Node = _main.get_node_or_null("DevOverlay")
 	if dev_overlay is Window:
 		(dev_overlay as Window).visible = false
+	# PUSH the 3D world at the Look tab rather than letting it reach up for one (#212): the game
+	# subtree keeps no path to this scene, and a flat Main.tscn launch simply never gets a host.
+	if dev_overlay is DevOverlay:
+		(dev_overlay as DevOverlay).attach_look_host(self)
 	if demo_mode:
 		_game_container.visible = false
 		_help.text = "Battle3D mirror (demo mode, read-only)  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset"
@@ -137,7 +141,7 @@ func load_mission(path: String) -> void:
 # would otherwise eat the first repaint on a same-coordinate cell.
 func _on_board_loaded() -> void:
 	rebuild()
-	_fit_camera()
+	fit_camera()
 	_pointer_cell = BoardSpace.NO_CELL
 	_overlays.clear_all()
 
@@ -175,7 +179,9 @@ func _sync_terrain_while_authoring() -> void:
 		_rig.rebound(_board_volume())
 
 
-func _fit_camera() -> void:
+# Public because the Look tab's Re-fit button calls it (#212): pitch and FOV feed the framing
+# maths, which otherwise only runs on a board load, so tuning either leaves the shot stale.
+func fit_camera() -> void:
 	var board := _board_volume()
 	_rig.frame(_opening_volume(board), board)
 

--- a/Scenes/DevOverlay.tscn
+++ b/Scenes/DevOverlay.tscn
@@ -9,6 +9,7 @@
 [ext_resource type="Script" path="res://Classes/dev/CharacterEditorTool.gd" id="4_chr79"]
 [ext_resource type="Script" uid="uid://bgy2v6i3ovpuq" path="res://Classes/dev/AttackEditorTool.gd" id="5_qihyv"]
 [ext_resource type="ButtonGroup" uid="uid://6a8b7yuy02ce" path="res://Classes/dev/AttackTypeToggle.tres" id="6_p14e7"]
+[ext_resource type="Script" path="res://Classes/dev/LookTool.gd" id="7_look1"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1dnd3"]
 bg_color = Color(0.4416867, 0.22230786, 0.4029888, 1)
@@ -483,6 +484,13 @@ offset_bottom = 40.0
 [node name="TileBoxCheck" type="CheckBox" parent="Panel/MarginContainer/VBoxContainer/DevTabs/Tile Brush/Panel/TileBrushRow" unique_id=38756860]
 layout_mode = 2
 text = "Tile Brush on/off"
+
+[node name="Look" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DevTabs" unique_id=990000050]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+script = ExtResource("7_look1")
+metadata/_tab_index = 6
 
 [connection signal="toggled" from="Panel/MarginContainer/VBoxContainer/DevModeToggle" to="." method="_on_dev_mode_toggled"]
 [connection signal="text_changed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/UnitNameInput" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" method="_on_unit_name_input_text_changed"]

--- a/tests/dev/test_look_tool.gd
+++ b/tests/dev/test_look_tool.gd
@@ -126,14 +126,51 @@ func test_dragging_a_slider_moves_the_live_property() -> void:
 
 
 func _slider_for(label_text: String) -> HSlider:
+	return _row_for(label_text).get_child(1) as HSlider
+
+
+func _row_for(label_text: String) -> HBoxContainer:
 	for row in _look._rows.get_children():
 		var box := row as HBoxContainer
 		if box == null:
 			continue
 		var label := box.get_child(0) as Label
 		if label != null and label.text == label_text:
-			return box.get_child(1) as HSlider
+			return box
 	return null
+
+
+# A colour knob is FOUR sliders and a swatch, not a picker. ColorPickerButton froze the dev window
+# solid the first time one was opened (dev, 2026-08-14), so the ban is a law with a test rather
+# than a comment that the next colour knob quietly re-breaks. It bans the ColorPicker FAMILY, not
+# popups -- the tonemap OptionButton on this same panel is fine, as it is on every other dev tab.
+func test_the_panel_builds_no_colorpicker_widgets() -> void:
+	var offenders: Array[String] = []
+	_walk_for_pickers(_look, offenders)
+	assert_array(offenders).override_failure_message(
+		"ColorPicker widgets in the Look tab (these freeze the dev window): %s"
+		% ", ".join(offenders)).is_empty()
+
+
+func _walk_for_pickers(node: Node, offenders: Array[String]) -> void:
+	for child in node.get_children(true):   # include internal children
+		if child is ColorPicker or child is ColorPickerButton:
+			offenders.append("%s (%s)" % [child.name, child.get_class()])
+		_walk_for_pickers(child, offenders)
+
+
+func test_dragging_a_colour_channel_moves_the_live_property() -> void:
+	var knob := _knob("Sun", "light_color")
+	var row := _row_for(knob["label"])
+	assert_object(row).is_not_null()
+	var before: Color = _look.read(knob)
+	# Child order is label, swatch, then (tag, slider) per channel -- index 3 is the R slider.
+	var red := row.get_child(3) as HSlider
+	assert_object(red).is_not_null()
+	red.value = 0.5
+	var after: Color = _look.read(knob)
+	assert_float(after.r).is_equal_approx(0.5, 0.005)
+	assert_float(after.g).is_equal_approx(before.g, 0.005)   # the other channels are untouched
 
 
 # --- The handoff --------------------------------------------------------------------------

--- a/tests/dev/test_look_tool.gd
+++ b/tests/dev/test_look_tool.gd
@@ -159,18 +159,32 @@ func _walk_for_pickers(node: Node, offenders: Array[String]) -> void:
 		_walk_for_pickers(child, offenders)
 
 
+# Child order is label, swatch, then (tag, slider, field) per channel: 3 = R slider, 4 = R field.
 func test_dragging_a_colour_channel_moves_the_live_property() -> void:
 	var knob := _knob("Sun", "light_color")
 	var row := _row_for(knob["label"])
 	assert_object(row).is_not_null()
 	var before: Color = _look.read(knob)
-	# Child order is label, swatch, then (tag, slider) per channel -- index 3 is the R slider.
 	var red := row.get_child(3) as HSlider
 	assert_object(red).is_not_null()
-	red.value = 0.5
+	red.value = 128.0                                        # 0-255, the scale a hex code is in
 	var after: Color = _look.read(knob)
-	assert_float(after.r).is_equal_approx(0.5, 0.005)
-	assert_float(after.g).is_equal_approx(before.g, 0.005)   # the other channels are untouched
+	assert_float(after.r).is_equal_approx(128.0 / 255.0, 0.005)
+	# Editing R must not re-quantise the others through 8-bit -- G is authored 0.985, and a
+	# round trip would land it on 0.9843 and report the colour as changed when it was not.
+	assert_float(after.g).is_equal_approx(before.g, 0.0001)
+
+
+# Typing a number is its own wire: the field could be built, display correctly, and drive nothing.
+func test_typing_a_colour_channel_moves_the_live_property_and_the_slider() -> void:
+	var knob := _knob("Sun", "light_color")
+	var row := _row_for(knob["label"])
+	var slider := row.get_child(3) as HSlider
+	var field := row.get_child(4) as SpinBox
+	assert_object(field).is_not_null()
+	field.value = 64.0
+	assert_float(_look.read(knob).r).is_equal_approx(64.0 / 255.0, 0.005)
+	assert_float(slider.value).is_equal_approx(64.0, 0.001)   # the two never disagree
 
 
 # --- The handoff --------------------------------------------------------------------------

--- a/tests/dev/test_look_tool.gd
+++ b/tests/dev/test_look_tool.gd
@@ -1,0 +1,189 @@
+# The Look tab (#212). Two of these are laws rather than examples.
+#
+# "Every knob resolves" catches a table entry left pointing at a renamed or moved property --
+# the drift a pointer-shaped table is exposed to.
+#
+# "A written knob survives the next frame" is the one that matters: a knob may only name a
+# property that is authored and READ, never one the game writes back per frame. Pointed at
+# runtime-written state (the rig's yaw, dof_blur_*_distance, max_distance, orbit_button) a
+# slider moves and silently reverts, which is the failure that makes a tuning panel worthless.
+# Writing and asserting immediately cannot see it -- the write always lands -- so these wait
+# TWO frames: process_frame resumes a coroutine BEFORE node _process runs (#215's lesson), so
+# one await proves nothing about what _process does with the value.
+#
+# The host arriving at all is a WIRE, not two ends: the suite instantiates the real Battle3D
+# scene and lets battle3d._ready push, rather than calling attach_host itself.
+extends GdUnitTestSuite
+
+const SCENE_PATH := "res://Scenes/Battle3D/Battle3D.tscn"
+
+var _scene: Node3D
+var _look: LookTool
+
+
+func before_test() -> void:
+	var packed := load(SCENE_PATH) as PackedScene
+	_scene = packed.instantiate() as Node3D
+	_scene.auto_play = false   # no board needed: every knob is a scene property
+	get_tree().root.add_child(_scene)
+	await await_idle_frame()
+	var dev_overlay := _scene.get_node("Main/DevOverlay") as DevOverlay
+	_look = dev_overlay.look_tool
+
+
+func after_test() -> void:
+	get_tree().root.remove_child(_scene)
+	_scene.free()
+
+
+# --- Helpers ---------------------------------------------------------------------------
+
+func _knob(node: String, prop: String) -> Dictionary:
+	for knob: Dictionary in LookTool.KNOBS:
+		if knob["node"] == node and knob["prop"] == prop:
+			return knob
+	return {}
+
+
+# A different, legal value for whatever kind this knob holds.
+func _nudged(knob: Dictionary, value: Variant) -> Variant:
+	if knob.has("options"):
+		var options: Array = knob["options"]
+		return (int(value) + 1) % options.size()
+	match typeof(value):
+		TYPE_BOOL:
+			return not value
+		TYPE_COLOR:
+			var color: Color = value
+			return Color(color.r, color.g, color.b, fposmod(color.a + 0.3, 1.0))
+		_:
+			var low: float = knob["min"]
+			var high: float = knob["max"]
+			var current: float = value
+			var step: float = (high - low) * 0.1
+			return current - step if current + step > high else current + step
+
+
+# --- The laws ---------------------------------------------------------------------------
+
+func test_battle3d_hands_the_look_tab_its_host() -> void:
+	assert_bool(_look.has_host()).is_true()
+
+
+func test_every_knob_resolves_against_the_real_scene() -> void:
+	var unresolved: Array[String] = []
+	for knob: Dictionary in LookTool.KNOBS:
+		if typeof(_look.read(knob)) == TYPE_NIL:
+			unresolved.append("%s:%s" % [knob["node"], knob["prop"]])
+	assert_array(unresolved).override_failure_message(
+		"Knobs pointing at nothing: %s" % ", ".join(unresolved)).is_empty()
+
+
+func test_a_written_knob_survives_the_next_frame() -> void:
+	var wanted: Array = []
+	var inert: Array[String] = []
+	for knob: Dictionary in LookTool.KNOBS:
+		var value: Variant = _look.read(knob)
+		if typeof(value) == TYPE_NIL:
+			continue
+		_look.write(knob, _nudged(knob, value))
+		# Compare against what the property ACCEPTED, never against what was asked for:
+		# engine-backed floats are single-precision, so a double asked for and the float
+		# stored differ in the last bits and every one of these would read as a revert.
+		# A real per-frame overwrite still fails, which mutant 2 in the PR body proves.
+		var stored: Variant = _look.read(knob)
+		if stored == value:
+			inert.append("%s:%s" % [knob["node"], knob["prop"]])
+			continue
+		wanted.append({"knob": knob, "want": stored})
+	# A knob whose nudge never registered would sail through the survival check below without
+	# testing anything -- a set_indexed that silently does nothing looks identical to a value
+	# that held. Fail on it separately rather than letting it hide.
+	assert_array(inert).override_failure_message(
+		"Knobs that did not take a write at all: %s" % ", ".join(inert)).is_empty()
+	# Two frames: the first resumes this coroutine before any node _process has run.
+	await await_idle_frame()
+	await await_idle_frame()
+	var reverted: Array[String] = []
+	for entry: Dictionary in wanted:
+		var knob: Dictionary = entry["knob"]
+		if _look.read(knob) != entry["want"]:
+			reverted.append("%s:%s" % [knob["node"], knob["prop"]])
+	assert_array(reverted).override_failure_message(
+		"Knobs the game writes back (a slider here would lie): %s" % ", ".join(reverted)).is_empty()
+
+
+# The panel's own WIRE. Every other case here calls write() directly, so without this the rows
+# could be built completely disconnected and the whole suite would stay green -- two ends, no
+# wire. A slider is what actually gets dragged.
+func test_dragging_a_slider_moves_the_live_property() -> void:
+	var knob := _knob("BoardOverlays", "fill_lift")
+	var slider := _slider_for(knob["label"])
+	assert_object(slider).is_not_null()
+	var before: float = _look.read(knob)
+	slider.value = before + 0.05
+	assert_float(_look.read(knob)).is_equal_approx(before + 0.05, 0.0005)
+
+
+func _slider_for(label_text: String) -> HSlider:
+	for row in _look._rows.get_children():
+		var box := row as HBoxContainer
+		if box == null:
+			continue
+		var label := box.get_child(0) as Label
+		if label != null and label.text == label_text:
+			return box.get_child(1) as HSlider
+	return null
+
+
+# --- The handoff --------------------------------------------------------------------------
+
+func test_nothing_is_reported_changed_until_something_moves() -> void:
+	assert_dict(_look.changed_values()).is_empty()
+
+
+func test_a_moved_knob_is_reported_under_its_paste_target() -> void:
+	var knob := _knob("WorldEnvironment", "environment:glow_hdr_threshold")
+	_look.write(knob, _nudged(knob, _look.read(knob)))
+	var changed := _look.changed_values()
+	# The header names the RESOURCE the value is authored in, not just the node -- that is
+	# where the line gets pasted.
+	assert_dict(changed).contains_keys(["Battle3D.tscn -> WorldEnvironment.environment"])
+	var entries: Dictionary = changed["Battle3D.tscn -> WorldEnvironment.environment"]
+	assert_dict(entries).contains_keys(["glow_hdr_threshold"])
+
+
+# A vector component has no resource between it and the node, so the whole vector is emitted:
+# "x = 0.6" would mean nothing pasted into a .tscn, and the x and y knobs share one line.
+func test_a_vector_component_knob_emits_the_whole_vector() -> void:
+	var knob := _knob("BoardMirror", "flame_size:x")
+	_look.write(knob, _nudged(knob, _look.read(knob)))
+	var entries: Dictionary = _look.changed_values()["Battle3D.tscn -> BoardMirror"]
+	assert_dict(entries).contains_keys(["flame_size"])
+	assert_str(entries["flame_size"]).starts_with("Vector2(")
+
+
+func test_reset_puts_every_knob_back_to_its_authored_value() -> void:
+	for knob: Dictionary in LookTool.KNOBS:
+		var value: Variant = _look.read(knob)
+		if typeof(value) != TYPE_NIL:
+			_look.write(knob, _nudged(knob, value))
+	assert_dict(_look.changed_values()).is_not_empty()
+	_look._on_reset_pressed()
+	assert_dict(_look.changed_values()).is_empty()
+	# Reset redraws every row, and a detached-then-queue_free'd node reads as a gdUnit orphan
+	# until a frame processes the queue (#215's lesson).
+	await await_idle_frame()
+
+
+# The flat 2D game is a real shipping target and never gets a host; the tab reports that
+# instead of crashing on every read.
+func test_a_tab_with_no_host_degrades_instead_of_crashing() -> void:
+	var orphan := LookTool.new()
+	add_child(orphan)
+	await await_idle_frame()
+	assert_bool(orphan.has_host()).is_false()
+	assert_object(orphan.read(LookTool.KNOBS[0])).is_null()
+	assert_dict(orphan.changed_values()).is_empty()
+	orphan.queue_free()
+	await await_idle_frame()

--- a/tests/dev/test_look_tool.gd.uid
+++ b/tests/dev/test_look_tool.gd.uid
@@ -1,0 +1,1 @@
+uid://vq4uqe0umeya


### PR DESCRIPTION
Closes the first slice of #212: a **Look** tab in the dev-tools window (7th top-level tab, `DevTools.enabled()`-gated like the rest) that tunes the HD-2D stack live on the real board and hands back a paste-ready list of only what you moved.

## The scope call worth knowing about

#212 was written for the standalone `Scenes/LookDev/` diorama — "no DevOverlay dependency, the scene stays standalone". That was right in stage 0 and is wrong now: `Battle3D.tscn` is the boot scene, so the look worth tuning is the shipping one. This tab drives the live Battle3D world; the LookDev diorama and its preset keys are untouched.

## One mechanism, ~60 knobs

Every knob names a property that **already exists** on the running scene, in one of two homes — an `@export` on a presentation node (`BoardOverlays`, `BoardMirror`, the camera rig, `battle3d` itself), or a field of a sub-resource authored in `Battle3D.tscn` (the `Environment`, the `Sun`, the `CameraAttributesPractical` DoF block, the sky material). Both are reached through `get_indexed`/`set_indexed`, which walks a `node:resource:property` path, so **one table addresses both** and adding a knob is one line. Nothing in this tab stores a value.

Grouped as Lighting / Sky / Post / Fog / Camera / Depth of field / Board markup / Effects.

## Structural choices, stated rather than buried in the diff

**The host is pushed, not looked up.** `battle3d._ready` hands itself to the tab through the `DevOverlay` reference it already holds to hide the window. The alternative — the tab reaching up from `Main/DevOverlay` to its grandparent — would have put the first upward path from the game subtree into the 3D scene, which is the shape that made F1 dead when an absolute `/root/Main/...` path stopped resolving. It also means launching `Main.tscn` flat (still a real shipping target) simply never attaches a host, and the tab says so instead of crashing.

**A knob may only name a property that is authored and READ.** Anything the game writes back per frame would give a slider that moves and silently reverts — the failure that makes a whole tuning panel untrustworthy. Traced and deliberately excluded: the rig's yaw, `dof_blur_near/far_distance` (re-derived each frame from `focus_band_*`, which is why the *bands* are the knobs), `max_distance`, `orbit_button`, `manual_input_enabled`, and the HOVER layer's modulate. This is a law with a test, not a comment.

**"Has this moved?" is an approximate compare, and that was a real find.** A value written and read straight back is not bit-identical: engine properties store single-precision, and a euler component round-trips through a basis. With an exact compare, Copy Values listed the sun and board pitch as still changed *immediately after Reset had put them back* — and would have done the same to any slider you dragged out and returned. Every slider step here is orders of magnitude coarser than the tolerance.

**`fit_camera` is now public** (was `_fit_camera`, two call sites). Pitch and FOV feed framing maths that otherwise only runs on a board load, so tuning either leaves the shot stale — the Re-fit button is the fix.

**`DevWidgets` grew `add_slider` and `add_color`**, both shared statics in the existing style. The slider is a label + `HSlider` + live numeric readout: feel work is drag work, and `add_spinbox` is the typing form. Narrow scope — these were added for this panel, not as a general restyle.

## The knobs that are yours

Everything on the tab, but the ones with a name already attached: **shadow bias / normal bias** (the standing candidate for #226's units-read-as-hovering), the **fog density + albedo** the sunset "forest fire" motivated, **glow HDR threshold**, the **DoF bands and blur amount**, **board pitch and FOV**, **marker lift**, the **bracket** trio, and the **flame** block. Copy Values dumps only what moved, grouped by paste target — the header names the resource the value lives in, so the line goes straight where it belongs. Nothing writes a file; the clipboard is the handoff, as #212 asked.

## Verification

`tests/dev` 109/109, `tests/presentation` 160/160, **full tree 1473/1473, 0 orphans, exit 0** (256s).

Nine new cases drive the **real** `Battle3D.tscn` and let `_ready` do the pushing rather than calling `attach_host` themselves. Falsified three ways, each reddening exactly one case and nothing else:

1. Cut the slider's `value_changed` call → the drag case goes red. *(Without that case the rows could have been built completely disconnected and every other assertion would still pass — two ends, no wire.)*
2. Point a knob at the runtime-written `dof_blur_far_distance` → the survives-a-frame case goes red, naming the offending knob in the failure message.
3. Remove the host push → the wire case goes red.

The survival case waits **two** frames, because `process_frame` resumes a coroutine before any node `_process` runs — one await would prove nothing about what `_process` does with the value. It also compares against what the property *accepted* rather than what was asked for, and separately fails any knob whose write did not register at all, so a silently inert `set_indexed` cannot hide inside a passing assertion.

**What the suite cannot see, and is yours:** whether the slider ranges are sane, whether the panel is usable at that row count, and whether any tuned value actually looks right. I did not launch the game.

## Not in this slice

- **Per-layer overlay colour + alpha** — your movement-highlight transparency ask. Different mechanism: `BoardOverlays.LAYERS` is a `const`, so it needs `set_layer_modulate` plus a copy-back of its own. Slice 2, next, and per your call it ships **3D-only and explicitly provisional** — the 2D `OverlayManager` constants stay put until you have looked at a tuned 3D value and decided whether 2D should follow.
- **#227's arrow lift — correcting my own plan.** I implied it fell out of this table; it does not. `fill_lift`/`lift_step` raise every ground marker *together*, arrows included. A lift the arrows own **alone** needs its own export on `BoardOverlays`, which is a presentation-stack change rather than a table line, so it stayed out rather than quietly widening the diff.
- #234's camera-start capture button and #217's photosensitivity toggle — natural tenants of this tab, later slices.
- The Re-fit button is not covered by a test (it needs a loaded board); it is a dev-only button pressed mid-play.
