### PR TITLE
Skip CI on docs-only pushes [skip ci]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,20 @@
 name: Tests
 
+# A DOCS-ONLY change skips the suite entirely (2026-08-15). Safe because NOTHING in the
+# suite reads a tracked .md: every .md mention under tests/ and Classes/ is a comment
+# pointing at canon, and the only real read is report.md, which BugReporter GENERATES at
+# runtime under user://. Verified before this filter went in -- recheck it before widening
+# the list. GitHub matches paths-ignore against the WHOLE PR diff, so a PR touching docs
+# AND code still runs; only an all-docs change is skipped. If a docs lint ever lands (a
+# canon-marker check, a link checker), it needs its OWN workflow with the inverse filter
+# (paths: ['docs/**']) -- this one would skip exactly the change it exists to catch.
 on:
   push:
     branches: [main]
+    paths-ignore: ['docs/**', '**.md']
   pull_request:
     branches: [main]
+    paths-ignore: ['docs/**', '**.md']
 
 jobs:
   test:


### PR DESCRIPTION
## What

`paths-ignore: ['docs/**', '**.md']` on both triggers of the Tests workflow. A push or PR whose changed files are *all* markdown no longer spends a full-tree run.

Dev ask, 2026-08-15: *"sometimes we push updates that are only docs, and we still have to run the full CI on them."*

## Why it is safe here

Three things were checked before the filter went in, not assumed:

1. **Nothing in the suite reads a tracked `.md`.** Every `.md` mention under `tests/` and `Classes/` is a comment pointing at canon. The only real read is `report.md`, which `BugReporter` *generates* at runtime under `user://`. So "docs-only implies the suite cannot break" is actually true, not merely probable.
2. **`main` has no branch protection and no rulesets** (`gh api .../protection` returns 404, `.../rulesets` returns `[]`). "Tests" is therefore not a required status check. This is the usual trap with this change - a skipped workflow never reports, so a required check sits pending forever and you have to fake a green job - and it does not apply.
3. **Version bump is untouched.** `version-bump.yml` fires on `pull_request: closed`, a different event with no path filter, so a docs PR still takes its patch bump on merge. That matches the standing rule that docs are semver-equivalent to a bugfix.

A PR touching docs **and** code still runs the full suite: GitHub matches `paths-ignore` against the whole PR diff, not per commit.

## The one caveat, recorded in the workflow itself

If a docs lint ever lands (a canon-marker staleness check, a link checker), it needs its **own** workflow with the inverse filter (`paths: ['docs/**']`). This one would skip exactly the change such a lint exists to catch.

## About this PR's own CI

This diff is a workflow file, not docs, so `paths-ignore` would **not** have caught it. The commit carries `[skip ci]` instead - GitHub's native per-commit escape hatch, the second mechanism. The title carries it too, so the default merge-commit message inherits it and the push to `main` skips as well.

Consequence worth knowing: **nothing verifies this workflow until the next real run.** A YAML error would surface as a workflow parse failure on GitHub rather than silently, but if you would rather buy the belt-and-braces, drop `[skip ci]` from the merge title and let it run once.

## How to actually test the feature

PR #297 (`docs/240-report-canon`) is docs-only and open. For `pull_request` events GitHub reads the workflow from the **base** branch, so once this lands, pushing any commit to that branch should produce **no** Tests run.
