### PR TITLE
Board-swap case asks the column seam instead of re-deriving it

### DIFF
--- a/tests/presentation/test_input_bridge.gd
+++ b/tests/presentation/test_input_bridge.gd
@@ -400,18 +400,16 @@ func test_a_board_swap_rebuilds_the_mirror_through_the_load_funnel() -> void:
 	await await_idle_frame()   # the swap's clear_board queue_frees the old roster
 	await await_idle_frame()
 	var board: GridMap = _scene.get_node("Board")
-	# COLUMNS, not cells. This case asks whether the mirror is aimed at the NEW board; how tall
-	# each column is belongs to test_board_mirror. It compared raw cells against every cell at
-	# level 0 until 2026-08-15, which silently depended on Level_1 being FLAT -- painting
-	# elevation into it (b057f6e) turned #273's correct multi-cell columns into a red case.
+	# Compared as FOOTPRINTS — the set of columns, never their heights. The claim here is "the
+	# rebuild ran", and a cell-for-cell compare answered it by hand-listing what the mission happens
+	# to be painted to, so a height-brush stroke reddened a case about the load funnel (it did:
+	# b057f6e). What a column CONTAINS is BoardMirror's business, pinned by test_board_mirror's #273
+	# cases against game.board_heights. column_tops_from is keyed by column, so its keys are the
+	# footprint — the production seam already answers this, and the next assert uses the same call.
 	var mirrored: Array[Vector2i] = []
-	for cell: Vector3i in board.get_used_cells():
-		var column := BoardSpace.flat(cell)
-		if not mirrored.has(column):
-			mirrored.append(column)
+	mirrored.assign(BoardPicker.column_tops_from(board).keys())
 	mirrored.sort()
-	var expected: Array[Vector2i] = []
-	expected.assign(_game.grid.get_used_cells())
+	var expected: Array[Vector2i] = _game.grid.get_used_cells()
 	expected.sort()
 	assert_that(mirrored).is_equal(expected)   # the 3D board IS the new 2D board
 	assert_that(_scene._tops).is_equal(BoardPicker.column_tops_from(board))


### PR DESCRIPTION
Tiny cleanup, no behaviour change. #288 got fixed **twice in parallel** — [#290](https://github.com/Phaazoid/Godoiosis/pull/290) and [#289](https://github.com/Phaazoid/Godoiosis/pull/289)'s first commit — and the merge kept the weaker of the two.

Both compare column **footprints**. #290 got there by asking the production seam; the version that survived hand-rolls a dedup loop:

```gdscript
mirrored.assign(BoardPicker.column_tops_from(board).keys())   # #290, restored here
```
```gdscript
for cell: Vector3i in board.get_used_cells():                 # what survived the merge
    var column := BoardSpace.flat(cell)
    if not mirrored.has(column):
        mirrored.append(column)
```

`column_tops_from` is keyed by column, so its keys **are** the footprint — and the assert three lines below already calls it. The loop is a second spelling of a seam that is right there.

It is also exactly what the **content razor** #290 added to `CLAUDE.md` rules out, which names this call explicitly:

> Derive every expectation from the seam under test (`BoardPicker.column_tops_from` = the footprint, …)

So this restores #290's version verbatim, comment and all. Mine was written before that rule existed; theirs is the one the canon now points at.

**Verified:** `tests/presentation/test_input_bridge.gd` 27/27.

---

## Unrelated find, NOT fixed here — `column_tops_from` cannot represent a dip

While checking the swap was equivalent I hit an edge worth its own look. `_top_level` returns **0 to mean "nothing in this column"**, so 0 is overloaded as the miss sentinel — and the adapter inherits it:

```gdscript
var top := cell.y + 1
var existing: int = tops.get(column, 0)
if top > existing:
    tops[column] = top
```

A column whose highest cell sits at `y = -1` computes `top = 0`, fails `0 > 0`, and **never enters the table**. That is reachable: #260 made negative elevation deliberate (*"if I want a dip, without allowing negatives I'd have to shift everything up"*), and `_write_column` drops `floor_level` to `min(0, lowest)`, so a dipped cell writes only `y = -1` while its flat neighbours write `-1` and `0` and stay fine.

Expected consequence — **reasoned from the code, not probed**: a one-deep dip is missing from the picker's table, so a click there falls through to the plane fallback and resolves at `FLAT_TOP_LEVEL` instead of its real level. `max_top` starts at 0 with the same `>` too.

`tests/presentation/test_board_picker.gd` has **no negative-level case at all**, so nothing would have caught it. The fix is not the comparison — it is separating the "no column here" sentinel from a legitimate top of 0, which is a production change and wants its own ticket rather than riding a test cleanup. Happy to file it.

Label: `type/debt`.
