### PR TITLE
Fix #317: planning ghosts sort under path arrows and terrain icons

### DIFF
--- a/Classes/presentation/BoardOverlays.gd
+++ b/Classes/presentation/BoardOverlays.gd
@@ -33,7 +33,9 @@ const UNIT_RENDER_LAYER := 2   # bit for layer index 1 — UnitSprite3D sets thi
 # Every unit sprite (real or planning ghost) sorts ABOVE every overlay layer, structurally
 # rather than by numeric luck — the 3D twin of the 2D's "tile overlays sit below
 # Unit.BASE_SPRITE_INDEX". Must stay greater than any LAYERS "sort"; pinned by a test.
-# Without it a ghost was just render_priority 0, so arrows and terrain icons drew over it.
+# It only ARBITRATES in the alpha queue, though (#317): an OPAQUE_PREPASS sprite is held above
+# markup by the depth it writes instead, and it writes none where alpha is under the prepass
+# threshold — which is why UnitMirror builds the translucent ghosts alpha_cut DISABLED.
 const UNIT_RENDER_PRIORITY := 32
 # Fire's 3D form is a STANDING effect, not markup lying on the tile face, so it sorts above every
 # overlay layer — the same structural claim units make, one band below them so the flame-vs-sprite

--- a/Classes/presentation/UnitMirror.gd
+++ b/Classes/presentation/UnitMirror.gd
@@ -167,6 +167,10 @@ func set_ghosts(ghosts: Array[Dictionary]) -> void:
 	while _ghosts.size() < ghosts.size():
 		var ghost := UnitSprite3D.new()
 		ghost.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF  # a translucent stand-in casts no shadow
+		# ...and it sorts by PRIORITY, not by depth (#317). OPAQUE_PREPASS writes depth only where
+		# alpha clears the prepass threshold, and a ghost's tint is 0.75 — so a ghost wrote none,
+		# and what holds markup behind a REAL sprite is that depth, never UNIT_RENDER_PRIORITY.
+		ghost.alpha_cut = SpriteBase3D.ALPHA_CUT_DISABLED
 		add_child(ghost)
 		_ghosts.append(ghost)
 	for i in _ghosts.size():

--- a/Classes/presentation/UnitSprite3D.gd
+++ b/Classes/presentation/UnitSprite3D.gd
@@ -63,8 +63,9 @@ func _init() -> void:
 	offset = Vector2(0, 16)  # pivot at the feet
 	layers = BoardOverlays.UNIT_RENDER_LAYER  # overlay fills never paint sprites (#213 mask contract)
 	# Board markup never draws OVER a unit — the mask above stops fills painting onto the
-	# sprite, this stops them sorting in front of it. Ghosts are UnitSprite3Ds too, which is
-	# what the freeze-icons-over-ghosts report came down to.
+	# sprite, this stops them sorting in front of it. An OPAQUE sprite is actually held there by
+	# the prepass depth above; the priority is what carries a TRANSLUCENT one, which writes no
+	# depth — see UnitMirror.set_ghosts (#317).
 	render_priority = BoardOverlays.UNIT_RENDER_PRIORITY
 
 

--- a/tests/presentation/test_overlay_mirror.gd
+++ b/tests/presentation/test_overlay_mirror.gd
@@ -246,6 +246,31 @@ func test_a_queued_move_mirrors_ghost_hide_and_arrows() -> void:
 	assert_that(markers[0]["modulate"]).is_equal(move.preview[0].modulate)
 
 
+func test_a_ghost_sorts_where_its_priority_is_actually_read() -> void:
+	# #317, found in play: arrows and freeze icons drew over planning ghosts even though every
+	# UnitSprite3D carries UNIT_RENDER_PRIORITY. A ghost is TRANSLUCENT, and OPAQUE_PREPASS writes
+	# depth only above the prepass threshold — so a ghost wrote none, and priority does not
+	# arbitrate outside the alpha queue. Driven through the real ghost path, because the POOL is
+	# what shipped wrong; the constructor was always carrying the number.
+	var unit := _spawn(PLAYER, Vector2i(2, 2))
+	game.enter_move_mode(unit)
+	game.selected_unit = unit
+	game._on_left_click(Vector2i(3, 2))
+	await _settle()
+	assert_int(_unit_mirror.ghost_count()).is_equal(1)
+	var ghost: UnitSprite3D = _unit_mirror._ghosts[0]
+	assert_bool(ghost.modulate.a < 1.0).override_failure_message(
+			"the ghost tint is opaque, so this case no longer covers the translucent path").is_true()
+	assert_int(ghost.alpha_cut).override_failure_message(
+			"a translucent ghost on OPAQUE_PREPASS writes no depth and is not priority-sorted, so "
+			+ "board markup draws over it (#317)").is_equal(SpriteBase3D.ALPHA_CUT_DISABLED)
+	# ...and the priority now doing the work really does outrank what was drawing over it.
+	for layer: BoardOverlays.Layer in [BoardOverlays.Layer.PATH_ARROWS, BoardOverlays.Layer.TERRAIN]:
+		var sort: int = BoardOverlays.LAYERS[layer]["sort"]
+		assert_int(ghost.render_priority).override_failure_message(
+				"layer %d sorts at %d, at or above the ghost" % [layer, sort]).is_greater(sort)
+
+
 func test_hover_path_preview_mirrors_while_sweeping() -> void:
 	var unit := _spawn(PLAYER, Vector2i(2, 2))
 	game.enter_move_mode(unit)


### PR DESCRIPTION
Closes #317.

## The mechanism, which is not the one the issue guessed at

#317 was filed with two candidate causes and a note to measure before touching either. It falls out of the code instead — and the ghost-only scope is the tell.

`UnitSprite3D._init` sets `ALPHA_CUT_OPAQUE_PREPASS`. That mode writes depth **only where alpha clears the prepass threshold**, and it is that depth — not `UNIT_RENDER_PRIORITY` — that has been holding board markup behind unit sprites all along. #298 says the same thing from the other side: *"the sprite's depth prepass rejects the flame's pixels before the sort ever gets a say."*

- A **real** unit sprite is opaque, so it writes depth, and the arrow/icon quad on its cell is depth-rejected. Correct, and the priority number is doing nothing.
- A **ghost** wears `OverlayManager.PROJECTED_MODULATE` — alpha **0.75** — copied through `OverlayMirror._ghost_sync` → `UnitMirror.set_ghosts`. Under the threshold, so a ghost writes **no depth at all**, and `render_priority` does not arbitrate outside the alpha queue. Nothing was left to hold the markup back.

So "the priority fix did not take" is right, and the reason is that ghosts were never in the queue where the lever exists.

## The change

`UnitMirror.set_ghosts` builds pooled ghosts with `alpha_cut = ALPHA_CUT_DISABLED`, beside the existing `cast_shadow` line — the other declared ghost-vs-real asymmetry. That puts them in the alpha queue, where 32 genuinely outranks `PATH_ARROWS`' 5 and `TERRAIN`'s 2, and `UNIT_RENDER_PRIORITY` starts doing the job its own comment claims.

Depth **testing** is untouched (only the write is), so terrain, props and nearer unit sprites still occlude a ghost exactly as before. Nothing is lost by dropping the prepass here: it exists to stop a sprite sorting against *itself*, and a single quad has no self-overlap.

Two comments corrected in passing, because both asserted the thing that turned out to be false: `BoardOverlays.UNIT_RENDER_PRIORITY` and the `render_priority` line in `UnitSprite3D._init`.

## Verification

`tests/presentation/test_overlay_mirror.gd` — **17/17**, one new case. It drives the real ghost path (enter move mode → click → the pool) rather than constructing a sprite, because the constructor was always carrying the right number; the pool is what shipped wrong. **Falsified**: with the one line removed the new case reds on its own message and the eight cases below it are truncated, which is the expected shape.

Headless cannot see a sort order, so that case pins the *wire*. The artefact is a feel-check.

## What to look for

Queue a move so a ghost stands on a cell with a path arrow through it, or freeze the cell it stands on. The arrow/icon should now pass behind it.

A free extra check that the diagnosis was right, no code needed: **hover the ghost**. `set_projected_unit_highlighted` swaps in `PROJECTED_HIGHLIGHT`, which is alpha **1.0** — so on `main`, hovering should already make the arrow snap behind the ghost and pop back in front when you look away. If it does, that is this bug's mechanism visible with the naked eye.

## Known residual, deliberately not fixed here

For a **real** sprite the arrow quad's camera-near half is genuinely closer than the billboard plane, so it can still paint over the very bottom of the feet. Not reported, a sliver, and geometric rather than a sorting edit — #227 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
