### PR TITLE
Board markup lies flat against slopes (#281)

### DIFF
--- a/Classes/presentation/BoardOverlays.gd
+++ b/Classes/presentation/BoardOverlays.gd
@@ -104,7 +104,11 @@ func _ready() -> void:
 # Replaces the layer's cells wholesale (idempotent — calling twice with the same
 # set changes nothing; extras from a previous, larger set are hidden, not leaked).
 # FILL/BRACKET layers only — variant layers go through set_markers.
-func set_cells(layer: Layer, cells: Array[Vector3i]) -> void:
+#
+# `heights` is what lets a fill LIE ON a ramp rather than hang level through it (#281). Taken as a
+# parameter rather than held, the way BoardMirror.sync takes it: null reads as flat, which is what
+# the headless Play boards and the pooled-clear path both want.
+func set_cells(layer: Layer, cells: Array[Vector3i], heights: BoardHeights = null) -> void:
 	var spec: Dictionary = LAYERS[layer]
 	if spec["kind"] != Kind.FILL and spec["kind"] != Kind.BRACKET:
 		push_error("set_cells on a %s layer — use set_markers" % Kind.keys()[spec["kind"]])
@@ -117,13 +121,14 @@ func set_cells(layer: Layer, cells: Array[Vector3i]) -> void:
 		var marker := pool[i] as Node3D
 		if i < cells.size():
 			marker.visible = true
-			marker.position = _marker_position(spec, cells[i])
+			marker.transform = _marker_transform(spec, cells[i], heights)
 		else:
 			marker.visible = false
 
 
 # Replaces a variant layer wholesale: one entry per marker, {"pos": Vector3 (the
-# cell's top-face anchor), "texture": Texture2D, "modulate": Color}. Same
+# cell's top-face anchor), "texture": Texture2D, "modulate": Color, "basis": Basis
+# (optional — how the surface under it is tilted, identity on flat ground)}. Same
 # idempotent-pool contract as set_cells. SPRITE/BILLBOARD layers only.
 func set_markers(layer: Layer, markers: Array[Dictionary]) -> void:
 	var spec: Dictionary = LAYERS[layer]
@@ -215,10 +220,16 @@ func _pool_for(layer: Layer) -> Array:
 	return _markers[layer]
 
 
-func _marker_position(spec: Dictionary, cell: Vector3i) -> Vector3:
+# A BRACKET marks a cell VOLUME, so it keeps the centre and stays axis-aligned; a FILL is ground
+# markup and rides the surface, tilt included (#281). The clearance is applied along the surface's
+# OWN normal, so stacked coplanar layers stay parallel to what they sit on rather than shearing
+# apart on a slope.
+func _marker_transform(spec: Dictionary, cell: Vector3i, heights: BoardHeights) -> Transform3D:
 	if spec["kind"] == Kind.BRACKET:
-		return BoardSpace.cell_center(cell)
-	return BoardSpace.standing_point(cell) + Vector3(0.0, _lift_of(spec), 0.0)
+		return Transform3D(Basis.IDENTITY, BoardSpace.cell_center(cell))
+	var rise := Terrain.RampRise.NONE if heights == null else heights.ramp_rise_at(BoardSpace.flat(cell))
+	var surface := BoardSpace.lie_on(cell, rise)
+	return Transform3D(surface.basis, surface.origin + surface.basis.y * _lift_of(spec))
 
 
 # Per-sort spacing keeps coplanar stacked fills apart; render_priority (set at
@@ -237,14 +248,20 @@ func _apply_marker(spec: Dictionary, node: Node3D, marker: Dictionary) -> void:
 		sprite.texture = texture
 		sprite.modulate = tint
 		return
+	# Orientation and art scale are ONE write: a basis carries scale, so assigning them separately
+	# would have whichever came second wipe the other. Both are set unconditionally because the
+	# marker nodes are POOLED — a quad that was on a ramp and is now on flat ground, or that had art
+	# and now has none, would otherwise keep the tilt and the size of whatever it drew last.
 	var quad := node as MeshInstance3D
-	quad.position = pos + Vector3(0.0, _lift_of(spec), 0.0)
+	var tilt: Basis = marker.get("basis", Basis.IDENTITY)
+	var art := Vector3.ONE
+	if texture != null:
+		var size: Vector2 = texture.get_size() / ART_PIXELS_PER_CELL
+		art = Vector3(size.x, 1.0, size.y)
+	quad.transform = Transform3D(tilt * Basis.from_scale(art), pos + tilt.y * _lift_of(spec))
 	var material := quad.material_override as StandardMaterial3D
 	material.albedo_texture = texture
 	material.albedo_color = tint
-	if texture != null:
-		var art: Vector2 = texture.get_size() / ART_PIXELS_PER_CELL
-		quad.scale = Vector3(art.x, 1.0, art.y)
 
 
 func _make_marker(layer: Layer) -> Node3D:

--- a/Classes/presentation/BoardSpace.gd
+++ b/Classes/presentation/BoardSpace.gd
@@ -45,12 +45,53 @@ static func surface_y(level: int) -> float:
 # level. That is the one place presentation and rules deliberately disagree, and it is why
 # UnitSprite3D.stand_at was made injectable in the first place.
 static func surface_point(cell: Vector2i, heights: BoardHeights) -> Vector3:
+	return surface_transform(cell, heights).origin
+
+
+# One level of rise per cell of run — the authored wedge's own profile (its slope face runs corner
+# to corner, normal (0,1,1)), and the same ratio surface_point's half-level lift already encodes.
+const RAMP_SLOPE_ANGLE := atan2(CELL_SIZE, CELL_SIZE)
+
+# A slope is LONGER than the cell it spans (1/cos of the angle), so markup that only rotated would
+# cover the cell's footprint and leave the ramp face bare at both edges. Stretching along the slope
+# is what keeps a fill covering its whole cell and an arrow foreshortening exactly as the ground
+# under it does.
+const SLOPE_STRETCH := 1.0 / cos(RAMP_SLOPE_ANGLE)
+
+
+# How a FLAT thing LIES on this cell's surface (#281) — a path arrow, an overlay fill, any markup
+# that is part of the ground rather than standing on it. The origin half is surface_point's, so the
+# two cannot drift; the basis half is what makes markup follow a slope instead of hanging level
+# through it. Anything that STANDS stays upright and keeps reading surface_point (units, flames,
+# props).
+static func surface_transform(cell: Vector2i, heights: BoardHeights) -> Transform3D:
 	if heights == null:
-		return standing_point(of_cell(cell, 0))
-	var point := standing_point(of_cell(cell, heights.elevation_at(cell)))
-	if heights.is_ramp(cell):
-		point.y += CELL_SIZE * 0.5
-	return point
+		return lie_on(of_cell(cell, 0), Terrain.RampRise.NONE)
+	return lie_on(of_cell(cell, heights.elevation_at(cell)), heights.ramp_rise_at(cell))
+
+
+# The lie itself, for a caller that already resolved the level — the overlay fills, whose Vector3i
+# states it (of_cell's "every caller states the LEVEL it means" rule, #273; re-deriving it here
+# would look up what was already passed).
+#
+# The tilt is DERIVED from Terrain.rise_direction — the same call BoardMirror._ramp_orientation
+# yaws the wedge by — so the ground and the markup on it cannot disagree about which way it climbs.
+static func lie_on(cell: Vector3i, rise: Terrain.RampRise) -> Transform3D:
+	var origin := standing_point(cell)
+	if rise == Terrain.RampRise.NONE:
+		return Transform3D(Basis.IDENTITY, origin)
+	# The midpoint of the slope, which is exactly where a quad tilted about its own centre lies flat.
+	origin.y += CELL_SIZE * 0.5
+	var dir := Terrain.rise_direction(rise)
+	var uphill := Vector3(dir.x, 0.0, dir.y)
+	var basis := Basis(uphill.cross(Vector3.UP).normalized(), RAMP_SLOPE_ANGLE)
+	# Stretch the ONE local axis that ends up running up the slope, so the art keeps its orientation
+	# (a rotated arrow would point somewhere else) and only its length along the slope changes.
+	if dir.x != 0:
+		basis.x *= SLOPE_STRETCH
+	else:
+		basis.z *= SLOPE_STRETCH
+	return Transform3D(basis, origin)
 
 
 # The cell containing a world position (floor per axis — see the boundary rule above).

--- a/Classes/presentation/OverlayMirror.gd
+++ b/Classes/presentation/OverlayMirror.gd
@@ -133,7 +133,7 @@ func _fill(layer: BoardOverlays.Layer, used: Array[Vector2i]) -> void:
 	if _last_cells.get(layer, Array()) == cells:
 		return
 	_last_cells[layer] = cells
-	overlays.set_cells(layer, cells)
+	overlays.set_cells(layer, cells, _heights())
 
 
 # ATTACK is dual-use in 2D: reach fill at (0,0), target-pick markers at (3,0) on the
@@ -149,7 +149,7 @@ func _attack(om: OverlayManager) -> void:
 	reach.sort()
 	if _last_cells.get(BoardOverlays.Layer.ATTACK, Array()) != reach:
 		_last_cells[BoardOverlays.Layer.ATTACK] = reach
-		overlays.set_cells(BoardOverlays.Layer.ATTACK, reach)
+		overlays.set_cells(BoardOverlays.Layer.ATTACK, reach, _heights())
 	overlays.set_layer_modulate(BoardOverlays.Layer.ATTACK, om.attack_overlay.modulate)
 	_markers(BoardOverlays.Layer.TARGET_PICK, picks)
 
@@ -210,8 +210,9 @@ func _icons(om: OverlayManager) -> void:
 			var icon := by_type[type] as OverlayIcon
 			if icon == null or not is_instance_valid(icon):
 				continue
-			var pos := _anchor(icon.target_cell) + Vector3(0.0, float(type) * 0.02, 0.0)
-			entries.append(_marker(pos, icon.sprite.texture, icon.sprite.modulate))
+			var surface := _anchor(icon.target_cell)
+			surface.origin.y += float(type) * 0.02
+			entries.append(_marker(surface, icon.sprite.texture, icon.sprite.modulate))
 	_markers(BoardOverlays.Layer.ICONS, entries)
 
 
@@ -261,19 +262,22 @@ func _markers(layer: BoardOverlays.Layer, entries: Array[Dictionary]) -> void:
 	overlays.set_markers(layer, entries)
 
 
-func _marker(pos: Vector3, texture: Texture2D, tint: Color) -> Dictionary:
-	return {"pos": pos, "texture": texture, "modulate": tint}
+# Both halves of a marker come off ONE surface_transform, so where it sits and how it lies can
+# never disagree. A BILLBOARD ignores the basis and stays upright; the ghost channel likewise.
+func _marker(surface: Transform3D, texture: Texture2D, tint: Color) -> Dictionary:
+	return {"pos": surface.origin, "texture": texture, "modulate": tint, "basis": surface.basis}
 
 
-# A cell's top-face center — the marker anchor convention, now on the cell's own SURFACE (#273)
-# so a marker on a terrace rides the terrace. BoardSpace.surface_point is the one answer; a ramp's
-# half-level lift comes along with it.
-func _anchor(cell: Vector2i) -> Vector3:
-	return BoardSpace.surface_point(cell, _heights())
+# How markup LIES on a cell — the marker anchor convention, on the cell's own SURFACE since #273 so
+# a marker on a terrace rides the terrace, and tilted with that surface since #281 so one on a ramp
+# lies flat against the slope. BoardSpace.surface_transform is the one answer.
+func _anchor(cell: Vector2i) -> Transform3D:
+	return BoardSpace.surface_transform(cell, _heights())
 
 
-# A 2D world position's top-face anchor (sprites sit at cell centers). The LEVEL comes from the
-# cell those pixels fall in, so a ghost or arrow over a terrace lifts with it.
-func _anchor_px(px: Vector2) -> Vector3:
+# The same, for a 2D world position (sprites sit at cell centers). The LEVEL and the SLOPE both come
+# from the cell those pixels fall in, so a ghost or arrow over a terrace lifts and tilts with it.
+func _anchor_px(px: Vector2) -> Transform3D:
 	var cell := Vector2i(floori(px.x / float(GridUtils.TILE_SIZE)), floori(px.y / float(GridUtils.TILE_SIZE)))
-	return BoardSpace.of_pixels(px, BoardSpace.surface_point(cell, _heights()).y)
+	var surface := BoardSpace.surface_transform(cell, _heights())
+	return Transform3D(surface.basis, BoardSpace.of_pixels(px, surface.origin.y))

--- a/tests/presentation/test_board_overlays.gd
+++ b/tests/presentation/test_board_overlays.gd
@@ -212,6 +212,105 @@ func test_hover_is_a_bracket_mesh_at_the_cell() -> void:
 	assert_bool(bracket_seen).is_true()
 
 
+# --- Markup lies on the surface it marks (#281) ------------------------------------
+
+# A fresh sink rather than the demo scene's: these cases read a single quad's transform, and the
+# demo's own zone patch would put other visible quads in the same child sweep.
+func _bare_overlays() -> BoardOverlays:
+	var overlays: BoardOverlays = auto_free(BoardOverlays.new())
+	add_child(overlays)
+	return overlays
+
+
+func _ramp_at(cell: Vector2i, level: int) -> BoardHeights:
+	var heights := BoardHeights.new()
+	heights.set_cell(cell, level, Terrain.RampRise.EAST)
+	return heights
+
+
+# The quad's own facing, which is what "flat against the ground" means. basis.y is the normal; it
+# carries no art scale, so it compares clean.
+func _normal_of(overlays: BoardOverlays) -> Vector3:
+	for child in overlays.get_children():
+		var quad := child as MeshInstance3D
+		if quad != null and quad.visible and quad.mesh is PlaneMesh:
+			return quad.basis.y.normalized()
+	return Vector3.ZERO
+
+
+func test_a_fill_on_a_ramp_lies_on_the_slope_instead_of_hanging_level_through_it() -> void:
+	# The fill half of #281, and with it the anchoring defect it shared a cause with: _fill resolved
+	# a cell to its RULES level (the ramp's low edge) while every marker went through surface_point's
+	# midpoint, so a move tile and a path arrow on one ramp cell disagreed by half a level.
+	# Both halves are derived from the seam here, never from a literal.
+	var cell := Vector2i(3, 2)
+	var heights := _ramp_at(cell, 1)
+	var overlays := _bare_overlays()
+	overlays.set_cells(BoardOverlays.Layer.MOVE, [BoardSpace.of_cell(cell, 1)], heights)
+
+	var expected := BoardSpace.surface_transform(cell, heights)
+	assert_that(_normal_of(overlays)).is_equal(expected.basis.y.normalized())
+	assert_bool(_normal_of(overlays).is_equal_approx(Vector3.UP)).override_failure_message(
+			"the fill is still level -- it would cut through the slope").is_false()
+
+	for child in overlays.get_children():
+		var quad := child as MeshInstance3D
+		if quad != null and quad.visible and quad.mesh is PlaneMesh:
+			# The clearance rides the surface normal, so the height is the surface's plus a lift
+			# smaller than the half-level the ramp midpoint itself contributes.
+			var above := quad.position.y - expected.origin.y
+			assert_float(above).is_between(0.0, BoardSpace.CELL_SIZE * 0.5)
+
+
+func test_a_marker_lies_on_the_slope_its_own_cell_carries() -> void:
+	var cell := Vector2i(3, 2)
+	var heights := _ramp_at(cell, 1)
+	var surface := BoardSpace.surface_transform(cell, heights)
+	var overlays := _bare_overlays()
+	overlays.set_markers(BoardOverlays.Layer.PATH_ARROWS, [{
+		"pos": surface.origin, "texture": GridUtils.ERROR_ICON,
+		"modulate": Color.WHITE, "basis": surface.basis,
+	}])
+	assert_that(_normal_of(overlays)).is_equal(surface.basis.y.normalized())
+
+
+func test_an_entry_with_no_basis_still_draws_flat() -> void:
+	# Every pre-#281 caller -- and the ghost channel, which ignores the key -- omits it.
+	var overlays := _bare_overlays()
+	overlays.set_markers(BoardOverlays.Layer.PATH_ARROWS, [
+		{"pos": Vector3(2.5, 1.0, 2.5), "texture": GridUtils.ERROR_ICON, "modulate": Color.WHITE}])
+	assert_that(_normal_of(overlays)).is_equal(Vector3.UP)
+
+
+func test_a_pooled_marker_reused_on_flat_ground_drops_the_tilt_it_had() -> void:
+	# Marker nodes are REUSED between frames, so the tilt is written unconditionally rather than only
+	# when a cell ramps. A mutant that sets the basis only for ramps passes every case above and
+	# fails here: walk an arrow off a ramp and it keeps sloping over flat ground forever.
+	var cell := Vector2i(3, 2)
+	var surface := BoardSpace.surface_transform(cell, _ramp_at(cell, 1))
+	var overlays := _bare_overlays()
+	overlays.set_markers(BoardOverlays.Layer.PATH_ARROWS, [{
+		"pos": surface.origin, "texture": GridUtils.ERROR_ICON,
+		"modulate": Color.WHITE, "basis": surface.basis,
+	}])
+	assert_that(_normal_of(overlays)).is_not_equal(Vector3.UP)   # the precondition, not the claim
+
+	overlays.set_markers(BoardOverlays.Layer.PATH_ARROWS, [
+		{"pos": Vector3(9.5, 1.0, 9.5), "texture": GridUtils.ERROR_ICON, "modulate": Color.WHITE}])
+	assert_that(_normal_of(overlays)).is_equal(Vector3.UP)
+
+
+func test_a_fill_pooled_off_a_ramp_drops_the_tilt_too() -> void:
+	# The same reuse hazard on the set_cells path, which writes a whole transform per frame.
+	var cell := Vector2i(3, 2)
+	var overlays := _bare_overlays()
+	overlays.set_cells(BoardOverlays.Layer.MOVE, [BoardSpace.of_cell(cell, 1)], _ramp_at(cell, 1))
+	assert_that(_normal_of(overlays)).is_not_equal(Vector3.UP)
+
+	overlays.set_cells(BoardOverlays.Layer.MOVE, [BoardSpace.of_cell(Vector2i(9, 9), 0)], BoardHeights.new())
+	assert_that(_normal_of(overlays)).is_equal(Vector3.UP)
+
+
 # --- find_reachable under the traversal ruling -------------------------------------
 
 func test_reachable_respects_the_ramp_ruling_and_the_cap() -> void:

--- a/tests/presentation/test_board_space.gd
+++ b/tests/presentation/test_board_space.gd
@@ -86,3 +86,59 @@ func test_a_ramp_stands_things_half_a_level_up_its_slope() -> void:
 func test_a_board_with_no_heights_wired_reads_as_flat() -> void:
 	# The headless Play boards never set one, and every anchor still has to resolve.
 	assert_float(BoardSpace.surface_point(Vector2i(4, 4), null).y).is_equal(BoardSpace.surface_y(0))
+	assert_that(BoardSpace.surface_transform(Vector2i(4, 4), null).basis).is_equal(Basis.IDENTITY)
+
+
+# --- How markup LIES on a surface (#281) --------------------------------------------
+
+# Markup on a ramp has to reach the two levels the ramp CONNECTS -- its low edge at the level below,
+# its high edge at the level above. Asserted as that geometry rather than as an angle, so it stays
+# true of whatever the wedge's profile is and cannot be satisfied by a quad that merely tilts
+# (one rotated but unstretched would fall short of both edges).
+#
+# Every rise is checked because "no sideways entry" means each one connects a DIFFERENT pair of
+# neighbours, and a sign error shows up in exactly one of the four.
+func test_markup_on_a_ramp_spans_the_two_levels_the_ramp_joins() -> void:
+	for rise: Terrain.RampRise in [Terrain.RampRise.NORTH, Terrain.RampRise.SOUTH,
+			Terrain.RampRise.EAST, Terrain.RampRise.WEST]:
+		var cell := Vector2i(3, 2)
+		var heights := BoardHeights.new()
+		heights.set_cell(cell, 1, rise)
+		var xform := BoardSpace.surface_transform(cell, heights)
+
+		# The quad's own uphill/downhill edge midpoints, in ITS local frame: half a cell either way
+		# along whichever local axis the slope runs on.
+		var dir := Terrain.rise_direction(rise)
+		var edge := Vector3(dir.x, 0.0, dir.y) * 0.5 * BoardSpace.CELL_SIZE
+		var high := xform * edge
+		var low := xform * -edge
+
+		assert_float(high.y).override_failure_message(
+				"%s: the high edge misses the level above" % Terrain.RampRise.keys()[rise]) \
+			.is_equal_approx(BoardSpace.surface_y(2), 0.0001)
+		assert_float(low.y).override_failure_message(
+				"%s: the low edge misses the level below" % Terrain.RampRise.keys()[rise]) \
+			.is_equal_approx(BoardSpace.surface_y(1), 0.0001)
+
+		# ...and it still covers exactly its own cell in plan view, or it would spill onto a neighbour.
+		var span := Vector2(high.x - low.x, high.z - low.z).length()
+		assert_float(span).override_failure_message(
+				"%s: the footprint is not one cell wide" % Terrain.RampRise.keys()[rise]) \
+			.is_equal_approx(BoardSpace.CELL_SIZE, 0.0001)
+
+
+func test_markup_lies_flat_where_there_is_no_ramp() -> void:
+	# The pair to the above: an unrotated basis on ordinary ground, and the level the cell states.
+	var heights := BoardHeights.new()
+	heights.set_cell(Vector2i(2, 2), 2, Terrain.RampRise.NONE)
+	var xform := BoardSpace.surface_transform(Vector2i(2, 2), heights)
+	assert_that(xform.basis).is_equal(Basis.IDENTITY)
+	assert_float(xform.origin.y).is_equal(BoardSpace.surface_y(2))
+
+
+func test_lie_on_takes_the_level_it_is_given_rather_than_looking_one_up() -> void:
+	# The fill path resolves the level itself (of_cell's rule) and asks only the RISE question here.
+	# Were this to re-derive elevation, a caller's stated level would be silently overridden.
+	var flat := BoardSpace.lie_on(BoardSpace.of_cell(Vector2i(6, 6), 3), Terrain.RampRise.NONE)
+	assert_float(flat.origin.y).is_equal(BoardSpace.surface_y(3))
+	assert_that(flat.basis).is_equal(Basis.IDENTITY)

--- a/tests/presentation/test_overlay_mirror.gd
+++ b/tests/presentation/test_overlay_mirror.gd
@@ -83,6 +83,50 @@ func _squad_pair() -> Array[Unit]:
 
 # --- Fills -------------------------------------------------------------------------
 
+# The WIRE for #281: BoardOverlays can tilt a fill onto a slope, and OverlayMirror knows the board's
+# heights, and neither of those facts puts a tilt on screen unless the mirror actually HANDS the
+# heights over. Both ends were correct while nothing connected them is #103's shape exactly, and the
+# unit-level cases cannot see it -- they call set_cells themselves.
+#
+# The ramp is painted into the fixture's own hand-built board, so nothing here reads authored
+# content. It is painted BEFORE the mode is entered because _fill diffs on the CELL LIST: a rise
+# added under an already-drawn overlay does not change any cell, so it would not re-push.
+func test_a_fill_over_a_ramp_reaches_the_3d_tilted() -> void:
+	var pair := _squad_pair()
+	var mover: Unit = pair[1]
+
+	# Discover the real range first, then ramp a cell inside it -- picking a cell blind would sit
+	# outside the range on any future change to MOV or cohesion and quietly assert nothing.
+	game.enter_move_mode(mover)
+	await _settle()
+	var painted: Array[Vector2i] = _om().move_overlay.get_used_cells()
+	assert_bool(painted.size() > 0).override_failure_message(
+			"nothing painted -- this case cannot see the wire").is_true()
+	game.exit_current_mode()
+	await _settle()
+
+	# EAST so the ramp is entered along its own axis from the west, keeping it reachable.
+	painted.sort()
+	var ramp: Vector2i = painted[0]
+	game.board_heights.set_cell(ramp, 0, Terrain.RampRise.EAST)
+
+	game.enter_move_mode(mover)
+	await _settle()
+	var still_painted: Array[Vector2i] = _om().move_overlay.get_used_cells()
+	assert_bool(still_painted.has(ramp)).override_failure_message(
+			"the ramped cell fell out of range -- nothing tilted would be drawn").is_true()
+
+	var tilted := 0
+	for child in _overlays.get_children():
+		var quad := child as MeshInstance3D
+		if quad != null and quad.visible and quad.mesh is PlaneMesh \
+				and not quad.basis.y.normalized().is_equal_approx(Vector3.UP):
+			tilted += 1
+	assert_int(tilted).override_failure_message(
+			"every fill came through level -- the mirror is not handing its heights to set_cells") \
+		.is_greater(0)
+
+
 func test_move_and_invalid_fills_mirror_the_2d_layers() -> void:
 	var pair := _squad_pair()
 	game.enter_move_mode(pair[1])   # the member: cohesion clips its range -> both layers paint


### PR DESCRIPTION
Closes #281.

## What was actually wrong

**Not what the issue theorised.** Its two candidate mechanisms — a bad pixel-to-cell resolution, and arrows anchored once for the whole run — are both falsified: `OverlayMirror._anchor_px` has resolved each sprite's own cell and taken that cell's `surface_point` since #273, and arrow sprites are placed at cell *centres* (`GridUtils.cell_world` -> `map_to_local`), so the floor lands in the right cell. The heights per arrow were already right.

**Nothing in the 3D markup stack has ever carried an ORIENTATION.** `BoardOverlays._apply_marker` set `quad.position`, `set_cells` set `marker.position`, and both draw a `PlaneMesh` lying in XZ. On flat ground that is invisible; on a ramp wedge the quad hangs horizontally through the slope.

## The seam

`BoardSpace.surface_transform(cell, heights)` is the one answer to *"how does a flat thing LIE on this cell's surface"*. `surface_point` becomes its `.origin`, so the position half and the orientation half cannot drift apart, and its six existing readers are untouched.

The tilt is **derived from `Terrain.rise_direction`** — the same call `BoardMirror._ramp_orientation` yaws the wedge by — so the ground and the markup on it cannot disagree about which way the slope climbs. No new orientation source; nothing had to be built first.

`lie_on(cell3d, rise)` is the half for a caller that already resolved the level (the fills, whose `Vector3i` states it, per `of_cell`'s "every caller states the LEVEL it means" rule). Re-deriving elevation there would look up what was already passed.

## The stretch, which is not obvious

A 45-degree ramp face is **1.414 cells long**, so a 1x1 quad that merely *rotated* would cover the cell's footprint and leave the face bare at both edges. The tilt therefore carries a stretch along the slope (`SLOPE_STRETCH`), which keeps a fill covering its whole cell and makes an arrow foreshorten exactly as the ground under it does. Only the axis that runs up-slope is stretched, so the arrow art keeps its orientation.

Both values are **derived geometry, not taste** — `atan2(CELL_SIZE, CELL_SIZE)` and `1/cos` of it — so neither wants a Look-tab knob.

## A second defect, fixed here too (your call on scope)

`OverlayMirror._fill` anchored cells with `BoardSpace.of_cell(cell, _level_of(cell))` — the **rules** level, the ramp's low edge — while every marker went through `surface_point`, which adds the half-level midpoint. So on one ramp cell a move-range fill and a path arrow **disagreed about where the surface is by half a level**, and the fill sat buried in the slope. Two answers to one question; both now ask `BoardSpace`.

## Deliberately NOT tilted

- **`Kind.BILLBOARD`** (selection icons) and **`Kind.BRACKET`** (the 3D hover pointer) — a bracket marks a cell *volume*, not the ground plane, and keeps `cell_center`.
- Everything that **stands on** a surface rather than lying on it: `UnitMirror`, and `BoardMirror`'s flame and prop placement all keep reading `surface_point`.
- The `Scenes/LookDev/` demo boards pass no heights, so they render exactly as before.

## Verification

`tests/presentation` **201/201**. Per the standing rule the full tree is CI's.

The tilt is asserted as **geometry, not an angle**: markup on a ramp must reach the two levels the ramp *connects* — high edge at `surface_y(level+1)`, low edge at `surface_y(level)` — and still span exactly one cell in plan view. That holds for all four rise directions and would fail loudly if the wedge's authored profile ever changed. It is also what caught the missing stretch: a rotated-but-unstretched quad falls short of both edges.

No authored content is pinned. Heights are built in-test with `BoardHeights.set_cell`, and the mirror case paints its ramp into the fixture's own hand-built board.

**Falsified against two mutants**, the two places a green run could genuinely be blind:

1. **Write the basis only when the cell ramps** — passes every tilt assertion, reds only `test_a_pooled_marker_reused_on_flat_ground_drops_the_tilt_it_had`. Marker nodes are pooled, so an arrow walked off a ramp would otherwise keep sloping over flat ground forever.
2. **Drop `heights` at the `set_cells` call site** — reds `test_a_fill_over_a_ramp_reaches_the_3d_tilted` with its own message. Both ends correct while nothing connects them is #103's shape, and the unit-level cases cannot see it because they call `set_cells` themselves.

**Not checked, and yours:** whether the tilted markup *reads* right at the real camera distance. I did not launch the game.

## One residual, flagged not fixed

`_fill` diffs on the **cell list**, so painting a *rise* under an already-drawn overlay (same cells, same elevation) does not re-push and the fill keeps its old tilt until the cell set next changes. Reachable via #285's elevation brush with a zone overlay up; it self-heals on the next change. Out of scope here — say the word and it gets its own ticket.

## Knobs

None added. See the stretch note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
