### PR TITLE
Elevation gets a store and a rule: can_step (#257)

### DIFF
--- a/Classes/board/BoardContext.gd
+++ b/Classes/board/BoardContext.gd
@@ -11,13 +11,15 @@ var units: Array[Unit]
 var squad_manager: SquadManager
 var terrain_states: TerrainStateManager
 var zones: ZoneManager
+var heights: BoardHeights
 
-func _init(grid_layer: TileMapLayer, unit_list: Array[Unit], manager: SquadManager, states: TerrainStateManager = null, zone_manager: ZoneManager = null) -> void:
+func _init(grid_layer: TileMapLayer, unit_list: Array[Unit], manager: SquadManager, states: TerrainStateManager = null, zone_manager: ZoneManager = null, board_heights: BoardHeights = null) -> void:
 	grid = grid_layer
 	units = unit_list
 	squad_manager = manager
 	terrain_states = states
 	zones = zone_manager
+	heights = board_heights
 
 func unit_at_cell(cell: Vector2i) -> Unit:
 	for unit in units:
@@ -70,6 +72,22 @@ func cover_def_at(cell: Vector2i) -> int:
 	if terrain_states == null:
 		return 0
 	return Terrain.COVER_DEF if terrain_states.has_state(cell, Terrain.TileState.COVER) else 0
+
+# The rules' read-points for elevation (#257), siblings of terrain_kind_at / cover_def_at and there
+# for the same reason: methods rather than inline store reads, so a fixture board can stub them.
+#
+# A board built WITHOUT a heights store reads perfectly flat — every existing caller, test fixture
+# and headless board therefore behaves exactly as it did before elevation existed, which is what
+# lets can_step ship without touching a single one of them.
+func elevation_at(cell: Vector2i) -> int:
+	if heights == null:
+		return 0
+	return heights.elevation_at(cell)
+
+func ramp_rise_at(cell: Vector2i) -> Terrain.RampRise:
+	if heights == null:
+		return Terrain.RampRise.NONE
+	return heights.ramp_rise_at(cell)
 
 # Census over this board's units — shared by game.gd and the headless PlaySession so the
 # turn cycle's membership/auto-skip reads have ONE implementation.

--- a/Classes/board/HoverPresenter.gd
+++ b/Classes/board/HoverPresenter.gd
@@ -322,5 +322,14 @@ func _tile_readout_lines(cell: Vector2i) -> Array[String]:
 		var cost: int = data.get_custom_data("move_cost")
 		if cost > 1:
 			lines.append("Slow going — costs %d movement to enter." % cost)
+	# Elevation (#257). Only spoken when it is non-default, so a flat board's card reads exactly as
+	# it did before verticality existed — the same rule the move_cost line above follows.
+	var elevation: int = board.elevation_at(cell)
+	var rise: Terrain.RampRise = board.ramp_rise_at(cell)
+	if rise != Terrain.RampRise.NONE:
+		lines.append("Ramp — rises %s from height %d. Enter or leave it only along that slope."
+			% [Terrain.ramp_rise_display_name(rise).to_lower(), elevation])
+	elif elevation != 0:
+		lines.append("Height %d — reached only by a ramp from height %d." % [elevation, elevation - 1])
 	lines.append_array(Glossary.terrain_reactions_for(kind, held))
 	return lines

--- a/Classes/board/RulesService.gd
+++ b/Classes/board/RulesService.gd
@@ -30,11 +30,49 @@ static func can_traverse(cell: Vector2i, unit: Unit, board: BoardContext) -> boo
 	return board.terrain_kind_at(cell) == Terrain.Kind.WATER \
 		and unit.has_live_ability(Abilities.Id.WATERWALK)
 
-static func movement_cost(cell: Vector2i, unit: Unit, board: BoardContext) -> int:
+# May this unit step FROM one cell TO an orthogonally adjacent one (#257)? The EDGE question, and
+# the reason elevation needs one at all: can_traverse above answers "may this unit be on that cell",
+# which cannot express "only via a ramp, and only along the ramp's slope".
+#
+# The rule is platforms-and-ramps, NOT Z arithmetic (dev reframe, docs/design/verticality.md): the
+# only height maths here is equality and +/-1. A cliff of five is a staircase of five ramp cells or
+# it is not climbable at all.
+#
+# A ramp's own elevation is its LOW side, so the climb happens LEAVING it and the descent happens
+# ENTERING it -- which is why the two height clauses look at opposite cells.
+static func can_step(from: Vector2i, to: Vector2i, unit: Unit, board: BoardContext) -> bool:
+	if not can_traverse(to, unit, board):
+		return false
+
+	var step := to - from
+	var from_rise := board.ramp_rise_at(from)
+	var to_rise := board.ramp_rise_at(to)
+
+	# No sideways entry (dev ruling): a ramp connects exactly its high and low sides, so any step
+	# touching one must run along its slope. Checked for BOTH cells -- leaving a ramp sideways and
+	# entering one sideways are separate clauses, and a test covering only one is blind to the other.
+	if from_rise != Terrain.RampRise.NONE and not Terrain.is_on_rise_axis(from_rise, step):
+		return false
+	if to_rise != Terrain.RampRise.NONE and not Terrain.is_on_rise_axis(to_rise, step):
+		return false
+
+	var delta := board.elevation_at(to) - board.elevation_at(from)
+	if delta == 0:
+		return true
+	if abs(delta) != 1:
+		return false
+	if delta > 0:
+		return Terrain.rise_direction(from_rise) == step      # climbing off the ramp we stand on
+	return Terrain.rise_direction(to_rise) == -step           # descending onto a ramp, against its rise
+
+static func movement_cost(from: Vector2i, cell: Vector2i, unit: Unit, board: BoardContext) -> int:
 	var data := board.grid.get_cell_tile_data(cell)
 	if data == null:
 		return OUT_OF_MAP_TILE
-	if not can_traverse(cell, unit, board):
+	# Takes `from` since #257: legality is an EDGE question. Deliberately REQUIRED rather than an
+	# optional defaulting to `cell` -- an optional would give one question two answers depending on
+	# who called, which is the exact drift #102 was built to end.
+	if not can_step(from, cell, unit, board):
 		return CANNOT_WALK_TILE
 	if not board.grid.get_used_rect().has_point(cell):
 		return OUT_OF_MAP_TILE
@@ -85,7 +123,7 @@ static func compute_move_range(unit: Unit, board: BoardContext, leader_cell = nu
 
 		for dir in NEIGHBOURS:
 			var next: Vector2i = current_cell + dir
-			var move_cost: int = movement_cost(next, unit, board)
+			var move_cost: int = movement_cost(current_cell, next, unit, board)
 
 			if move_cost > CANNOT_WALK_TILE:
 				continue
@@ -262,9 +300,14 @@ static func def_breakdown(unit: Unit, cell: Vector2i, board: BoardContext) -> Di
 # _path_hops until the second caller arrived (Law #4 -- one question, one answer).
 #
 # Takes the unit because traversal is per-unit (#115): a Waterwalker's connected region includes
-# water. Asks can_traverse and NOT movement_cost -- occupancy blocks a move but is not terrain and
+# water. Asks can_step and NOT movement_cost -- occupancy blocks a move but is not terrain and
 # moves every turn. Letting an enemy body sever this field would change formations near any enemy,
 # and would make a pursuing squad route around the very unit it is chasing.
+#
+# Still UNWEIGHTED after #257, and deliberately so: a ramp climb costs one hop like any other step.
+# This measures how terrain CONNECTS, not what a move costs -- which is also why an unramped cliff
+# breaks a squad's cohesion leash for free (dev ruling: a 1-block rise blocks squad range the way
+# unwalkable terrain already does). Do not "fix" it by weighting climbs.
 #
 # `block_on_occupancy` (#127) is the opt-in exception, and the DEFAULT IS LOAD-BEARING: cohesion
 # must keep the terrain-only field for the reason directly above (docs/performance.md states this
@@ -304,7 +347,7 @@ static func path_hops(source: Vector2i, board: BoardContext, unit: Unit, max_dep
 				continue
 			if not bounds.has_point(next):
 				continue
-			if not can_traverse(next, unit, board):
+			if not can_step(cell, next, unit, board):
 				continue
 			if block_on_occupancy and blocks_passage(unit, board.unit_at_cell(next)):
 				continue

--- a/Classes/dev/HeightDebugOverlay.gd
+++ b/Classes/dev/HeightDebugOverlay.gd
@@ -1,0 +1,61 @@
+extends Node2D
+class_name HeightDebugOverlay
+
+# THROWAWAY dev readout for elevation (#257): each cell's height, and an arrow on ramp cells showing
+# which way they rise. F5 toggles it; dev builds only.
+#
+# It exists because slice 1 ships the RULES for verticality with no art to render them — wall-face
+# autotiles, ramp sprites and per-level sprite offsets are a separate ticket gated on a tileset
+# choice. Without something like this, a board with elevation is indistinguishable from a flat one.
+# Expect it to be deleted, not extended, once the real 2D height render lands.
+#
+# A child of the grid so map_to_local lands in this node's own space with no conversion. Draws with
+# _draw rather than pooling a Label per cell: one node and one pass, and nothing to keep in sync.
+
+const RISE_ARROWS: Dictionary[Terrain.RampRise, String] = {
+	Terrain.RampRise.NONE: "",
+	Terrain.RampRise.NORTH: "^",
+	Terrain.RampRise.SOUTH: "v",
+	Terrain.RampRise.EAST: ">",
+	Terrain.RampRise.WEST: "<"
+}
+
+const FONT_SIZE := 8
+const FLAT_COLOR := Color(1, 1, 1, 0.35)     # height 0 is the overwhelming majority — keep it quiet
+const RAISED_COLOR := Color(1, 0.85, 0.4, 0.9)
+const RAMP_COLOR := Color(0.5, 0.9, 1.0, 0.95)
+
+var grid: TileMapLayer
+var heights: BoardHeights
+
+func _ready() -> void:
+	visible = false
+	z_index = 100   # above the tile overlays, which sit below Unit.BASE_SPRITE_INDEX
+
+func toggle() -> void:
+	visible = not visible
+	refresh()
+
+# Call after anything mutates the store — the height brush (#260) is the first real caller. Not
+# wired to a signal because BoardHeights deliberately has none: it is a data store, not a subject.
+func refresh() -> void:
+	if visible:
+		queue_redraw()
+
+func _draw() -> void:
+	if grid == null or heights == null:
+		return
+	var font := ThemeDB.fallback_font
+	for cell in grid.get_used_cells():
+		var height := heights.elevation_at(cell)
+		var rise := heights.ramp_rise_at(cell)
+		var label := str(height) + RISE_ARROWS[rise]
+		var color := FLAT_COLOR
+		if rise != Terrain.RampRise.NONE:
+			color = RAMP_COLOR
+		elif height != 0:
+			color = RAISED_COLOR
+		# map_to_local is the cell CENTRE; nudge so the glyphs sit centred-ish rather than hanging
+		# off the corner. Eyeballed, and deliberately not a knob — this whole node is temporary.
+		var at := grid.map_to_local(cell) + Vector2(-5, 4)
+		draw_string(font, at, label, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE, color)

--- a/Classes/dev/HeightDebugOverlay.gd.uid
+++ b/Classes/dev/HeightDebugOverlay.gd.uid
@@ -1,0 +1,1 @@
+uid://bm12w34ddcagl

--- a/Classes/flow/ScenarioData.gd
+++ b/Classes/flow/ScenarioData.gd
@@ -10,6 +10,12 @@ class_name ScenarioData
 @export var unit_entries: Array[ScenarioUnitEntry] = []
 @export var tile_data: PackedByteArray
 @export var terrain_states: Dictionary = {}   # Vector2i -> Array[Terrain.TileState] deposited at runtime
+@export var elevations: Dictionary = {}   # Vector2i -> int surface height (#257). SPARSE: an absent
+										  # cell is height 0, so a flat board saves as {}. BoardHeights
+										  # owns that default and is the only reader — see verticality.md.
+@export var ramp_rises: Dictionary = {}   # Vector2i -> Terrain.RampRise. Sparse the same way (absent =
+										  # NONE = not a ramp). Separate from `elevations` because a ramp
+										  # at height 0 is legal and must survive the round trip.
 @export var active_faction: Team.Faction = Team.Faction.PLAYER # whose turn it was when saved
 @export var zones: Dictionary = {}   # zone name -> {"kind": ZoneManager.Kind, "cells": Array[Vector2i]},
 									 # painted via Tile Brush's Zone mode. Straight pass-through of

--- a/Classes/flow/ScenarioManager.gd
+++ b/Classes/flow/ScenarioManager.gd
@@ -118,6 +118,8 @@ func capture_scenario(scenario_name: String, authored := false) -> ScenarioData:
 	scenario.tile_data = grid.tile_map_data
 	scenario.active_faction = turn_manager.active_faction()
 	scenario.terrain_states = game.terrain_states.to_state_dict()
+	scenario.elevations = game.board_heights.to_elevation_dict()
+	scenario.ramp_rises = game.board_heights.to_ramp_dict()
 	scenario.zones = game.zone_manager.to_dict()
 	scenario.objectives = game.mission_controller.objectives.duplicate()
 	scenario.ai_factions = game.ai_controller.ai_factions()   # #150: who the computer plays here
@@ -167,6 +169,7 @@ func apply_scenario(scenario: ScenarioData) -> void:
 
 	grid.tile_map_data = scenario.tile_data
 	game.terrain_states.load_state_dict(scenario.terrain_states)
+	game.board_heights.load_dicts(scenario.elevations, scenario.ramp_rises)
 	# Authored state must be VISIBLE at turn one -- nothing else redraws until the first round tick (#174).
 	overlay_manager.redraw_terrain_live(game.terrain_states)
 	game.zone_manager.load_dict(scenario.zones)
@@ -273,6 +276,8 @@ func clear_board():
 	overlay_manager.redraw_zones(game.zone_manager)
 	game.terrain_states.clear()   # tile states are board content too -- a sandbox spawn inherits no fire (#174)
 	overlay_manager.redraw_terrain_live(game.terrain_states)
+	game.board_heights.clear()   # so is elevation (#257) -- a sandbox spawn starts flat, not on the
+								 # last mission's cliff. apply_scenario refills it straight after.
 	if game.dev_overlay != null:
 		game.dev_overlay.unit_editor.edit_unit(null)
 	game.unit_info_panel.clear()

--- a/Classes/terrain/BoardHeights.gd
+++ b/Classes/terrain/BoardHeights.gd
@@ -1,0 +1,82 @@
+extends RefCounted
+class_name BoardHeights
+
+# The per-cell elevation store (#218/#257) — how high each cell's surface sits, and which cells are
+# ramps. Sibling of TerrainStateManager: same per-cell shape, same round-trip through ScenarioData,
+# same role in BoardContext. Canon: docs/design/verticality.md.
+#
+# NOT tileset custom data, unlike walkable / move_cost / terrain_type. Those are per-TILE (per atlas
+# coordinate), so an elevation among them would need a distinct grass tile per level -- 21 of them
+# for a 20-level cliff city -- and a Tile Brush palette to match. Per-cell also means the rules can
+# be tested on any painted board with no new tiles or art.
+#
+# NOT folded into TerrainStateManager either: that holds a STACK of enum states with durations, this
+# holds two scalars, and height is authored map geometry rather than something attacks deposit. It is
+# deliberately not assumed permanent, though -- terrain.md's "attack the map" list already carries
+# EARTH raising a destructible wall.
+#
+# RefCounted rather than TerrainStateManager's Node: no signals, no _process, nothing needing the
+# tree, and a RefCounted frees itself instead of reading as a gdUnit orphan.
+
+var _elevations: Dictionary[Vector2i, int] = {}
+var _ramps: Dictionary[Vector2i, Terrain.RampRise] = {}
+
+# An ABSENT cell is elevation 0, and that is a decision rather than a gap: a flat board is the
+# overwhelmingly common case, so it is stored as nothing at all. This method is the ONE place that
+# default is applied -- no caller re-derives it, and no caller reads the dictionaries directly.
+func elevation_at(cell: Vector2i) -> int:
+	return _elevations.get(cell, 0)
+
+func ramp_rise_at(cell: Vector2i) -> Terrain.RampRise:
+	return _ramps.get(cell, Terrain.RampRise.NONE)
+
+func is_ramp(cell: Vector2i) -> bool:
+	return ramp_rise_at(cell) != Terrain.RampRise.NONE
+
+# The one writer. Defaults are PRUNED rather than stored so to_dict stays sparse and two boards
+# painted to the same shape compare equal regardless of how they got there.
+func set_cell(cell: Vector2i, elevation: int, rise: Terrain.RampRise = Terrain.RampRise.NONE) -> void:
+	if elevation == 0:
+		_elevations.erase(cell)
+	else:
+		_elevations[cell] = elevation
+	if rise == Terrain.RampRise.NONE:
+		_ramps.erase(cell)
+	else:
+		_ramps[cell] = rise
+
+func clear() -> void:
+	_elevations.clear()
+	_ramps.clear()
+
+# Every cell carrying a non-default value -- what a dev readout or a renderer iterates. Ramp cells
+# at elevation 0 are legal and must not be missed, so both stores contribute.
+func painted_cells() -> Array[Vector2i]:
+	var seen: Dictionary[Vector2i, bool] = {}
+	for cell: Vector2i in _elevations:
+		seen[cell] = true
+	for cell: Vector2i in _ramps:
+		seen[cell] = true
+	var result: Array[Vector2i] = []
+	result.assign(seen.keys())
+	return result
+
+# Serialization pair, mirroring TerrainStateManager.to_state_dict / load_state_dict exactly. Two
+# plain Dictionaries because that is what ScenarioData can @export; the typed views above are the
+# only way the rest of the game reads them.
+func to_elevation_dict() -> Dictionary:
+	return _elevations.duplicate()
+
+func to_ramp_dict() -> Dictionary:
+	return _ramps.duplicate()
+
+func load_dicts(elevations: Dictionary, ramps: Dictionary) -> void:
+	clear()
+	for cell: Vector2i in elevations:
+		var height: int = elevations[cell]
+		if height != 0:
+			_elevations[cell] = height
+	for cell: Vector2i in ramps:
+		var rise: Terrain.RampRise = ramps[cell]
+		if rise != Terrain.RampRise.NONE:
+			_ramps[cell] = rise

--- a/Classes/terrain/BoardHeights.gd.uid
+++ b/Classes/terrain/BoardHeights.gd.uid
@@ -1,0 +1,1 @@
+uid://6w7oubvaovim

--- a/Classes/terrain/Terrain.gd
+++ b/Classes/terrain/Terrain.gd
@@ -49,6 +49,41 @@ enum Kind {
 		   # default ground beside GRASS (which ignites)
 }
 
+# Which way a ramp cell RISES (#218/#257). Stored per-cell in BoardHeights and serialized into
+# ScenarioData as an int: APPEND-ONLY. NONE = 0 = unset default (an ordinary flat cell).
+#
+# A DIRECTION, not an axis, and that is the whole point: docs/design/verticality.md sketched
+# {NONE, NS, EW}, which cannot say which side is high — a ramp at height N with a NS axis could
+# climb to either neighbour, and if both sit at N+1 the rule has no answer. One field carries the
+# axis AND the high side, and the dev's "ramps connect exactly their high/low sides, no sideways
+# entry" ruling becomes a single question: does this step run along the rise axis?
+enum RampRise {
+	NONE,
+	NORTH,
+	SOUTH,
+	EAST,
+	WEST
+}
+
+const RISE_DIRECTIONS: Dictionary[RampRise, Vector2i] = {
+	RampRise.NONE: Vector2i.ZERO,
+	RampRise.NORTH: Vector2i.UP,
+	RampRise.SOUTH: Vector2i.DOWN,
+	RampRise.EAST: Vector2i.RIGHT,
+	RampRise.WEST: Vector2i.LEFT
+}
+
+# The step direction that climbs this ramp. ZERO for NONE, which is what makes is_on_rise_axis
+# below refuse every direction on a flat cell without a special case.
+static func rise_direction(rise: RampRise) -> Vector2i:
+	return RISE_DIRECTIONS[rise]
+
+# Does a step run along this ramp's slope (either up it or down it)? The "no sideways entry" rule,
+# in one place — a ramp may only be entered or left along the axis it rises on.
+static func is_on_rise_axis(rise: RampRise, step: Vector2i) -> bool:
+	var dir := rise_direction(rise)
+	return dir != Vector2i.ZERO and (step == dir or step == -dir)
+
 # The player-facing spellings ("Burning", "Water") — Elemental.display_name's rule applied to the
 # tile vocabularies. Hover readouts and the Glossary's composed lines read these; dev readouts
 # that deliberately show the raw enum key keep doing so.
@@ -57,3 +92,6 @@ static func tile_state_display_name(s: TileState) -> String:
 
 static func kind_display_name(k: Kind) -> String:
 	return Kind.keys()[k].capitalize()
+
+static func ramp_rise_display_name(r: RampRise) -> String:
+	return RampRise.keys()[r].capitalize()

--- a/docs/SHORTCUTS.md
+++ b/docs/SHORTCUTS.md
@@ -36,6 +36,7 @@ The view **opens close on your own squad**, not on the whole board (`opening_vie
 | F1 | Toggle the dev tools window (`toggle_dev_overlay`) — enters/exits DEV_MODE |
 | Space | Spawn a unit at the hovered cell *(in dev mode, with the Spawn tool configured)* — hardcoded `KEY_SPACE` check in `game.gd`, not an Input Map action |
 | F2 | Reload the last-loaded scenario (`dev_reset_scenario`) — instant board reset |
+| F5 | Toggle the elevation readout ([#257](https://github.com/Phaazoid/Godoiosis/issues/257)) — each cell's height, with an arrow on ramps showing which way they rise. Flat 2D view only; **throwaway**, and deleted when the real 2D height render lands. Hardcoded `KEY_F5` in `game.gd`, gated on `DevTools.enabled()` |
 | Left-click a unit | (DEV_MODE) Edit that unit in the Unit Editor |
 | Left-drag | (DEV_MODE, Tile Brush active) Paint the selected tile — works in **both** views; the 3D one previews the real block under the cursor |
 | Right-click | (DEV_MODE, Tile Brush active) Erase a tile. In the 3D view this is why orbit steps aside to middle-drag while the brush is armed |

--- a/docs/design/verticality.md
+++ b/docs/design/verticality.md
@@ -27,7 +27,14 @@ below follows from taking that literally.
 ### Where height lives
 
 **A per-cell store, serialized into `ScenarioData` beside `terrain_states`.** Two fields per cell:
-`elevation: int` and `ramp_axis: {NONE, NS, EW}`.
+`elevation: int` and `ramp_rise: Terrain.RampRise`.
+
+> **AMENDED at build time (#257).** This originally read `ramp_axis: {NONE, NS, EW}`, which cannot
+> say which side of the ramp is high — a ramp at height N with an EW axis climbs to *either*
+> neighbour, and if both sit at N+1 the rule has no answer. `RampRise { NONE, NORTH, SOUTH, EAST,
+> WEST }` is **the direction the ramp rises toward**: one field carries the axis *and* the high side,
+> and "no sideways entry" collapses to a single question — does this step run along the rise axis?
+> Built as `Terrain.RampRise` with `Terrain.rise_direction` / `Terrain.is_on_rise_axis` beside it.
 
 **Not tileset custom data.** This was the first proposal and it is wrong: `walkable` / `move_cost` /
 `terrain_type` / `terrain_name` are per-TILE (per atlas coordinate), not per-cell. Elevation as tile
@@ -73,6 +80,13 @@ engine grows one:
   if one of the two cells is a ramp whose axis matches the step direction and whose high/low sides
   line up. **Ramps connect exactly ±1**, so a 5-tall cliff is a staircase of five ramp cells or it is
   not climbable at all.
+
+  **BUILT in #257.** Because a ramp's own elevation is its LOW side, the climb happens when *leaving*
+  it and the descent when *entering* it — so the two height clauses read opposite cells: `+1` is
+  legal iff `from` is a ramp whose rise equals the step, `-1` iff `to` is a ramp whose rise opposes
+  it. The sideways guard is **two clauses, one per cell**, and they are tested separately: the
+  2026-08-12 stage-2 round found that a case covering only *leaving* a ramp sideways let the
+  entering-guard mutant survive.
 
 **Blast radius is small, which is why the movement half is slice 1.** `movement_cost` has exactly ONE
 production caller (`compute_move_range`'s BFS) and it already holds `current_cell`. `can_traverse` has
@@ -321,6 +335,11 @@ Split so each is one reviewable diff and one feel-check, per the bite-sized-part
 
 1. **Store, `can_step`, 2D face rendering.** Movement only — complete and playable on its own. No
    climb cost, so `movement_cost` gains the `from` parameter purely for legality.
+   **NARROWED and BUILT as [#257](https://github.com/Phaazoid/Godoiosis/issues/257):** the rules and
+   store half shipped with a throwaway F5 readout instead of real rendering, because wall-face and
+   ramp art is gated on a tileset choice that has not been made. The 2D render — wall autotiles,
+   ramp sprites, per-level sprite Y-offset, and the `HoverPresenter` sprite-vs-cell disambiguation —
+   became its own ticket.
 2. **Height → reach.** Per-attack asymmetric tolerances in `Reach` (aim methods only), plus
    `ResolvedOutcome.elevation_delta`, plus the "in range but blocked" preview treatment.
 3. **Falls.** Drop damage, void removal, the tumble, the no-push-uphill rule. Closes the

--- a/game.gd
+++ b/game.gd
@@ -72,6 +72,8 @@ var _target_pick_callback: Callable           # func(picked: Unit) -> void
 var dev_controller: DevController
 var ai_controller: AIController
 var terrain_states: TerrainStateManager
+var board_heights: BoardHeights   # per-cell elevation + ramps (#257); RefCounted, so not a child
+var height_debug_overlay: HeightDebugOverlay   # F5 readout, dev builds only; deleted when art lands
 var zone_manager: ZoneManager
 var main_action_menu: MainActionMenu
 var hover_presenter: HoverPresenter
@@ -126,6 +128,15 @@ func _build_collaborators() -> void:
 	# board swap cannot leave the rule judging against the previous scenario's terrain.
 	terrain_states.ground_source = func(cell: Vector2i) -> bool: return GridUtils.has_ground(grid, cell)
 	add_child(terrain_states)
+
+	board_heights = BoardHeights.new()   # no add_child: RefCounted, and it needs nothing from the tree
+
+	if DevTools.enabled():
+		height_debug_overlay = HeightDebugOverlay.new()
+		height_debug_overlay.name = "HeightDebugOverlay"
+		height_debug_overlay.grid = grid
+		height_debug_overlay.heights = board_heights
+		grid.add_child(height_debug_overlay)   # child of the grid so map_to_local needs no conversion
 
 	zone_manager = ZoneManager.new()
 	zone_manager.name = "ZoneManager"
@@ -224,6 +235,12 @@ func _unhandled_input(event: InputEvent) -> void:
 			dev_overlay.spawn.try_spawn_at(hover_presenter.last_hovered_cell)
 		else:
 			camera_controller.center_on_position(get_global_mouse_position())
+
+	# Elevation readout (#257) — throwaway until the real 2D height render lands. Gated like
+	# Battle3D's F4 so it cannot reach a shipped build.
+	if event is InputEventKey and event.pressed and event.keycode == Key.KEY_F5 \
+			and DevTools.enabled() and height_debug_overlay != null:
+		height_debug_overlay.toggle()
 
 # Esc during play. MENU locks the board while the card is up; the prior state is restored on
 # Resume so an in-progress aim survives the pause.
@@ -941,7 +958,7 @@ func clear_selection_icons() -> void:
 # ==============================================================================
 
 func _board() -> BoardContext:
-	return BoardContext.new(grid, _all_units(), squad_manager, terrain_states, zone_manager)
+	return BoardContext.new(grid, _all_units(), squad_manager, terrain_states, zone_manager, board_heights)
 
 func _all_units() -> Array[Unit]:
 	var result: Array[Unit] = []

--- a/play/board_builder.gd
+++ b/play/board_builder.gd
@@ -60,6 +60,12 @@ static func build(parent: Node, root_name := "PlayRoot") -> Dictionary:
 	terrain_states.ground_source = func(cell: Vector2i) -> bool: return GridUtils.has_ground(grid, cell)
 	root.add_child(terrain_states)
 
+	# Elevation (#257), the twin of game.board_heights. RefCounted, so nothing to parent -- it lives
+	# as long as the lambda and the returned board Dictionary hold it. Wired here for the same reason
+	# terrain_states is: a headless board that silently reads flat would let the Play API and the game
+	# disagree about whether a move is legal, which is exactly the split #103 was.
+	var board_heights := BoardHeights.new()
+
 	# Cohesion reads live terrain (#151) -- fresh BoardContext per call, mirroring game._board, with
 	# units scanned off units_root so mid-test spawns are seen. Sits below terrain_states because a
 	# lambda captures what exists at creation.
@@ -68,7 +74,7 @@ static func build(parent: Node, root_name := "PlayRoot") -> Dictionary:
 		for child in units_root.get_children():
 			if child is Unit:
 				units.append(child)
-		return BoardContext.new(grid, units, squad_manager, terrain_states)
+		return BoardContext.new(grid, units, squad_manager, terrain_states, null, board_heights)
 
 	return {
 		"root": root,
@@ -78,6 +84,7 @@ static func build(parent: Node, root_name := "PlayRoot") -> Dictionary:
 		"squad_manager": squad_manager,
 		"turn_manager": turn_manager,
 		"terrain_states": terrain_states,
+		"board_heights": board_heights,
 	}
 
 static func paint_rect(grid: TileMapLayer, rect: Rect2i) -> void:
@@ -111,6 +118,8 @@ static func apply_scenario(board: Dictionary, scenario: ScenarioData) -> Array[U
 	board.grid.tile_map_data = scenario.tile_data
 	if board.get("terrain_states") != null:
 		board.terrain_states.load_state_dict(scenario.terrain_states)   # mirrors ScenarioManager
+	if board.get("board_heights") != null:
+		board.board_heights.load_dicts(scenario.elevations, scenario.ramp_rises)   # mirrors ScenarioManager
 
 	var spawned: Array[Unit] = []
 	var entry_by_unit := {}            # Unit -> ScenarioUnitEntry

--- a/play/play_session.gd
+++ b/play/play_session.gd
@@ -13,6 +13,7 @@ var squad_manager: SquadManager
 var turn_manager: TurnManager
 var overlay_manager: OverlayManager
 var terrain_states: TerrainStateManager   # twin of game.terrain_states; null on a board built without one
+var board_heights: BoardHeights           # twin of game.board_heights (#257); null board reads flat
 
 var _handle_by_unit := {}      # Unit -> String (stable display handle)
 var _next_player := 0
@@ -30,6 +31,7 @@ func _init(board: Dictionary) -> void:
 	turn_manager = board.turn_manager
 	overlay_manager = board.overlay_manager
 	terrain_states = board.get("terrain_states")
+	board_heights = board.get("board_heights")
 	for unit in live_units():
 		_register(unit)
 
@@ -86,7 +88,7 @@ func unit_by_handle(h: String) -> Unit:
 	return null
 
 func _board() -> BoardContext:
-	return BoardContext.new(grid, live_units(), squad_manager, terrain_states)
+	return BoardContext.new(grid, live_units(), squad_manager, terrain_states, null, board_heights)
 
 func active_faction() -> Team.Faction:
 	return turn_manager.active_faction()

--- a/tests/rules/test_can_step.gd
+++ b/tests/rules/test_can_step.gd
@@ -1,0 +1,220 @@
+# RulesService.can_step (#257) — the EDGE question elevation needed. can_traverse answers "may this
+# unit be on that cell"; this answers "may it get there from here", which is the only shape that can
+# express "only via a ramp, and only along the ramp's slope".
+#
+# Uses the REAL TestTiles-backed board (BoardBuilder) because movement_cost reads tile custom data
+# straight off the grid. Elevation itself needs no new tiles or art — it is a per-cell store, which
+# is exactly why the design put it there instead of in tileset custom data.
+#
+# Ramp geometry used throughout, laid out west→east on row y=1 (a ramp's own elevation is its LOW
+# side, so the climb happens LEAVING it):
+#
+#   (0,1) flat h0   (1,1) RAMP h0 rising EAST   (2,1) flat h1
+extends GdUnitTestSuite
+
+const BoardBuilder := preload("res://play/board_builder.gd")
+const H := preload("res://tests/support/squad_fixtures.gd")
+
+const PLAYER := Team.Faction.PLAYER
+
+func _board() -> Dictionary:
+	var board := BoardBuilder.build(self)
+	auto_free(board.root)
+	BoardBuilder.paint_rect(board.grid, Rect2i(0, 0, 6, 3))
+	return board
+
+func _heights(board: Dictionary) -> BoardHeights:
+	var heights: BoardHeights = board.board_heights
+	return heights
+
+func _spawn(board: Dictionary, cell: Vector2i) -> Unit:
+	return BoardBuilder.spawn(board, H.make_unit_data({}, PLAYER), cell)
+
+func _context(board: Dictionary, unit: Unit) -> BoardContext:
+	var units: Array[Unit] = [unit]
+	return BoardContext.new(board.grid, units, board.squad_manager, null, null, board.board_heights)
+
+# One ramp at (1,1) rising east, its high neighbour (2,1) one level up.
+func _ramp_board() -> Dictionary:
+	var board := _board()
+	var heights := _heights(board)
+	heights.set_cell(Vector2i(1, 1), 0, Terrain.RampRise.EAST)
+	heights.set_cell(Vector2i(2, 1), 1)
+	return board
+
+
+# --- the defaults, which are decisions rather than gaps ---
+
+func test_absent_cell_is_elevation_zero() -> void:
+	# Sparse storage: a flat board saves as {}. BoardHeights is the ONE place that default lives, so
+	# it is pinned here rather than left to whichever caller reads the dictionary first.
+	var board := _board()
+	assert_int(_heights(board).elevation_at(Vector2i(4, 2))).is_equal(0)
+	assert_int(_heights(board).ramp_rise_at(Vector2i(4, 2))).is_equal(Terrain.RampRise.NONE)
+
+func test_board_without_heights_reads_perfectly_flat() -> void:
+	# The contract that let can_step ship without touching a single existing caller: a BoardContext
+	# built with no heights store behaves exactly as the game did before elevation existed.
+	var board := _board()
+	var unit := _spawn(board, Vector2i(0, 1))
+	var units: Array[Unit] = [unit]
+	var flat := BoardContext.new(board.grid, units, board.squad_manager)
+
+	assert_int(flat.elevation_at(Vector2i(2, 1))).is_equal(0)
+	assert_bool(RulesService.can_step(Vector2i(0, 1), Vector2i(1, 1), unit, flat)).is_true()
+
+
+# --- height changes need a ramp ---
+
+func test_flat_step_is_legal() -> void:
+	var board := _board()
+	var unit := _spawn(board, Vector2i(0, 1))
+	assert_bool(RulesService.can_step(Vector2i(0, 1), Vector2i(1, 1), unit, _context(board, unit))).is_true()
+
+func test_a_climb_without_a_ramp_is_refused() -> void:
+	var board := _board()
+	_heights(board).set_cell(Vector2i(1, 1), 1)   # a bare rise: no ramp anywhere
+	var unit := _spawn(board, Vector2i(0, 1))
+	assert_bool(RulesService.can_step(Vector2i(0, 1), Vector2i(1, 1), unit, _context(board, unit))).is_false()
+
+func test_a_drop_without_a_ramp_is_refused() -> void:
+	# The mirror clause, and a separate one in the code: descending reads the DESTINATION's ramp.
+	var board := _board()
+	_heights(board).set_cell(Vector2i(0, 1), 1)
+	var unit := _spawn(board, Vector2i(0, 1))
+	assert_bool(RulesService.can_step(Vector2i(0, 1), Vector2i(1, 1), unit, _context(board, unit))).is_false()
+
+func test_two_levels_is_never_one_step() -> void:
+	# Ramps connect exactly +/-1. A cliff of five is a staircase of five ramps or it is unclimbable.
+	var board := _board()
+	var heights := _heights(board)
+	heights.set_cell(Vector2i(1, 1), 0, Terrain.RampRise.EAST)
+	heights.set_cell(Vector2i(2, 1), 2)
+	var unit := _spawn(board, Vector2i(0, 1))
+	assert_bool(RulesService.can_step(Vector2i(1, 1), Vector2i(2, 1), unit, _context(board, unit))).is_false()
+
+
+# --- the ramp itself ---
+
+func test_stepping_onto_a_ramp_from_its_low_side() -> void:
+	var board := _ramp_board()
+	var unit := _spawn(board, Vector2i(0, 1))
+	assert_bool(RulesService.can_step(Vector2i(0, 1), Vector2i(1, 1), unit, _context(board, unit))).is_true()
+
+func test_ramp_climbs_to_its_high_side() -> void:
+	var board := _ramp_board()
+	var unit := _spawn(board, Vector2i(0, 1))
+	assert_bool(RulesService.can_step(Vector2i(1, 1), Vector2i(2, 1), unit, _context(board, unit))).is_true()
+
+func test_ramp_descends_from_its_high_side() -> void:
+	var board := _ramp_board()
+	var unit := _spawn(board, Vector2i(2, 1))
+	assert_bool(RulesService.can_step(Vector2i(2, 1), Vector2i(1, 1), unit, _context(board, unit))).is_true()
+
+func test_climbing_the_wrong_way_off_a_ramp_is_refused() -> void:
+	# A ramp rising EAST does not also climb WEST. Without this the rise direction would be doing no
+	# work at all and a bare axis would have been enough.
+	var board := _board()
+	var heights := _heights(board)
+	heights.set_cell(Vector2i(1, 1), 0, Terrain.RampRise.EAST)
+	heights.set_cell(Vector2i(0, 1), 1)   # high ground on the ramp's LOW side
+	var unit := _spawn(board, Vector2i(2, 1))
+	assert_bool(RulesService.can_step(Vector2i(1, 1), Vector2i(0, 1), unit, _context(board, unit))).is_false()
+
+
+# --- no sideways entry: TWO clauses, tested in both directions ---
+#
+# The 2026-08-12 lesson from the stage-2 falsification round: a case covering only one direction let
+# the entering-guard mutant survive. Leaving a ramp sideways and entering one sideways are separate
+# guards in can_step and each needs its own case.
+
+func test_a_ramp_refuses_sideways_ENTRY() -> void:
+	var board := _ramp_board()
+	var unit := _spawn(board, Vector2i(1, 0))
+	assert_bool(RulesService.can_step(Vector2i(1, 0), Vector2i(1, 1), unit, _context(board, unit))).is_false()
+
+func test_a_ramp_refuses_sideways_EXIT() -> void:
+	var board := _ramp_board()
+	var unit := _spawn(board, Vector2i(1, 1))
+	assert_bool(RulesService.can_step(Vector2i(1, 1), Vector2i(1, 2), unit, _context(board, unit))).is_false()
+
+
+# --- staircases and routing ---
+
+func test_a_staircase_of_ramps_chains() -> void:
+	# Each ramp's low side equals the previous ramp's height, which is what makes the chain work
+	# without any Z arithmetic beyond +/-1.
+	var board := _board()
+	var heights := _heights(board)
+	heights.set_cell(Vector2i(1, 1), 0, Terrain.RampRise.EAST)
+	heights.set_cell(Vector2i(2, 1), 1, Terrain.RampRise.EAST)
+	heights.set_cell(Vector2i(3, 1), 2)
+	var unit := _spawn(board, Vector2i(0, 1))
+	var context := _context(board, unit)
+
+	assert_bool(RulesService.can_step(Vector2i(0, 1), Vector2i(1, 1), unit, context)).is_true()
+	assert_bool(RulesService.can_step(Vector2i(1, 1), Vector2i(2, 1), unit, context)).is_true()
+	assert_bool(RulesService.can_step(Vector2i(2, 1), Vector2i(3, 1), unit, context)).is_true()
+
+func test_an_unramped_cliff_severs_the_connectivity_field() -> void:
+	# path_hops is what SquadCohesion.field walks, so this is also the dev's "a 1-block rise blocks
+	# squad range the way unwalkable terrain does" ruling — satisfied with no cohesion code at all.
+	var board := _board()
+	var heights := _heights(board)
+	for y in range(0, 3):
+		heights.set_cell(Vector2i(2, y), 1)   # a full-height ridge across the board, no ramps
+	var unit := _spawn(board, Vector2i(0, 1))
+	var field := RulesService.path_hops(Vector2i(0, 1), _context(board, unit), unit)
+
+	assert_bool(field.has(Vector2i(1, 1))).is_true()    # near side reachable
+	assert_bool(field.has(Vector2i(2, 1))).is_false()   # the ridge itself is unclimbable
+	assert_bool(field.has(Vector2i(4, 1))).is_false()   # and nothing beyond it
+
+func test_one_ramp_reopens_the_cliff() -> void:
+	# The same ridge with a single ramp cut into it: the detour IS the cost, since climbing is free.
+	var board := _board()
+	var heights := _heights(board)
+	for y in range(0, 3):
+		heights.set_cell(Vector2i(2, y), 1)
+	heights.set_cell(Vector2i(2, 0), 0, Terrain.RampRise.NORTH)   # unreachable rise dir on purpose
+	heights.set_cell(Vector2i(2, 1), 0, Terrain.RampRise.EAST)
+	heights.set_cell(Vector2i(3, 1), 1)
+	var unit := _spawn(board, Vector2i(0, 1))
+	var field := RulesService.path_hops(Vector2i(0, 1), _context(board, unit), unit)
+
+	assert_bool(field.has(Vector2i(2, 1))).is_true()
+	assert_bool(field.has(Vector2i(3, 1))).is_true()
+
+func test_move_range_refuses_an_unramped_cliff() -> void:
+	# The weighted twin of the field test above — compute_move_range must agree with path_hops about
+	# legality even though only one of them is weighted.
+	var board := _board()
+	var heights := _heights(board)
+	for y in range(0, 3):
+		heights.set_cell(Vector2i(2, y), 1)
+	var unit := _spawn(board, Vector2i(0, 1))
+	var result := RulesService.compute_move_range(unit, _context(board, unit))
+
+	assert_bool(result.reachable.has(Vector2i(1, 1))).is_true()
+	assert_bool(result.reachable.has(Vector2i(2, 1))).is_false()
+
+
+# --- persistence ---
+
+func test_heights_round_trip_through_a_scenario() -> void:
+	var heights := BoardHeights.new()
+	heights.set_cell(Vector2i(1, 1), 0, Terrain.RampRise.EAST)
+	heights.set_cell(Vector2i(2, 1), 3)
+
+	var scenario := ScenarioData.new()
+	scenario.elevations = heights.to_elevation_dict()
+	scenario.ramp_rises = heights.to_ramp_dict()
+
+	var restored := BoardHeights.new()
+	restored.load_dicts(scenario.elevations, scenario.ramp_rises)
+
+	assert_int(restored.elevation_at(Vector2i(2, 1))).is_equal(3)
+	assert_int(restored.ramp_rise_at(Vector2i(1, 1))).is_equal(Terrain.RampRise.EAST)
+	# A ramp at height 0 is legal and must survive — which is why the two facts serialize separately.
+	assert_int(restored.elevation_at(Vector2i(1, 1))).is_equal(0)
+	assert_bool(restored.is_ramp(Vector2i(1, 1))).is_true()

--- a/tests/rules/test_can_step.gd.uid
+++ b/tests/rules/test_can_step.gd.uid
@@ -1,0 +1,1 @@
+uid://dnw6uupl01bub

--- a/tests/rules/test_movement_cost.gd
+++ b/tests/rules/test_movement_cost.gd
@@ -48,7 +48,7 @@ func test_water_is_impassable_without_waterwalk() -> void:
 	BoardBuilder.paint_cell(board.grid, Vector2i(1, 0), BoardBuilder.WATER_ATLAS)
 	var unit := _spawn(board, Vector2i(0, 0), false)
 
-	var cost := RulesService.movement_cost(Vector2i(1, 0), unit, _rules_board(board, unit))
+	var cost := RulesService.movement_cost(Vector2i(0, 0), Vector2i(1, 0),unit, _rules_board(board, unit))
 
 	assert_int(cost).is_equal(RulesService.CANNOT_WALK_TILE)
 
@@ -57,7 +57,7 @@ func test_waterwalk_water_step_costs_the_same_as_any_other_tile() -> void:
 	BoardBuilder.paint_cell(board.grid, Vector2i(1, 0), BoardBuilder.WATER_ATLAS)
 	var unit := _spawn(board, Vector2i(0, 0), true)
 
-	var cost := RulesService.movement_cost(Vector2i(1, 0), unit, _rules_board(board, unit))
+	var cost := RulesService.movement_cost(Vector2i(0, 0), Vector2i(1, 0),unit, _rules_board(board, unit))
 
 	assert_int(cost).is_equal(1)
 
@@ -88,7 +88,7 @@ func test_can_traverse_ignores_occupancy() -> void:
 	var context := BoardContext.new(board.grid, units, board.squad_manager)
 
 	assert_bool(RulesService.can_traverse(Vector2i(1, 0), mover, context)).is_true()
-	assert_int(RulesService.movement_cost(Vector2i(1, 0), mover, context)).is_equal(RulesService.CANNOT_WALK_TILE)
+	assert_int(RulesService.movement_cost(Vector2i(0, 0), Vector2i(1, 0),mover, context)).is_equal(RulesService.CANNOT_WALK_TILE)
 
 
 func test_active_enemy_still_blocks_movement() -> void:
@@ -100,7 +100,7 @@ func test_active_enemy_still_blocks_movement() -> void:
 	var units: Array[Unit] = [mover, blocker]
 	var context := BoardContext.new(board.grid, units, board.squad_manager)
 
-	assert_int(RulesService.movement_cost(Vector2i(1, 0), mover, context)).is_equal(RulesService.CANNOT_WALK_TILE)
+	assert_int(RulesService.movement_cost(Vector2i(0, 0), Vector2i(1, 0),mover, context)).is_equal(RulesService.CANNOT_WALK_TILE)
 
 func test_downed_enemy_is_traversable_but_not_reachable() -> void:
 	# #122: a downed enemy body stops blocking a PATH through its cell (matching a downed ally
@@ -114,7 +114,7 @@ func test_downed_enemy_is_traversable_but_not_reachable() -> void:
 	var units: Array[Unit] = [mover, blocker]
 	var context := BoardContext.new(board.grid, units, board.squad_manager)
 
-	assert_int(RulesService.movement_cost(Vector2i(1, 0), mover, context)).is_less(RulesService.CANNOT_WALK_TILE)
+	assert_int(RulesService.movement_cost(Vector2i(0, 0), Vector2i(1, 0),mover, context)).is_less(RulesService.CANNOT_WALK_TILE)
 
 	var result := RulesService.compute_move_range(mover, context)
 	assert_bool(result.reachable.has(Vector2i(1, 0))).is_false()


### PR DESCRIPTION
🤖 Claude says:

Slice 1 of the #218 verticality design. **Narrowed from the filed ticket on your call** — the 2D wall-face render needs tile art you haven't chosen, so this ships the rules and store half plus a throwaway readout, and the real rendering becomes its own ticket (filed alongside).

Closes #257.

## The structural calls, in prose

**1. The store is per-CELL, not tileset custom data.** My first proposal in the design session was tile custom data, and your dev-tools question is what exposed it as wrong: `walkable` / `move_cost` / `terrain_type` are per-*tile* (per atlas coordinate), so an elevation among them needs a distinct grass tile per level — 21 of them for the 20-level cliff city the design explicitly allows — and a Tile Brush palette to match. `BoardHeights` is a sparse per-cell store instead. It also means elevation is testable on any painted board with no new tiles or art at all, which is why the test suite needed no art work.

**2. It is its own store, not part of `TerrainStateManager`.** That one holds a *stack of enum states with durations*; this holds two scalars. And it is deliberately not built as permanently static — `terrain.md`'s "attack the map" list already carries EARTH raising a destructible wall.

**3. `RefCounted`, breaking symmetry with its `Node` sibling.** It has no signals, no `_process` and nothing needing the tree, and a `RefCounted` frees itself rather than reading as a gdUnit orphan. Flagging it because it *is* an inconsistency with `TerrainStateManager` sitting right next to it.

**4. `can_step` is the edge question, and the blast radius was counted rather than estimated.** `movement_cost` has **exactly one** production caller (`compute_move_range`'s BFS, which already held the previous cell); `path_hops` is the other BFS; and `AITactics._standable_firing_cells` correctly does **not** change, because "could anyone stand here" genuinely is cell-shaped. `movement_cost`'s new `from` is **required, not optional** — an optional would give one question two answers depending on who called, which is the exact drift #102 was built to end. Cost of that: five call sites in `test_movement_cost.gd`.

**5. `RampRise`, not `ramp_axis` — a design detail the doc had wrong.** `verticality.md` sketched `{NONE, NS, EW}`, which cannot say which side is high: a ramp at height N with an EW axis climbs to *either* neighbour, and if both sit at N+1 the rule has no answer. `Terrain.RampRise` is the **direction of rise**, so one field carries the axis *and* the high side, and "no sideways entry" collapses to one question. **The doc is amended in this diff** so it and the code agree.

**6. Squad range needed no code at all.** `SquadCohesion.field` is a `path_hops` walk, so an unramped cliff severs the leash exactly the way water already does. That is your "a 1-block rise blocks squad range like unwalkable terrain does" ruling, satisfied by construction — pinned with a test rather than built.

## Falsification

Six mutants, each caught by its intended case. The one worth naming: **removing only the *entering*-sideways guard reddens the ENTRY test while the EXIT test stays green.** They are two separate clauses, and the 2026-08-12 stage-2 round is exactly where a suite that tested only one of them let a real mutant through.

The others: drop the exit guard · allow a climb with no ramp · allow a drop with no ramp · make `movement_cost` ignore its `from` · make an absent cell default to height 1.

## Testing

Full suite **1510/1510, 164 suites, 0 orphans** (228s).

Being straight with you: **that full run was premature and you called it mid-flight.** The rule is that a full run gates the PR after your feel-check, not the hand-off. What I should have run was `rules` plus one area that instantiates the real game scene — which would have caught the actual failure it found (a missing `--import` after adding a `class_name`, so `game.gd` wouldn't parse). Since it is already spent I am counting it as this PR's full run and will not re-run after your feedback unless something changes.

## Your half

You are on `feature/257-elevation-rules` — launch it.

**Expect the board to look completely flat**, because there is no way to author height yet (#260 is the painting ticket) and no wall art. What you can check:

- **F5** toggles the elevation readout in the flat 2D view (dev builds only): each cell's height, with `> < ^ v` on ramps showing which way they rise.
- The hover card gains an elevation/ramp line, and stays silent on flat cells so an ordinary board's card reads exactly as before.

If you want something to actually walk around on, say so and I'll do #260 next as a small PR — that is the point where this becomes feel-checkable.

## Follow-on

Filed: the 2D height render (wall-face autotiles, ramp sprites, per-level sprite Y-offset, and the `HoverPresenter` sprite-vs-cell disambiguation), gated on your tileset decision.
