### PR TITLE
Pin that path arrows climb ramps -- they already did (#281)

### DIFF
--- a/tests/presentation/test_overlay_mirror.gd
+++ b/tests/presentation/test_overlay_mirror.gd
@@ -218,6 +218,88 @@ func test_hover_path_preview_mirrors_while_sweeping() -> void:
 			first.global_position.x / 16.0, 1.0, first.global_position.y / 16.0))
 
 
+# --- Path arrows over elevation (#281) ---------------------------------------------
+
+# The RENDERED heights, straight off the layer's own node pool — the quads that actually draw,
+# not the entry dictionaries feeding them. Only the visible ones: the pool is retained and
+# extras from a longer previous path are hidden rather than freed.
+func _arrow_heights() -> Array[float]:
+	var ys: Array[float] = []
+	for node: Node3D in _overlays._markers.get(BoardOverlays.Layer.PATH_ARROWS, []):
+		if node.visible:
+			ys.append(node.position.y)
+	return ys
+
+
+# #281's claim, pinned on the real trigger. Board: flat at (2,2), a ramp at (3,2) whose LOW side
+# is level 0, a level-1 terrace at (4,2)/(5,2). Every expectation is hand-derived from the board's
+# own geometry — a block is one cell tall, so one level of climb is exactly 1.0 world unit, and a
+# ramp's surface is half a level between its two platforms. Differences, never absolutes, so the
+# marker lift (a tuning knob) cancels out instead of being pinned here.
+func test_path_arrows_climb_a_ramp_onto_a_terrace() -> void:
+	var heights: BoardHeights = game.board_heights
+	heights.set_cell(Vector2i(3, 2), 0, Terrain.RampRise.EAST)
+	heights.set_cell(Vector2i(4, 2), 1)
+	heights.set_cell(Vector2i(5, 2), 1)
+	_scene.rebuild()
+	var standing := _spawn(PLAYER, Vector2i(5, 2))   # the independent height reference
+	var walker := _spawn(PLAYER, Vector2i(2, 2), {Stats.Stat.DEX: 40})
+	game.enter_move_mode(walker)
+	game.selected_unit = walker
+	game.hover_presenter._hover_choosing_move(Vector2i(4, 2))
+	await _settle()
+	var preview: MoveAction = _om().hover_move_preview
+	assert_object(preview).is_not_null()
+	# The case proves nothing if the path never crossed the ramp — the rules refuse a climb that
+	# does not run up a ramp's own slope, so a mis-authored fixture would silently route around.
+	assert_that(preview.get_move_path()).override_failure_message(
+			"the fixture path never climbed — nothing about elevation was exercised") \
+		.is_equal([Vector2i(2, 2), Vector2i(3, 2), Vector2i(4, 2)] as Array[Vector2i])
+
+	var ys := _arrow_heights()
+	assert_int(ys.size()).is_equal(3)
+	assert_float(ys[2] - ys[0]).override_failure_message(
+			"the arrow on the terrace is not one level above the arrow on the flat") \
+		.is_equal_approx(1.0, 0.0001)
+	assert_bool(ys[0] < ys[1] and ys[1] < ys[2]).override_failure_message(
+			"the ramp's arrow does not sit between its two platforms") .is_true()
+	# Cross-checked against a SECOND placement path: UnitMirror._sync puts a standing unit on the
+	# terrace by its own arithmetic. The arrow over the neighbouring terrace cell must land there
+	# too, within the markup's ground clearance — well under a level, so a level-sized error fails.
+	var stand_y: float = _unit_mirror.sprite_for(standing).position.y
+	assert_float(absf(ys[2] - stand_y)).override_failure_message(
+			"the terrace arrow and a unit standing on the terrace disagree about the surface") \
+		.is_less(0.2)
+
+
+# The ordering half: heights change AFTER the arrows are on screen, which is exactly what painting
+# elevation in the 3D view does with a path preview up. The 2D sprites do not move, so the anchor
+# has to be re-resolved from the live heights every frame — a marker cache keyed on anything but
+# the resolved position would sit stale here and this case is the only thing that would notice.
+func test_an_arrow_re_anchors_when_the_ground_under_it_rises() -> void:
+	var walker := _spawn(PLAYER, Vector2i(2, 2), {Stats.Stat.DEX: 40})
+	game.enter_move_mode(walker)
+	game.selected_unit = walker
+	game.hover_presenter._hover_choosing_move(Vector2i(5, 2))
+	await _settle()
+	var before := _arrow_heights()
+	assert_int(before.size()).is_equal(4)
+	assert_float(before[2] - before[0]).is_equal_approx(0.0, 0.0001)   # a flat board, flat arrows
+
+	game.board_heights.set_cell(Vector2i(4, 2), 1)   # the dev brush's own writer
+	_scene.rebuild()
+	await _settle()
+	assert_object(_om().hover_move_preview).override_failure_message(
+			"the 2D preview was rebuilt, so nothing about re-anchoring was tested").is_not_null()
+	var after := _arrow_heights()
+	assert_int(after.size()).is_equal(4)
+	assert_float(after[2] - before[2]).override_failure_message(
+			"the arrow over the raised cell stayed at the old level") .is_equal_approx(1.0, 0.0001)
+	assert_float(after[0] - before[0]).override_failure_message(
+			"an arrow off the raised cell moved with it") .is_equal_approx(0.0, 0.0001)
+	assert_float(after[3] - before[3]).is_equal_approx(0.0, 0.0001)
+
+
 func test_knockback_preview_mirrors_trail_and_landing_ghost() -> void:
 	var foe := _spawn(ENEMY, Vector2i(3, 2))
 	var shoves: Array = [{"target": foe, "from": Vector2i(3, 2), "to": Vector2i(5, 2)}]


### PR DESCRIPTION
Closes nothing yet — **[#281](https://github.com/Phaazoid/Godoiosis/issues/281) goes back to you with a decision to make.** Read this instead of the diff; the diff is two test cases.

## The short version

**The bug you reported does not exist in the code the issue accused.** Path arrows already climb, per cell, and have since #273. What is actually wrong on a slope is a different thing, and fixing it is the option you told me not to build. So this PR ships the guard the issue asked for, and hands the design call back.

## What I measured

Driven through the real triggers on the real `Battle3D` scene: a flat cell at (2,2), a ramp at (3,2) whose low side is level 0, a level-1 terrace at (4,2). Enter move mode, hover the destination, read the heights off the quads that actually draw.

| cell | what it is | arrow height |
|---|---|---|
| (2,2) | flat ground | **1.0** |
| (3,2) | ramp, low side level 0 | **1.5** |
| (4,2) | terrace, level 1 | **2.0** |

The terrace arrow lands at 2.0. A unit *standing* on that terrace — placed by `UnitMirror._sync`, a completely separate piece of arithmetic — also lands at 2.0. They agree. The arrows are on the surface.

## Why the issue's two guesses were both wrong

- *"the arrows are anchored once for the run rather than per sprite"* — `OverlayMirror._arrows` calls `_anchor_px(sprite.global_position)` inside the loop, once per sprite, every frame.
- *"the pixel→cell resolution is landing on the wrong cell"* — arrow sprites are created at `GridUtils.cell_world(board_tilemap, cell)`, which is the cell **centre**: cell (2,2) sits at pixel (40,40), and `floor(40/16) = 2`. Dead centre, no half-cell offset, and `ArrowIconOverlay` has no transform of its own. Every arrow resolves to its own cell.

I also checked the two things you'd suspect next, and both are fine: the 3D side does consume the marker's Y (`BoardOverlays._apply_marker` sets `quad.position = pos + lift`), and there is no cache in the arrow path that can go stale on a height change — I fired that exact sequence and the arrow moved. See the second test case.

## So what did you actually see?

Two candidates, and I can't tell them apart from headless. **Both are worth acting on.**

### 1. On a ramp cell the arrow is a flat quad cutting through the wedge

This is the one that matches your words most literally — *"don't slope up slopes, they stay flat"*.

A ramp cell's surface climbs a **full world unit** across that one cell (the wedge occupies `[level+1 .. level+2]`). The arrow is a horizontal 1×1 quad at the midpoint. So the downhill half of every ramp arrow floats above the slope and the **uphill half is inside solid geometry**. On the one cell where the path visibly climbs, you see half an arrow.

That is not something option (a) can fix — "flat at the cell's own surface" has no good answer when the cell's surface is a ramp. It needs **(b) the tilt** (which makes the burial vanish exactly, at zero clearance cost) or **(c) a clearance of at least half a level**, which floats every arrow on flat ground too and is therefore a look call that belongs with [#227](https://github.com/Phaazoid/Godoiosis/issues/227)'s arrow-lift knob.

**Your call, and I did not pick it.** My read: (b) is the geometrically correct answer and the only one that costs nothing elsewhere.

### 2. Nothing on `Level_1` can be climbed, so no arrow you could have drawn was ever on a slope

This one is concrete and I'd fix it first, because until it's fixed you cannot feel-check any of the above.

`Level_1`'s plateau is five cells at (25..27, 9..11). All five are painted at **elevation 1**, and the four ramps rise **outward**:

| cell | position vs the plateau centre | painted rise |
|---|---|---|
| (25,10) | west of it | WEST |
| (26,9) | north of it | NORTH |
| (26,11) | south of it | SOUTH |
| (27,10) | east of it | EAST |

All four are exactly inverted. `RampRise` is **which way the ramp climbs**, not which side of the hill it sits on — and a ramp's own elevation is its **low** side, so these should be elevation 0 rising *inward*. As painted, `can_step((24,10) → (25,10))` is **false** and the plateau is not in the move range at all. Same story for the (27,13)–(27,15) staircase.

Measured, not inferred: I loaded the real mission and asked the rules.

So on the board you were looking at, every path routed around the hill on flat ground — which reads exactly like "the arrows don't climb". If you want that hill walkable, flip the four rises inward and drop them to elevation 0. And the naming trap is worth its own ticket: the brush asks for a "rise" and the natural mental model is "which side is this ramp on".

## Found in passing, not fixed here

**The FILL layers and the MARKER layers disagree about where a ramp's surface is.** `OverlayMirror._fill` goes through `of_cell(cell, elevation_at(cell))`, which is the ramp's *low* edge; `_anchor` / `_anchor_px` go through `surface_point`, which adds the ramp's half level. So on a ramp cell the yellow move-range tile sits at the **base of the wedge** and is buried under it, while the arrow on the same cell sits half a level higher. Two spellings of one question (Law #1), and it means move range is invisible on exactly the cells that matter. It needs `BoardOverlays.set_cells` to carry a non-integer height, so it is its own ticket — and it runs into the same (a)/(b)/(c) fork, since a flat fill on a slope has the same problem the arrow does.

## What's in the diff

Two cases in `tests/presentation/test_overlay_mirror.gd`, no production change.

- **`test_path_arrows_climb_a_ramp_onto_a_terrace`** — the issue's own "Done when", pinned. Asserts the climb as a **difference** (terrace minus flat is exactly one level), so `fill_lift`/`lift_step` cancel and no tuning value is pinned. Reads the heights off the layer's **rendered node pool**, not the entry dictionaries feeding it. Cross-checks the terrace arrow against a unit standing on that terrace — a second, independent placement path. Also asserts the fixture path really crossed the ramp, so a mis-authored board can't make the case vacuous.
- **`test_an_arrow_re_anchors_when_the_ground_under_it_rises`** — the ordering case nothing covered. Draw the path on flat ground, *then* raise a cell under it (through `board_heights.set_cell`, the dev brush's own writer), and assert that arrow rose exactly one level while its neighbours did not. Asserts the 2D preview was not rebuilt, so a passing run can't be a rebuild in disguise.

## Falsification

Mutated `_arrows` to anchor every arrow at `surface_y(0)` — the mutant the issue named.

- `test_path_arrows_climb_a_ramp_onto_a_terrace` → **RED**, on all three of its claims.
- The run **truncated the file at that failure**, so the second case never executed. Re-ran the mutant with the first case parked: `test_an_arrow_re_anchors_when_the_ground_under_it_rises` → **RED** on its own aimed assertion. Both have teeth independently.
- Mutant reverted; `git status` confirms `Classes/` is untouched by this branch.

`tests/presentation` 194/194, exit 0.

## What the suite cannot see

Everything in the "so what did you actually see" section. Headless proves *where the quads are*; it cannot show you a quad half-swallowed by a wedge, or tell me whether a three-step staircase of flat arrows reads as charming or as broken at your camera distance. That half is yours, and it needs a board with a climbable slope on it first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
