### PR TITLE
The diorama grows hills: render elevation in 3D (#273)

### DIFF
--- a/Classes/presentation/BoardMirror.gd
+++ b/Classes/presentation/BoardMirror.gd
@@ -2,9 +2,17 @@ extends Node3D
 class_name BoardMirror
 
 # The Battle3D board mirror (#215 / #176 stage 4a): paints the 3D GridMap from the
-# LIVE 2D grid — the hidden game is the authority, this only reads. Boards mirror
-# FLAT (column height 1) because the sim has no elevation yet — the diorama's hills
-# arrive when the rules do.
+# LIVE 2D grid — the hidden game is the authority, this only reads.
+#
+# THE HILLS HAVE ARRIVED (#273). This mirrored flat, column height 1, on the stated promise that
+# "the diorama's hills arrive when the rules do" — they did, in #257, and became authorable in
+# #260. A cell now writes its whole COLUMN: the surface block repeated down to a shared floor
+# (min(0, lowest painted level), so a dip has a bottom rather than a hole), and a ramp adds the
+# generated wedge ONE level above its own, since a level-E block occupies [E..E+1] and a ramp
+# whose elevation is its LOW side must slope from E+1 to E+2.
+#
+# The heights are PASSED IN, never looked up: the caller already holds the store, and this mirror
+# reaching back into the game for it would be the second answer to "how tall is this cell".
 #
 # WHICH BLOCK a cell gets is two questions, and Kind was answering both until #250:
 #   surface  — what the top face looks like. The 2D answers this with the tile's
@@ -52,6 +60,15 @@ const KIND_TO_ITEM: Dictionary[Terrain.Kind, int] = {
 	Terrain.Kind.TREE: 6,
 }
 const FALLBACK_ITEM := 3  # dirt
+
+# The ramp wedge the generator emits (#273). A NAME, not an id, for the reason item_for_tile is
+# name-keyed: gen_lookdev_assets.gd writes it under this exact string, so the mapping cannot drift
+# from the artifact it maps.
+const RAMP_ITEM_NAME := "dirt_ramp"
+
+# Which way the authored wedge already climbs, in board space: its high edge is at -Z, and -Z is
+# north. Every other rise is this rotated.
+const RAMP_MESH_HIGH_SIDE := Vector3(0.0, 0.0, -1.0)
 const FLAME_TEXTURE_PATH := "res://Art/LookDev/torch_flame.png"
 
 # Flame knobs (aesthetics get a knob, not a guess). See _make_fire for how lift and gap
@@ -121,30 +138,35 @@ var _item_by_name: Dictionary[String, int] = {}
 var _item_index_built := false
 
 
-func rebuild(grid: TileMapLayer, burning: Array[Vector2i]) -> void:
+func rebuild(grid: TileMapLayer, heights: BoardHeights, burning: Array[Vector2i]) -> void:
 	board.clear()
-	sync(grid)
-	refresh_states(burning)
+	sync(grid, heights)
+	refresh_states(heights, burning)
+
+
+func surface_point(cell: Vector2i, heights: BoardHeights) -> Vector3:
+	return BoardSpace.surface_point(cell, heights)   # the one answer lives with the convention
 
 
 # The live terrain diff: write only what differs, erase what the 2D no longer paints.
 # board.clear() is deliberately NOT here — a wholesale repaint per motion event is the
 # thing this exists to avoid; rebuild() owns the clear for a genuine board swap.
-func sync(grid: TileMapLayer) -> void:
+#
+# The heights are PASSED, not looked up (#273): this already takes the grid the same way, and the
+# mirror has no business reaching into the game for the store the caller is already holding.
+func sync(grid: TileMapLayer, heights: BoardHeights) -> void:
 	sync_passes += 1
+	var floor_level := _floor_level(heights)
 	var live: Dictionary[Vector2i, bool] = {}
 	var propped: Dictionary[Vector2i, bool] = {}
 	for cell in grid.get_used_cells():
 		live[cell] = true
-		var item := item_for_cell(grid, cell)
-		var at := BoardSpace.of_flat(cell)
-		if board.get_cell_item(at) != item:
-			board.set_cell_item(at, item)
+		_write_column(cell, item_for_cell(grid, cell), heights, floor_level)
 		# Props ride the SAME walk rather than a second pass over the same cells — this is the
 		# terrain diff, and whether a cell carries a standing object is a terrain fact.
 		if GridUtils.stands_up_at_cell(grid, cell):
 			propped[cell] = true
-			_reconcile_prop(grid, cell)
+			_reconcile_prop(grid, cell, heights)
 	_free_props_except(propped)
 	# get_used_cells returns a copy, so erasing inside the walk is safe.
 	for cell: Vector3i in board.get_used_cells():
@@ -152,15 +174,78 @@ func sync(grid: TileMapLayer) -> void:
 			board.set_cell_item(cell, GridMap.INVALID_CELL_ITEM)
 
 
+# The lowest surface any column has to reach down to. A dip must have a bottom rather than a hole,
+# and every column shares one floor so the board's underside stays flat. Clamped at 0 so an
+# all-flat board writes exactly the one layer it always did.
+func _floor_level(heights: BoardHeights) -> int:
+	var lowest := 0
+	for cell in heights.painted_cells():
+		lowest = mini(lowest, heights.elevation_at(cell))
+	return lowest
+
+
+# One cell's whole COLUMN (#273): the surface block repeated down to the shared floor, which is the
+# dev's call — BoardMirror already splits surface (top face, from atlas coords) from material (side
+# texture, from Kind), so a stack of one block already reads as a cliff face of that material.
+# Painting a DIFFERENT tile under a tile is a separate ticket he scoped out.
+#
+# A ramp adds its wedge ONE LEVEL ABOVE its own: a level-E block occupies [E..E+1], so level E's
+# surface is at E+1, and a ramp whose own elevation is its LOW side must slope from E+1 up to E+2.
+# That makes a ramp column read one cell taller than its flat neighbour, which is exactly what
+# BoardPicker's "ramps count as full blocks" already assumes.
+func _write_column(cell: Vector2i, item: int, heights: BoardHeights, floor_level: int) -> void:
+	var level := heights.elevation_at(cell)
+	var rise := heights.ramp_rise_at(cell)
+	for y in range(floor_level, level + 1):
+		var at := Vector3i(cell.x, y, cell.y)
+		if board.get_cell_item(at) != item:
+			board.set_cell_item(at, item)
+	var top := level
+	if rise != Terrain.RampRise.NONE:
+		var wedge := Vector3i(cell.x, level + 1, cell.y)
+		var orientation := _ramp_orientation(rise)
+		if board.get_cell_item(wedge) != ramp_item() \
+				or board.get_cell_item_orientation(wedge) != orientation:
+			board.set_cell_item(wedge, ramp_item(), orientation)
+		top = level + 1
+	# LOWERING a cell strands everything the column used to hold above its new top. Walk up until
+	# the column is genuinely clear rather than assuming one stale cell — a 5-level cut leaves 5.
+	var above := top + 1
+	while board.get_cell_item(Vector3i(cell.x, above, cell.y)) != GridMap.INVALID_CELL_ITEM:
+		board.set_cell_item(Vector3i(cell.x, above, cell.y), GridMap.INVALID_CELL_ITEM)
+		above += 1
+
+
+# The wedge's meshlib id, asked of the LIBRARY rather than hardcoded — the same reason
+# item_for_tile indexes by name: the library is the mapping, and a literal id here would silently
+# point at whatever the generator emitted second.
+func ramp_item() -> int:
+	_ensure_item_index()
+	return _item_by_name.get(RAMP_ITEM_NAME, GridMap.INVALID_CELL_ITEM)
+
+
+# The generator draws the wedge with its high edge at -Z and notes that "GridMap orientation (yaw
+# steps) points the high side at the upper level". -Z is NORTH in board space, so the yaw is
+# DERIVED from Terrain.rise_direction — the same vocabulary the rules use — rather than a
+# hand-written table of orthogonal indices that could drift from the mesh.
+func _ramp_orientation(rise: Terrain.RampRise) -> int:
+	var dir := Terrain.rise_direction(rise)
+	if dir == Vector2i.ZERO:
+		return 0
+	var target := Vector3(dir.x, 0.0, dir.y)
+	var angle := RAMP_MESH_HIGH_SIDE.signed_angle_to(target, Vector3.UP)
+	return board.get_orthogonal_index_from_basis(Basis(Vector3.UP, angle))
+
+
 # Add what is newly alight, free what went out, LEAVE STANDING what still burns. The last
 # clause is the one with teeth: a marker that is rebuilt every frame looks identical
 # through fire_marker_count(), so the pin is node identity, not the count.
-func refresh_states(burning: Array[Vector2i]) -> void:
+func refresh_states(heights: BoardHeights, burning: Array[Vector2i]) -> void:
 	var wanted: Dictionary[Vector2i, bool] = {}
 	for cell in burning:
 		wanted[cell] = true
 		if not _fire_markers.has(cell):
-			_fire_markers[cell] = _make_fire(BoardSpace.of_flat(cell))
+			_fire_markers[cell] = _make_fire(surface_point(cell, heights))
 	for cell: Vector2i in _fire_markers.keys():
 		if not wanted.has(cell):
 			_fire_markers[cell].queue_free()
@@ -216,7 +301,7 @@ func _ensure_item_index() -> void:
 # WYSIWYG beat the bracket I recommended). It runs item_for_cell against the 2D GHOST LAYER,
 # which is the same function sync() runs against the real grid — so the preview physically
 # cannot disagree with the paint that follows it; only the material differs.
-func show_brush_ghost(cell: Vector2i, ghost: TileMapLayer) -> void:
+func show_brush_ghost(cell: Vector2i, ghost: TileMapLayer, heights: BoardHeights) -> void:
 	if ghost == null:
 		hide_brush_ghost()
 		return
@@ -227,7 +312,7 @@ func show_brush_ghost(cell: Vector2i, ghost: TileMapLayer) -> void:
 		_brush_ghost.mesh = mesh
 	# The item's own transform carries any authored offset/rotation; the cell supplies where.
 	var item_xform: Transform3D = board.mesh_library.get_item_mesh_transform(item)
-	var at := BoardSpace.of_flat(cell)
+	var at := BoardSpace.of_cell(cell, heights.elevation_at(cell))
 	_brush_ghost.transform = Transform3D(item_xform.basis, BoardSpace.cell_center(at) + item_xform.origin)
 	_brush_ghost.visible = true
 
@@ -276,10 +361,10 @@ func flame_base_lift() -> float:
 	return maxf(flame_lift, flame_size.y * 0.5 + flame_ground_gap)
 
 
-func _make_fire(cell: Vector3i) -> Node3D:
+func _make_fire(at: Vector3) -> Node3D:
 	var root := Node3D.new()
 	add_child(root)
-	root.position = BoardSpace.standing_point(cell)
+	root.position = at
 
 	var flame := MeshInstance3D.new()
 	var quad := QuadMesh.new()
@@ -340,7 +425,7 @@ func prop_at(cell: Vector2i) -> Node3D:
 # Build the prop this cell wants, or leave the standing one alone when it is already the right
 # tile. The tile comparison is what makes REPLACEMENT work: painting a rock onto a tree keeps the
 # cell in the wanted-set, so a cell-only check would leave the tree standing.
-func _reconcile_prop(grid: TileMapLayer, cell: Vector2i) -> void:
+func _reconcile_prop(grid: TileMapLayer, cell: Vector2i, heights: BoardHeights) -> void:
 	var coords: Vector2i = grid.get_cell_atlas_coords(cell)
 	var tile := Vector3i(grid.get_cell_source_id(cell), coords.x, coords.y)
 	var standing: Node3D = _props.get(cell)
@@ -349,7 +434,7 @@ func _reconcile_prop(grid: TileMapLayer, cell: Vector2i) -> void:
 			return
 		standing.queue_free()
 		_props.erase(cell)
-	var built := _make_prop(grid, cell)
+	var built := _make_prop(grid, cell, surface_point(cell, heights))
 	if built == null:
 		return
 	built.set_meta(PROP_TILE_META, tile)
@@ -366,7 +451,7 @@ func _free_props_except(wanted: Dictionary[Vector2i, bool]) -> void:
 # The object standing on the cell that paints it, in whatever form its art asks for. The FORM is
 # the only fork; everything around it — where it stands, what layer it draws on, whether it casts
 # a shadow, whether it carries a light — is one answer for every prop.
-func _make_prop(grid: TileMapLayer, cell: Vector2i) -> Node3D:
+func _make_prop(grid: TileMapLayer, cell: Vector2i, at: Vector3) -> Node3D:
 	var shape := GridUtils.prop_shape_at_cell(grid, cell)
 	var body: GeometryInstance3D = null
 	if GridUtils.SOLID_SHAPES.has(shape):
@@ -381,7 +466,7 @@ func _make_prop(grid: TileMapLayer, cell: Vector2i) -> Node3D:
 
 	var root := Node3D.new()
 	add_child(root)
-	root.position = BoardSpace.standing_point(BoardSpace.of_flat(cell))
+	root.position = at
 	body.layers = BoardOverlays.WORLD_RENDER_LAYER
 	body.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
 	root.add_child(body)

--- a/Classes/presentation/BoardSpace.gd
+++ b/Classes/presentation/BoardSpace.gd
@@ -24,7 +24,33 @@ static func cell_center(cell: Vector3i) -> Vector3:
 
 # Center of the cell's TOP face: where a unit stands, an overlay lies, a highlight sits.
 static func standing_point(cell: Vector3i) -> Vector3:
-	return Vector3(cell.x + 0.5, cell.y + 1.0, cell.z + 0.5) * CELL_SIZE
+	return Vector3((cell.x + 0.5) * CELL_SIZE, surface_y(cell.y), (cell.z + 0.5) * CELL_SIZE)
+
+
+# The world Y of a surface at `level` — the top face of that level's block, since a level-E block
+# occupies [E .. E+1]. The ONE spelling of it (#273): the live board's unit placement
+# (UnitMirror) and the walk demo's injected stand_at both read this, so the mirrored board and
+# the demo cannot drift about where the ground is.
+static func surface_y(level: int) -> float:
+	return float(level + 1) * CELL_SIZE
+
+
+# Where a thing STANDING on this 2D cell sits — a unit, a flame, a crate (#273). ONE answer for
+# every such caller, because three of them eyeballing the same offset is how a flame ends up half a
+# level off the crate on its own tile. It lives here rather than on either mirror so neither has to
+# reach for the other.
+#
+# A ramp's surface SLOPES, and verticality.md rules its visual midpoint purely presentational — so
+# anything on one rides half a level up rather than sinking into the low edge the RULES call its
+# level. That is the one place presentation and rules deliberately disagree, and it is why
+# UnitSprite3D.stand_at was made injectable in the first place.
+static func surface_point(cell: Vector2i, heights: BoardHeights) -> Vector3:
+	if heights == null:
+		return standing_point(of_cell(cell, 0))
+	var point := standing_point(of_cell(cell, heights.elevation_at(cell)))
+	if heights.is_ramp(cell):
+		point.y += CELL_SIZE * 0.5
+	return point
 
 
 # The cell containing a world position (floor per axis — see the boundary rule above).
@@ -36,23 +62,25 @@ static func cell_of(position: Vector3) -> Vector3i:
 	)
 
 
-# The TOP LEVEL of a flat-board column: of_flat puts every cell at y-index 0, so the
-# face a unit stands on — and the plane BoardPicker falls back to over an erased cell
-# (#231) — sits one CELL_SIZE up, never at y = 0. Named because y=0 is the slab's
-# BOTTOM and reads plausible: a fallback plane there returns the wrong cell at grazing
-# angles. UnitMirror.COLUMN_TOP derives from this rather than restating it.
+# The TOP of a GROUND-LEVEL column, in cells — what BoardPicker's fallback plane sits on over an
+# erased cell (#231), since y=0 is the slab's BOTTOM and a plane there returns the wrong cell at
+# grazing angles. Elevation (#273) did NOT retire this: an unpainted column is still exactly one
+# cell tall, so this is the top of level 0 and nothing more. It equals surface_y(0), and
+# test_board_space pins the two spellings together.
 const FLAT_TOP_LEVEL := 1
 
-# The flat-board bridge (#222): sim cells are 2D (x, y), mirror cells are (x, 0, y)
-# until real elevation arrives — the ONE spelling of that pair. Not for columns with
-# a real height (BoardPicker._top_cell keeps its own y). flat(NO_CELL) equals
-# GridUtils.NO_CELL by value — pinned, the pointer source relies on it.
+# The sim<->mirror cell pair (#222): sim cells are 2D (x, y), mirror cells are (x, level, y).
+# The ONE spelling of it. flat(NO_CELL) equals GridUtils.NO_CELL by value — pinned, the pointer
+# source relies on it.
 static func flat(cell: Vector3i) -> Vector2i:
 	return Vector2i(cell.x, cell.z)
 
 
-static func of_flat(cell: Vector2i) -> Vector3i:
-	return Vector3i(cell.x, 0, cell.y)
+# Every caller states the LEVEL it means (#273 — this took no argument and hardcoded 0 while the
+# sim had no elevation). Passing beats looking up, and a required argument is what makes the old
+# flat assumption unrepresentable rather than merely discouraged.
+static func of_cell(cell: Vector2i, level: int) -> Vector3i:
+	return Vector3i(cell.x, level, cell.y)
 
 
 # A 2D-game world POSITION (pixels) as a 3D position at height `y`. The one spelling of

--- a/Classes/presentation/OverlayMirror.gd
+++ b/Classes/presentation/OverlayMirror.gd
@@ -27,7 +27,6 @@ class_name OverlayMirror
 # It also owns the fire poll: BoardMirror's flame markers are board markup with the
 # same cadence question, and this is the node that already runs every frame.
 
-const TOP := UnitMirror.COLUMN_TOP       # flat mirror boards: anchors at y 1.0
 
 var game: Node2D            # the hidden Game coordinator; set by battle3d._ready
 var overlays: BoardOverlays
@@ -87,7 +86,8 @@ func _fire() -> void:
 	if _last_fire == burning:
 		return
 	_last_fire = burning
-	board_mirror.refresh_states(burning)
+	var heights: BoardHeights = game.board_heights
+	board_mirror.refresh_states(heights, burning)
 
 
 # --- Fills -------------------------------------------------------------------------
@@ -107,10 +107,28 @@ func _fill_gated(layer: BoardOverlays.Layer, source, wanted: bool) -> void:
 	_fill(layer, cells)
 
 
+# Which level a marked cell's overlay lies on (#273) — a move-range tile on a terrace has to sit
+# ON the terrace. Read off the hidden game rather than passed, unlike BoardMirror.sync: this class
+# already POLLS the game for everything it draws, and nothing here takes board state as an
+# argument. Null-guarded for the headless Play boards that never set `game`.
+func _level_of(cell: Vector2i) -> int:
+	var heights := _heights()
+	return heights.elevation_at(cell) if heights != null else 0
+
+
+# Null on the headless Play boards that never set `game`; BoardSpace.surface_point reads that as
+# flat, so every anchor keeps working on a board with no heights wired.
+func _heights() -> BoardHeights:
+	if game == null:
+		return null
+	var heights: BoardHeights = game.board_heights
+	return heights
+
+
 func _fill(layer: BoardOverlays.Layer, used: Array[Vector2i]) -> void:
 	var cells: Array[Vector3i] = []
 	for cell in used:
-		cells.append(BoardSpace.of_flat(cell))
+		cells.append(BoardSpace.of_cell(cell, _level_of(cell)))
 	cells.sort()
 	if _last_cells.get(layer, Array()) == cells:
 		return
@@ -127,7 +145,7 @@ func _attack(om: OverlayManager) -> void:
 		if om.attack_overlay.get_cell_atlas_coords(cell) == OverlayManager.TARGET_ATLAS_COORDS:
 			picks.append(_marker(_anchor(cell), _target_pick_texture(om), Color.WHITE))
 		else:
-			reach.append(BoardSpace.of_flat(cell))
+			reach.append(BoardSpace.of_cell(cell, _level_of(cell)))
 	reach.sort()
 	if _last_cells.get(BoardOverlays.Layer.ATTACK, Array()) != reach:
 		_last_cells[BoardOverlays.Layer.ATTACK] = reach
@@ -247,11 +265,15 @@ func _marker(pos: Vector3, texture: Texture2D, tint: Color) -> Dictionary:
 	return {"pos": pos, "texture": texture, "modulate": tint}
 
 
-# A cell's top-face center — the marker anchor convention.
+# A cell's top-face center — the marker anchor convention, now on the cell's own SURFACE (#273)
+# so a marker on a terrace rides the terrace. BoardSpace.surface_point is the one answer; a ramp's
+# half-level lift comes along with it.
 func _anchor(cell: Vector2i) -> Vector3:
-	return Vector3(cell.x + 0.5, TOP, cell.y + 0.5)
+	return BoardSpace.surface_point(cell, _heights())
 
 
-# A 2D world position's top-face anchor (sprites sit at cell centers).
+# A 2D world position's top-face anchor (sprites sit at cell centers). The LEVEL comes from the
+# cell those pixels fall in, so a ghost or arrow over a terrace lifts with it.
 func _anchor_px(px: Vector2) -> Vector3:
-	return BoardSpace.of_pixels(px, TOP)
+	var cell := Vector2i(floori(px.x / float(GridUtils.TILE_SIZE)), floori(px.y / float(GridUtils.TILE_SIZE)))
+	return BoardSpace.of_pixels(px, BoardSpace.surface_point(cell, _heights()).y)

--- a/Classes/presentation/UnitMirror.gd
+++ b/Classes/presentation/UnitMirror.gd
@@ -12,9 +12,6 @@ class_name UnitMirror
 # so pulse/highlight/tint parity comes by copy rather than by reimplementation.
 
 const PIXELS_PER_CELL := float(GridUtils.TILE_SIZE)  # 16 — grid.map_to_local's metric
-# Flat mirror boards: every column is one cell tall. DERIVED, not restated — the picker's
-# fallback plane (#231) has to sit on this same face, and two literals would let them drift.
-const COLUMN_TOP := float(BoardSpace.FLAT_TOP_LEVEL) * BoardSpace.CELL_SIZE
 
 # Unit-sprite pixel density, in texels per world unit — the inspector face of
 # UnitSprite3D.texels_per_unit, which every sprite reads at construction (ghosts included, which
@@ -28,6 +25,11 @@ const COLUMN_TOP := float(BoardSpace.FLAT_TOP_LEVEL) * BoardSpace.CELL_SIZE
 @export var texels_per_unit := 32.0
 
 var units_root: Node2D
+
+# The elevation store (#273); pushed in by battle3d beside units_root. A unit stands on the
+# SURFACE, and this is what tells it where that is — null on a board with no heights wired, which
+# BoardSpace.surface_point reads as flat.
+var heights: BoardHeights
 
 var _mirrored: Dictionary[int, UnitSprite3D] = {}
 var _ghosts: Array[UnitSprite3D] = []
@@ -121,8 +123,14 @@ func ghost_count() -> int:
 
 func _sync(unit: Unit, sprite: UnitSprite3D) -> void:
 	var previous := sprite.position
-	sprite.position = Vector3(
-			unit.position.x / PIXELS_PER_CELL, COLUMN_TOP, unit.position.y / PIXELS_PER_CELL)
+	# The height comes from the cell the sprite is OVER, not from unit.movement.cell: mid-walk the
+	# pixel position is between cells, and reading the destination would pop the sprite to the new
+	# level before it arrives. Derived from the same pixels that place X and Z, so it steps up as
+	# the sprite crosses the edge.
+	var over := Vector2i(floori(unit.position.x / PIXELS_PER_CELL),
+			floori(unit.position.y / PIXELS_PER_CELL))
+	sprite.position = Vector3(unit.position.x / PIXELS_PER_CELL,
+			BoardSpace.surface_point(over, heights).y, unit.position.y / PIXELS_PER_CELL)
 	sprite.cell = BoardSpace.cell_of(sprite.position + Vector3(0, -0.5, 0))
 
 	var downed := unit.lifecycle_state == Unit.LifecycleState.DOWNED

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -112,6 +112,7 @@ func _ready() -> void:
 		_update_help()
 	_board_mirror.board = $Board
 	_unit_mirror.units_root = game.units_root
+	_unit_mirror.heights = game.board_heights
 	_overlay_mirror.game = game
 	_overlay_mirror.overlays = _overlays
 	_overlay_mirror.unit_mirror = _unit_mirror
@@ -147,7 +148,7 @@ func _on_board_loaded() -> void:
 
 
 func rebuild() -> void:
-	_board_mirror.rebuild(game.grid, game.terrain_states.burning_cells())
+	_board_mirror.rebuild(game.grid, game.board_heights, game.terrain_states.burning_cells())
 	_refresh_tops()
 
 
@@ -172,7 +173,7 @@ func _refresh_tops() -> void:
 func _sync_terrain_while_authoring() -> void:
 	if game.game_state != game.GameState.DEV_MODE:
 		return
-	_board_mirror.sync(game.grid)
+	_board_mirror.sync(game.grid, game.board_heights)
 	var before := _board_rect
 	_refresh_tops()
 	if _board_rect != before:
@@ -502,7 +503,7 @@ func _sync_brush_ghost() -> void:
 	if cell == GridUtils.NO_CELL:
 		_board_mirror.hide_brush_ghost()
 		return
-	_board_mirror.show_brush_ghost(cell, game.dev_controller.brush_ghost_layer())
+	_board_mirror.show_brush_ghost(cell, game.dev_controller.brush_ghost_layer(), game.board_heights)
 
 
 # The brush erases on RIGHT, so orbit steps aside to MIDDLE while it is armed — 2D and 3D keep

--- a/tests/presentation/test_board_mirror.gd
+++ b/tests/presentation/test_board_mirror.gd
@@ -249,7 +249,7 @@ func test_a_live_terrain_paint_reaches_the_3d_board_per_cell() -> void:
 	_game.game_state = _game.GameState.DEV_MODE
 	var board := _scene.get_node("Board") as GridMap
 	var cell: Vector2i = _game.grid.get_used_cells()[0]
-	var at := BoardSpace.of_flat(cell)
+	var at := BoardSpace.of_cell(cell, 0)
 	var before := board.get_cell_item(at)
 	var other := _a_tile_of_a_different_kind(cell)
 	assert_bool(other.source >= 0).override_failure_message(
@@ -268,7 +268,7 @@ func test_an_erased_cell_leaves_a_hole_in_the_3d_board() -> void:
 	_game.game_state = _game.GameState.DEV_MODE
 	var board := _scene.get_node("Board") as GridMap
 	var cell: Vector2i = _game.grid.get_used_cells()[0]
-	var at := BoardSpace.of_flat(cell)
+	var at := BoardSpace.of_cell(cell, 0)
 	assert_int(board.get_cell_item(at)).is_not_equal(GridMap.INVALID_CELL_ITEM)
 	_game.grid.erase_cell(cell)
 	await _settle()
@@ -352,8 +352,8 @@ func test_two_tiles_of_one_kind_render_as_two_different_blocks() -> void:
 	_game.grid.set_cell(b, pair[1].source, pair[1].coords)
 	await _settle()
 
-	var item_a := board.get_cell_item(BoardSpace.of_flat(a))
-	var item_b := board.get_cell_item(BoardSpace.of_flat(b))
+	var item_a := board.get_cell_item(BoardSpace.of_cell(a, 0))
+	var item_b := board.get_cell_item(BoardSpace.of_cell(b, 0))
 	assert_int(item_a).override_failure_message(
 			"two tiles of the same kind (%s and %s) render as the SAME block — the board is still keyed on Kind" \
 			% [pair[0].coords, pair[1].coords]).is_not_equal(item_b)
@@ -410,7 +410,7 @@ func test_a_tile_with_no_block_of_its_own_falls_back_to_its_kind() -> void:
 	_game.grid.set_cell(cell, entry.source, entry.coords)
 	await _settle()
 
-	var item := board.get_cell_item(BoardSpace.of_flat(cell))
+	var item := board.get_cell_item(BoardSpace.of_cell(cell, 0))
 	assert_int(item).override_failure_message(
 			"a skipped tile left the cell EMPTY — the 2D paints a tile there and the 3D shows a hole" \
 			).is_not_equal(GridMap.INVALID_CELL_ITEM)

--- a/tests/presentation/test_board_mirror.gd
+++ b/tests/presentation/test_board_mirror.gd
@@ -824,3 +824,95 @@ func test_the_flame_never_sits_in_the_ground_plane() -> void:
 	assert_float(mirror.flame_base_lift()).override_failure_message(
 			"the clamp moved the flame even with depth-write off, so the revert is not exact" \
 			).is_equal_approx(0.35, 0.0001)
+
+
+# --- Elevation (#273) --------------------------------------------------------------
+
+# All three drive the AUTHORITY (game.board_heights) and never call sync() themselves — the same
+# rule the #231 live cases follow, so a mirror that only works when a test pokes it goes red.
+
+func test_a_raised_cell_fills_its_whole_column() -> void:
+	# A terrace is a slab with a FACE, not a floating tile: the surface block repeats down to the
+	# floor. A mirror that writes only the top leaves the board hovering.
+	_scene.load_mission(PROLOG)
+	await _settle()
+	_game.game_state = _game.GameState.DEV_MODE
+	var board := _scene.get_node("Board") as GridMap
+	var cell: Vector2i = _game.grid.get_used_cells()[0]
+	var surface := board.get_cell_item(BoardSpace.of_cell(cell, 0))
+
+	_game.board_heights.set_cell(cell, 2, Terrain.RampRise.NONE)
+	await _settle()
+
+	for level in [0, 1, 2]:
+		assert_int(board.get_cell_item(BoardSpace.of_cell(cell, level))) \
+			.override_failure_message("level %d of the column is missing" % level) \
+			.is_equal(surface)
+	assert_int(board.get_cell_item(BoardSpace.of_cell(cell, 3))) \
+		.override_failure_message("the column runs past the level it was painted at") \
+		.is_equal(GridMap.INVALID_CELL_ITEM)
+
+
+func test_lowering_a_cell_clears_the_column_it_used_to_fill() -> void:
+	# The stranding case: a 3-level cut leaves 3 orphans if the erase assumes one stale block.
+	_scene.load_mission(PROLOG)
+	await _settle()
+	_game.game_state = _game.GameState.DEV_MODE
+	var board := _scene.get_node("Board") as GridMap
+	var cell: Vector2i = _game.grid.get_used_cells()[0]
+	_game.board_heights.set_cell(cell, 3, Terrain.RampRise.NONE)
+	await _settle()
+
+	_game.board_heights.set_cell(cell, 0, Terrain.RampRise.NONE)
+	await _settle()
+
+	for level in [1, 2, 3]:
+		assert_int(board.get_cell_item(BoardSpace.of_cell(cell, level))) \
+			.override_failure_message("level %d survived the cut" % level) \
+			.is_equal(GridMap.INVALID_CELL_ITEM)
+
+
+func test_a_ramp_puts_its_wedge_one_level_above_its_own() -> void:
+	# The off-by-one that is INVISIBLE on a flat board: a level-E block occupies [E..E+1], so E's
+	# surface is E+1 and a ramp whose elevation is its LOW side must slope from E+1 to E+2.
+	_scene.load_mission(PROLOG)
+	await _settle()
+	_game.game_state = _game.GameState.DEV_MODE
+	var board := _scene.get_node("Board") as GridMap
+	var mirror: BoardMirror = _scene._board_mirror
+	var cell: Vector2i = _game.grid.get_used_cells()[0]
+
+	_game.board_heights.set_cell(cell, 1, Terrain.RampRise.NORTH)
+	await _settle()
+
+	assert_int(mirror.ramp_item()).override_failure_message(
+			"the meshlib has no '%s'; the case is vacuous" % BoardMirror.RAMP_ITEM_NAME) \
+		.is_not_equal(GridMap.INVALID_CELL_ITEM)
+	assert_int(board.get_cell_item(BoardSpace.of_cell(cell, 2))) \
+		.override_failure_message("the wedge is not one level above the ramp's own") \
+		.is_equal(mirror.ramp_item())
+
+
+func test_each_rise_points_the_wedges_high_side_the_way_it_names() -> void:
+	# The orientation is DERIVED from Terrain.rise_direction, so this asserts the GEOMETRY rather
+	# than a magic orthogonal index: rotating the authored wedge's high side by the basis the
+	# mirror chose must land on the direction the rise names.
+	_scene.load_mission(PROLOG)
+	await _settle()
+	_game.game_state = _game.GameState.DEV_MODE
+	var board := _scene.get_node("Board") as GridMap
+	var cell: Vector2i = _game.grid.get_used_cells()[0]
+
+	for rise: Terrain.RampRise in [Terrain.RampRise.NORTH, Terrain.RampRise.EAST,
+			Terrain.RampRise.SOUTH, Terrain.RampRise.WEST]:
+		_game.board_heights.set_cell(cell, 0, rise)
+		await _settle()
+		var basis := board.get_cell_item_basis(BoardSpace.of_cell(cell, 1))
+		var high := basis * BoardMirror.RAMP_MESH_HIGH_SIDE
+		var want := Terrain.rise_direction(rise)
+		assert_float(high.x).override_failure_message(
+			"%s rises the wrong way on X" % Terrain.ramp_rise_display_name(rise)) \
+			.is_equal_approx(float(want.x), 0.01)
+		assert_float(high.z).override_failure_message(
+			"%s rises the wrong way on Z" % Terrain.ramp_rise_display_name(rise)) \
+			.is_equal_approx(float(want.y), 0.01)

--- a/tests/presentation/test_board_picker.gd
+++ b/tests/presentation/test_board_picker.gd
@@ -98,7 +98,7 @@ func test_an_erased_cell_inside_the_board_is_still_pickable() -> void:
 	assert_that(BoardPicker.pick_cell(over_the_hole, straight_down, _holed_tops, Rect2i())) \
 		.override_failure_message("the fixture's hole is not actually a hole").is_equal(BoardSpace.NO_CELL)
 	var cell := BoardPicker.pick_cell(over_the_hole, straight_down, _holed_tops, _apron_of(_holed_tops))
-	assert_that(cell).is_equal(BoardSpace.of_flat(Vector2i(1, 0)))
+	assert_that(cell).is_equal(BoardSpace.of_cell(Vector2i(1, 0), 0))
 
 
 func test_the_ground_plane_sits_on_the_top_face_not_the_slab_bottom() -> void:
@@ -107,7 +107,7 @@ func test_the_ground_plane_sits_on_the_top_face_not_the_slab_bottom() -> void:
 	# would travel a further cell and come down on the far column instead.
 	var cell := BoardPicker.pick_cell(Vector3(-1.5, 3.0, 0.5), Vector3(3.0, -2.0, 0.0),
 			_holed_tops, _apron_of(_holed_tops))
-	assert_that(cell).is_equal(BoardSpace.of_flat(Vector2i(1, 0)))
+	assert_that(cell).is_equal(BoardSpace.of_cell(Vector2i(1, 0), 0))
 	assert_int(cell.y).override_failure_message("the plane cell came back at the wrong level").is_equal(0)
 
 
@@ -129,7 +129,7 @@ func test_the_apron_bounds_where_the_plane_ends() -> void:
 	var inside := plane.end - Vector2i.ONE
 	var outside := plane.end
 	var hit := BoardPicker.pick_cell(Vector3(inside.x + 0.5, 5.0, inside.y + 0.5), Vector3.DOWN, _tower_tops, plane)
-	assert_that(hit).is_equal(BoardSpace.of_flat(inside))
+	assert_that(hit).is_equal(BoardSpace.of_cell(inside, 0))
 	var miss := BoardPicker.pick_cell(Vector3(outside.x + 0.5, 5.0, outside.y + 0.5), Vector3.DOWN, _tower_tops, plane)
 	assert_that(miss).is_equal(BoardSpace.NO_CELL)
 
@@ -140,7 +140,7 @@ func test_an_empty_board_is_still_pickable_under_a_plane() -> void:
 	var empty: Dictionary[Vector2i, int] = {}
 	var plane := Rect2i(0, 0, 4, 4)
 	var cell := BoardPicker.pick_cell(Vector3(1.5, 5.0, 1.5), Vector3.DOWN, empty, plane)
-	assert_that(cell).is_equal(BoardSpace.of_flat(Vector2i(1, 1)))
+	assert_that(cell).is_equal(BoardSpace.of_cell(Vector2i(1, 1), 0))
 	assert_that(BoardPicker.pick_cell(Vector3(1.5, 5.0, 1.5), Vector3.DOWN, empty, Rect2i())) \
 		.is_equal(BoardSpace.NO_CELL)
 

--- a/tests/presentation/test_board_space.gd
+++ b/tests/presentation/test_board_space.gd
@@ -35,10 +35,10 @@ func test_no_cell_sits_outside_any_real_board() -> void:
 	assert_bool(BoardSpace.NO_CELL.y < -100).is_true()
 
 
-func test_flat_and_of_flat_bridge_the_flat_board_convention() -> void:
+func test_flat_and_of_cell_bridge_the_sim_and_mirror_conventions() -> void:
 	assert_that(BoardSpace.flat(Vector3i(5, 2, 8))).is_equal(Vector2i(5, 8))
-	assert_that(BoardSpace.of_flat(Vector2i(5, 8))).is_equal(Vector3i(5, 0, 8))
-	assert_that(BoardSpace.flat(BoardSpace.of_flat(Vector2i(-3, 7)))).is_equal(Vector2i(-3, 7))
+	assert_that(BoardSpace.of_cell(Vector2i(5, 8), 0)).is_equal(Vector3i(5, 0, 8))
+	assert_that(BoardSpace.flat(BoardSpace.of_cell(Vector2i(-3, 7), 0))).is_equal(Vector2i(-3, 7))
 
 
 func test_flat_maps_the_no_cell_sentinel_onto_the_2d_one() -> void:
@@ -48,12 +48,41 @@ func test_flat_maps_the_no_cell_sentinel_onto_the_2d_one() -> void:
 
 
 func test_a_flat_boards_top_level_is_one_cell_up_not_zero() -> void:
-	# The y=0-vs-y=1 trap (#231). of_flat parks every cell at y-index 0, so the face
-	# things sit on is FLAT_TOP_LEVEL cells up. A picker fallback plane at y=0 would be
-	# the slab's BOTTOM and would resolve the wrong column at grazing angles.
-	var cell := BoardSpace.of_flat(Vector2i(4, 7))
+	# The y=0-vs-y=1 trap (#231). A level-0 cell sits at y-index 0, so the face things stand on
+	# is FLAT_TOP_LEVEL cells up. A picker fallback plane at y=0 would be the slab's BOTTOM and
+	# would resolve the wrong column at grazing angles.
+	var cell := BoardSpace.of_cell(Vector2i(4, 7), 0)
 	assert_that(BoardSpace.standing_point(cell).y) \
 		.override_failure_message("the flat standing face moved off FLAT_TOP_LEVEL") \
 		.is_equal(BoardSpace.FLAT_TOP_LEVEL * BoardSpace.CELL_SIZE)
-	# The derivation, not a second literal: UnitMirror must not drift from the constant.
-	assert_float(UnitMirror.COLUMN_TOP).is_equal(BoardSpace.FLAT_TOP_LEVEL * BoardSpace.CELL_SIZE)
+	# The two spellings of that face must agree (#273): surface_y is what the mirrors read, and
+	# FLAT_TOP_LEVEL is what the picker's fallback plane reads. Drift here puts units and the
+	# pointer on different faces.
+	assert_float(BoardSpace.surface_y(0)).is_equal(BoardSpace.FLAT_TOP_LEVEL * BoardSpace.CELL_SIZE)
+
+
+func test_a_surface_sits_on_top_of_its_own_level() -> void:
+	# A level-E block occupies [E .. E+1], so E's surface is E+1 — the arithmetic every column,
+	# unit and overlay in the 3D stack is built on.
+	assert_float(BoardSpace.surface_y(2)).is_equal(3.0 * BoardSpace.CELL_SIZE)
+	assert_float(BoardSpace.surface_y(-1)).is_equal(0.0)   # a dip's floor, not a hole
+	assert_float(BoardSpace.standing_point(BoardSpace.of_cell(Vector2i(1, 1), 3)).y) \
+		.is_equal(BoardSpace.surface_y(3))
+
+
+func test_a_ramp_stands_things_half_a_level_up_its_slope() -> void:
+	# The one place presentation and rules deliberately disagree: the RULES call a ramp its low
+	# side, and verticality.md rules the visual midpoint presentational. Anything standing on one
+	# rides the slope rather than sinking into its low edge.
+	var heights := BoardHeights.new()
+	heights.set_cell(Vector2i(2, 2), 1, Terrain.RampRise.NONE)
+	heights.set_cell(Vector2i(3, 2), 1, Terrain.RampRise.EAST)
+
+	assert_float(BoardSpace.surface_point(Vector2i(2, 2), heights).y).is_equal(BoardSpace.surface_y(1))
+	assert_float(BoardSpace.surface_point(Vector2i(3, 2), heights).y) \
+		.is_equal(BoardSpace.surface_y(1) + BoardSpace.CELL_SIZE * 0.5)
+
+
+func test_a_board_with_no_heights_wired_reads_as_flat() -> void:
+	# The headless Play boards never set one, and every anchor still has to resolve.
+	assert_float(BoardSpace.surface_point(Vector2i(4, 4), null).y).is_equal(BoardSpace.surface_y(0))

--- a/tests/presentation/test_camera_follow.gd
+++ b/tests/presentation/test_camera_follow.gd
@@ -92,7 +92,7 @@ func test_hovering_does_not_drag_the_3d_camera() -> void:
 	var before := _rig.position
 	var cell: Vector2i = unit.movement.cell
 	var motion := InputEventMouseMotion.new()
-	var screen := _camera3d.unproject_position(BoardSpace.standing_point(BoardSpace.of_flat(cell)))
+	var screen := _camera3d.unproject_position(BoardSpace.standing_point(BoardSpace.of_cell(cell, 0)))
 	motion.position = screen
 	motion.global_position = screen
 	Input.parse_input_event(motion)
@@ -100,7 +100,7 @@ func test_hovering_does_not_drag_the_3d_camera() -> void:
 	await _settle()
 
 	# The 2D camera DID move (non-vacuous: the snap is what the hover card rides on)...
-	assert_that(_scene._pointer_cell).is_equal(BoardSpace.of_flat(cell))
+	assert_that(_scene._pointer_cell).is_equal(BoardSpace.of_cell(cell, 0))
 	# ...and the 3D did not.
 	assert_that(_rig.position).override_failure_message(
 			"a hover dragged the 3D camera — the mirror is not gated on ai_locked").is_equal(before)
@@ -137,7 +137,7 @@ func test_a_menu_leaves_the_pointer_alone() -> void:
 	_game.game_state = _game.GameState.MENU
 	var unit := _player_unit()
 	var screen := _camera3d.unproject_position(
-			BoardSpace.standing_point(BoardSpace.of_flat(unit.movement.cell)))
+			BoardSpace.standing_point(BoardSpace.of_cell(unit.movement.cell, 0)))
 	var motion := InputEventMouseMotion.new()
 	motion.position = screen
 	motion.global_position = screen
@@ -168,7 +168,7 @@ func test_both_authored_missions_open_on_the_players_own_squad() -> void:
 			seen += 1
 			lo = lo.min(Vector2(unit.movement.cell))
 			hi = hi.max(Vector2(unit.movement.cell))
-			var point := BoardSpace.standing_point(BoardSpace.of_flat(unit.movement.cell))
+			var point := BoardSpace.standing_point(BoardSpace.of_cell(unit.movement.cell, 0))
 			assert_bool(_camera3d.is_position_in_frustum(point)).override_failure_message(
 					"%s: player unit at %s is off-camera at load" % [path, unit.movement.cell]).is_true()
 		assert_int(seen).override_failure_message(
@@ -218,7 +218,7 @@ func test_zooming_fully_out_still_shows_the_whole_board() -> void:
 			rect.position + rect.size - Vector2i.ONE,
 		]
 		for corner in corners:
-			var point := BoardSpace.standing_point(BoardSpace.of_flat(corner))
+			var point := BoardSpace.standing_point(BoardSpace.of_cell(corner, 0))
 			assert_bool(_camera3d.is_position_in_frustum(point)).override_failure_message(
 					"%s: board corner %s is off-camera even zoomed fully out" % [path, corner]).is_true()
 
@@ -254,7 +254,7 @@ func test_space_recentres_the_diorama_on_the_pointer() -> void:
 	var unit := _player_unit()
 	var cell: Vector2i = unit.movement.cell
 	_scene._update_pointer(_camera3d.unproject_position(
-			BoardSpace.standing_point(BoardSpace.of_flat(cell))))
+			BoardSpace.standing_point(BoardSpace.of_cell(cell, 0))))
 	_rig.position = Vector3(_rig.position.x + 12.0, _rig.position.y, _rig.position.z + 12.0)
 	var before := _rig.position
 

--- a/tests/presentation/test_input_bridge.gd
+++ b/tests/presentation/test_input_bridge.gd
@@ -80,7 +80,7 @@ func _under_ui(screen_pos: Vector2) -> bool:
 
 
 func _screen_of(cell: Vector2i) -> Vector2:
-	return _camera3d.unproject_position(BoardSpace.standing_point(BoardSpace.of_flat(cell)))
+	return _camera3d.unproject_position(BoardSpace.standing_point(BoardSpace.of_cell(cell, 0)))
 
 
 func _parse_motion(screen_pos: Vector2) -> void:
@@ -284,7 +284,7 @@ func test_hover_reaches_cells_the_hidden_camera_cannot_see() -> void:
 
 	assert_that(_game.hover_presenter.last_hovered_cell).is_equal(far)
 	assert_bool(seen.has(far)).is_true()
-	assert_that(_overlays.cells_of(BoardOverlays.Layer.HOVER)).is_equal([BoardSpace.of_flat(far)])
+	assert_that(_overlays.cells_of(BoardOverlays.Layer.HOVER)).is_equal([BoardSpace.of_cell(far, 0)])
 
 
 # --- Camera ownership (#176 stage 4d) ---------------------------------------------------
@@ -343,7 +343,7 @@ func test_a_board_swap_rebuilds_the_mirror_through_the_load_funnel() -> void:
 	mirrored.sort()
 	var expected: Array[Vector3i] = []
 	for cell: Vector2i in _game.grid.get_used_cells():
-		expected.append(BoardSpace.of_flat(cell))
+		expected.append(BoardSpace.of_cell(cell, 0))
 	expected.sort()
 	assert_that(mirrored).is_equal(expected)   # the 3D board IS the new 2D board
 	assert_that(_scene._tops).is_equal(BoardPicker.column_tops_from(board))


### PR DESCRIPTION
Closes #273. **Feel-checked and confirmed working by the dev on the real board** (2026-08-15) — terraces read as terraces, ramps connect their two levels, units stand on top rather than sinking in.

`BoardMirror` shipped on a stated promise — *"the diorama's hills arrive when the rules do."* They arrived in #257 and became authorable in #260. This is that sentence coming due, and it went first because #258 (reach) and #259 (falls) are rules whose payoff is spatial: building them on a board that renders flat ships two slices nobody can judge.

## Try it

F1 → Tile Brush → Paint: **Elevation** → tick the brush → F4 to paint (the readout lights itself) → **F4 back to 3D**.

## The geometry, which is the whole ticket

A level-E block occupies `[E .. E+1]`, so **E's surface is E+1**. Everything follows:

- **A cell writes its whole column** — the surface block repeated down to a shared floor (`min(0, lowest painted level)`, so a dip has a bottom rather than a hole). Painting a *different* tile under a tile is your follow-up, scoped out.
- **A ramp's wedge sits one level ABOVE its own**, because a ramp whose elevation is its LOW side must slope from E+1 to E+2. This is the off-by-one that is invisible on a flat board — hence its own falsified case.
- **Orientation is derived from `Terrain.rise_direction`**, the vocabulary the rules already use, not a hand-written table of orthogonal indices that could drift from the mesh.

## Two things the plan got wrong, corrected in the build

- **`stand_at` is the walk demo's hook, not the live board's.** `UnitMirror._sync`'s constant `COLUMN_TOP` was what actually had to learn about height. Flagged before editing rather than narrated after.
- **The picker needed no change at all.** `BoardPicker.column_tops_from` derives from the GridMap, and `_refresh_tops()` already ran after every sync — that plan line was work that didn't exist.

`BoardSpace.of_flat(cell)` → **`of_cell(cell, level)`**: a replacement, not an alias, because a *required* argument makes the old flat assumption unrepresentable rather than merely discouraged. `FLAT_TOP_LEVEL` survives — it was never the flat assumption, it is "a ground-level column is one cell tall", which is still true and is what the picker's fallback plane reads.

`BoardSpace.surface_point` is the one answer to "where does a thing stand" for units, flames and props alike, and it carries the single place presentation and rules deliberately disagree: a ramp's visual midpoint, which `verticality.md` rules presentational.

Heights are **passed** into `BoardMirror.sync` (it already takes the grid that way) and **polled** by `OverlayMirror` (which already polls the game for everything it draws) — different mechanisms because they are different shapes of caller, not drift.

## Verification

`tests/presentation` 172/172 before the new cases, `test_board_mirror.gd` 29/29 after — exit 0 both times. Four new cases, all driving `game.board_heights` and never calling `sync()` themselves.

**Falsified** on the one that could be blind: a wedge placed at `E` instead of `E+1` reddens the wedge-height case and nothing else.

## Found in the feel-check, filed not fixed

[#281](https://github.com/Phaazoid/Godoiosis/issues/281) — path arrows don't climb ramps; they stay at one level across a slope. The dev's own call to keep it out of this diff. Worth reading with #227.

Label: `type/feature`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
