### PR TITLE
Mirror the 2D attack lunge into the diorama (#321)

### DIFF
--- a/Classes/presentation/UnitMirror.gd
+++ b/Classes/presentation/UnitMirror.gd
@@ -15,6 +15,11 @@ class_name UnitMirror
 # only for whichever unit the pointer currently resolves to. Both facts it needs already have
 # exactly one answer elsewhere — hovered_unit_source asks the question HoverPresenter._process asks,
 # and HP comes off the Unit — so this adds a SURFACE, not a seam.
+#
+# Since #321 it also mirrors UnitVisuals' effect OFFSET (the attack lunge, the invalid-order shake),
+# which is expressed on the Unit's child sprite rather than on the Unit — the one fact of that class
+# the position read above cannot see. The rule the ticket settled: anything a 2D effect writes on the
+# Unit node mirrors for free, anything it writes as a child offset arrives through animation_offset().
 
 const PIXELS_PER_CELL := float(GridUtils.TILE_SIZE)  # 16 — grid.map_to_local's metric
 
@@ -189,16 +194,25 @@ func ghost_count() -> int:
 
 
 func _sync(unit: Unit, sprite: UnitSprite3D) -> void:
-	var previous := sprite.position
+	# The BOARD point, which is what every derivation below reads — never the written position,
+	# which since #321 also carries the effect offset.
+	var previous := sprite.position - sprite.art_offset
 	# The height comes from the cell the sprite is OVER, not from unit.movement.cell: mid-walk the
 	# pixel position is between cells, and reading the destination would pop the sprite to the new
 	# level before it arrives. Derived from the same pixels that place X and Z, so it steps up as
 	# the sprite crosses the edge.
 	var over := Vector2i(floori(unit.position.x / PIXELS_PER_CELL),
 			floori(unit.position.y / PIXELS_PER_CELL))
-	sprite.position = Vector3(unit.position.x / PIXELS_PER_CELL,
+	var stand := Vector3(unit.position.x / PIXELS_PER_CELL,
 			BoardSpace.surface_point(over, heights).y, unit.position.y / PIXELS_PER_CELL)
-	sprite.cell = BoardSpace.cell_of(sprite.position + Vector3(0, -0.5, 0))
+	sprite.cell = BoardSpace.cell_of(stand + Vector3(0, -0.5, 0))
+	# The attack lunge and the invalid-order shake (#321) tween $MapSprite's LOCAL position, which
+	# unit.position never sees — the one fact UnitVisuals expresses that the reads above cannot
+	# reach. Mapped through the same metric and the same axes as the stand point: a 2D y is board
+	# DEPTH, never height. Added last, so a lunge is not a step and does not change the cell.
+	var art := unit.visuals.animation_offset() / PIXELS_PER_CELL
+	sprite.art_offset = Vector3(art.x, 0.0, art.y)
+	sprite.position = stand + sprite.art_offset
 
 	var downed := unit.lifecycle_state == Unit.LifecycleState.DOWNED
 	if downed != sprite.is_downed():
@@ -218,7 +232,7 @@ func _sync(unit: Unit, sprite: UnitSprite3D) -> void:
 	# child alone is what left enemies un-reddened in 3D.
 	sprite.modulate = unit.modulate * unit.visuals.sprite.modulate
 
-	var step := sprite.position - previous
+	var step := stand - previous
 	if Vector2(step.x, step.z).length_squared() > 0.000001:
 		sprite.last_step = step
 		sprite.flip_h = sprite.facing_flip_for(step)

--- a/Classes/presentation/UnitSprite3D.gd
+++ b/Classes/presentation/UnitSprite3D.gd
@@ -34,6 +34,11 @@ var display_name := "Unit"
 # has stopped still needs its step remembered — otherwise an ORBIT leaves it facing the
 # way it faced under the old camera angle (#176 stage 4d).
 var last_step := Vector3.ZERO
+# The effect displacement riding on top of this sprite's board point (#321): position is
+# always `board point + art_offset`, one writer. Declared here rather than folded into
+# position because the mirror's step, facing and cell derivations all read the board point
+# alone — a lunge is art moving, not a unit moving.
+var art_offset := Vector3.ZERO
 
 # Texels per world unit — #176's "one pixel density, everywhere" convention, as a number
 # rather than a comment. STATIC, not @export: pixel_size is a Sprite3D property and cannot be

--- a/Classes/units/UnitVisuals.gd
+++ b/Classes/units/UnitVisuals.gd
@@ -113,6 +113,14 @@ func set_projected(value: bool):
 	else:
 		sprite.show()
 		
+# How far an effect has displaced the art from where it rests, in the Unit node's own pixels.
+# The 3D mirror's one read of it (#321): everything else this class writes is either already
+# mirrored (modulate) or has no 3D meaning, so this is the whole of the offset channel.
+func animation_offset() -> Vector2:
+	if sprite == null:
+		return Vector2.ZERO
+	return sprite.position - base_position
+
 func play_attack_lunge(direction: Vector2):
 	if sprite == null:
 		return

--- a/docs/design/presentation-effects.md
+++ b/docs/design/presentation-effects.md
@@ -2,7 +2,7 @@
 
 **Status: an idea wall plus two locked decisions.** Solicited by the dev on 2026-08-12, the day Stage 0 (#203) passed its GO gate: *"a full thought experiment, all ideas on the wall."* Nothing below the Decisions section is a commitment — it is the candidate pool for #176's stage 5 and beyond, kept so it can't evaporate from chat. The look-dev scene (`Scenes/LookDev/LookDev.tscn`) is the standing playground where any of it gets prototyped before it's real — and since #212 (2026-08-15) the **Look tab** in the dev-tools window tunes the *shipping* view live, so a value on this wall can be judged on a real board rather than in the diorama.
 
-**Canon checked through #308 (2026-08-15).**
+**Canon checked through #328 (2026-08-16).**
 
 ---
 
@@ -80,6 +80,20 @@ Two rules this settled, both general:
 
 - **A repaint can add or erase a COLUMN**, which is what the picker table and the camera bounds derive from — refresh them with it, or the cell you just painted is unclickable. Bounds only, never a re-frame: painting a tile must not yank the camera, matching what `CameraController.refresh_bounds` has always done in 2D.
 - **Authoring scaffolding mirrors only while the 2D shows it.** `ZONE_PATROL` (the brush's default kind) and the picked-zone highlight had no 3D twin at all; giving them one means mirroring *cells and visibility*, because the 2D reveals those layers solely while the Tile Brush tab is up. Mirror the question — "should this be on screen" — never the field the cells happen to live in.
+
+### What mirrors for free, and what needs a channel ([#321](https://github.com/Phaazoid/Godoiosis/issues/321), 2026-08-16)
+
+The attack lunge never reached the diorama, and the reason generalizes past this one effect. `UnitMirror` keys on **`unit.position`** — the Unit node — while `UnitVisuals` plays the lunge on **`$MapSprite.position`**, a local offset inside that node. The mirror was faithful and blind at once: it reproduced where the unit *is*, and the lunge deliberately never moves where the unit is. The walk is the counter-example that always worked, because `MovementComponent` moves the Unit node.
+
+**The rule: anything a 2D effect expresses on the Unit node mirrors for free; anything it expresses as a child-sprite offset arrives through `UnitVisuals.animation_offset()`, and that is the whole of the offset channel.** Measured rather than assumed — the rest of the class's vocabulary is `modulate` (already mirrored as the product of both nodes, #222), `visible`/`projected`, `z_index` and `scale`, none of which needs a second answer. The only other writer of that offset is the invalid-order shake, which now crosses too.
+
+Three things were decided here rather than discovered later:
+
+- **Mirroring the offset, not giving the 3D its own playback.** The lunge direction is a **board cardinal** (`GridUtils.cardinal_direction_between`), not a screen axis — in the flat view those are the same thing — so the offset reproduces exactly under any camera yaw, and the 2D stays the one animation authority (#222's ruling). A second playback off the same `AttackAction` beat is what an eventual *real* attack animation wants; it is not what a half-cell lunge needs.
+- **The lunge distance stays a 2D value** (`GridUtils.TILE_SIZE / 2`). There is deliberately **no 3D-side multiplier**: a view-local scale would mean the two views disagree about how far a lunge goes, which is the same second-authority problem one layer down. If it reads weakly at the pitched view, move the 2D constant and both views move — the same shape as `OverlayManager`'s attack-reach colour, which the 3D mirrors rather than duplicating.
+- **The offset is added LAST, after the step, facing and cell derivations.** Those all read the sprite's position, so folding the lunge in earlier makes an out-and-back swing register as two steps — the unit ends facing backwards — and puts a mid-swing unit on the cell it is leaning into. `UnitSprite3D.art_offset` exists so the board point stays recoverable: position is always *board point + art offset*, one writer.
+
+A 2D y is board **DEPTH**, never height, here as everywhere else on this stack (#263's fence, #280's flowerbed).
 
 ### Conventions the art commission must carry (pending look-dev experiments)
 

--- a/tests/presentation/test_unit_mirror.gd
+++ b/tests/presentation/test_unit_mirror.gd
@@ -246,6 +246,9 @@ func test_a_lunge_is_not_a_step() -> void:
 
 	assert_vector(sprite.last_step).override_failure_message(
 			"the lunge registered as a step — the sprite will face the way it swung").is_equal(facing_before)
+	# The cell half is an invariant rather than a proven one: a lunge is exactly half a cell, so it
+	# reaches the boundary without crossing it, and the naive version passes this line. Kept because
+	# the claim is about the derivation, and the next effect on this channel may travel further.
 	assert_vector(sprite.cell).override_failure_message(
 			"a mid-lunge unit reports the cell it is leaning into").is_equal(cell_before)
 

--- a/tests/presentation/test_unit_mirror.gd
+++ b/tests/presentation/test_unit_mirror.gd
@@ -159,6 +159,97 @@ func test_the_faction_tint_reaches_the_diorama() -> void:
 			"both factions mirror the same colour — the tint discriminates nothing").is_false()
 
 
+# --- The attack lunge (#321) -----------------------------------------------------------
+# UnitVisuals expresses the lunge (and the invalid-order shake) as a LOCAL offset on the Unit's
+# child sprite, which unit.position never sees — so the mirror was faithful and blind at once.
+
+# The lunge as the game plays it, then FROZEN mid-flight. Deliberately not awaited (the real
+# method awaits its own tween, and the claims below are about the displaced moment), and killed
+# rather than sampled live: the tween keeps moving between the mirror's sync and the assertion,
+# so a live read compares two different instants of the same animation. The displacement is
+# still whatever the real tween produced — only the clock stops.
+func _lunge_frozen(unit: Unit, direction: Vector2) -> void:
+	unit.visuals.play_attack_lunge(direction)
+	await _settle()
+	unit.visuals.visual_tween.kill()
+	await _settle()
+
+
+func test_the_attack_lunge_reaches_the_diorama() -> void:
+	var unit := _live_units()[0]
+	var sprite := _mirror.sprite_for(unit)
+	await _lunge_frozen(unit, Vector2.RIGHT)
+
+	var offset := unit.visuals.animation_offset()
+	assert_bool(offset.length_squared() > 0.0).override_failure_message(
+			"the 2D tween never displaced the art, so a mirror that ignores it would pass here"
+			).is_true()
+	# The IDENTITY, not a distance: whatever the 2D animation holds at this instant is what the
+	# diorama shows. True at every frame of the tween, so no timing makes it flaky.
+	var shown := sprite.position - _sprite_seat(unit.movement.cell)
+	assert_vector(shown).override_failure_message(
+			"the lunge did not cross: 2D art at %s, 3D sprite %s off its stand point" % [offset, shown]
+			).is_equal_approx(Vector3(offset.x, 0.0, offset.y) / UnitMirror.PIXELS_PER_CELL,
+					Vector3.ONE * 0.0001)
+
+	# ...and it comes home. A mirrored offset that never zeroed would leave the board permanently
+	# skewed by whoever swung last — so this half runs a whole lunge, unfrozen, to its end.
+	# Counted frames, never `await tween.finished`: a tween that has already completed never emits
+	# again, and that await would hang the whole run rather than fail (tests/README).
+	unit.visuals.play_attack_lunge(Vector2.RIGHT)
+	var tween := unit.visuals.visual_tween
+	# The TWEEN's own liveness, not the offset: play_attack_lunge zeroes the art before it starts,
+	# so an offset check breaks on the very first pass, before the swing has begun.
+	for _frame in 600:
+		if not tween.is_valid():
+			break
+		await await_idle_frame()
+	await _settle()
+	assert_vector(sprite.position).override_failure_message(
+			"the swing ended and the sprite is still %s from its stand point"
+			% (sprite.position - _sprite_seat(unit.movement.cell))
+			).is_equal_approx(_sprite_seat(unit.movement.cell), Vector3.ONE * 0.0001)
+
+
+func test_a_lunge_along_board_y_moves_the_sprite_in_depth() -> void:
+	# A 2D y is DEPTH INTO the board, never height — the same misreading that cost #263 a fence
+	# and #280 a flowerbed. A lunge south is a step toward the camera, not a hop.
+	var unit := _live_units()[0]
+	var sprite := _mirror.sprite_for(unit)
+	var seat := _sprite_seat(unit.movement.cell)
+	await _lunge_frozen(unit, Vector2.DOWN)
+
+	assert_float(sprite.position.z - seat.z).override_failure_message(
+			"a lunge down-screen moved the sprite %s in depth" % (sprite.position.z - seat.z)
+			).is_greater(0.0)
+	assert_float(sprite.position.y).override_failure_message(
+			"the lunge lifted the sprite off its surface — the 2D y was read as height"
+			).is_equal_approx(seat.y, 0.0001)
+
+
+func test_a_lunge_is_not_a_step() -> void:
+	# The regression the obvious version of this fix ships: `step` and `cell` are both derived from
+	# the sprite's position, so an offset folded in there makes a lunge out-and-back read as two
+	# steps — the unit ends the swing facing backwards — and puts it on the next cell mid-swing.
+	var unit := _live_units()[0]
+	var sprite := _mirror.sprite_for(unit)
+	await _settle()
+	var facing_before := sprite.last_step
+	var cell_before := sprite.cell
+
+	await _lunge_frozen(unit, Vector2.RIGHT)
+	var art := unit.visuals.animation_offset() / UnitMirror.PIXELS_PER_CELL
+	# Non-vacuity: the displacement must clear the epsilon `_sync` gates a step on, or the naive
+	# version would pass this case too.
+	assert_bool(art.length_squared() > 0.000001).override_failure_message(
+			"the lunge moved less than _sync's own step epsilon; the case proves nothing").is_true()
+
+	assert_vector(sprite.last_step).override_failure_message(
+			"the lunge registered as a step — the sprite will face the way it swung").is_equal(facing_before)
+	assert_vector(sprite.cell).override_failure_message(
+			"a mid-lunge unit reports the cell it is leaning into").is_equal(cell_before)
+
+
 func test_clear_board_empties_the_mirror() -> void:
 	assert_bool(_mirror.mirrored_count() > 0).is_true()
 	_game.scenario_manager.clear_board()


### PR DESCRIPTION
Closes #321.

An attack in the 3D view resolved with no motion at all from the attacker. `UnitVisuals.play_attack_lunge` tweens **`$MapSprite.position`** — a local offset inside the Unit node — while `UnitMirror` keys on **`unit.position`**, the Unit node itself. The mirror was faithful and blind at the same time: it reproduced where the unit *is*, and the lunge deliberately never moves where the unit is.

## Two of the issue's own premises were wrong, and they changed the build

Re-derived from the code before planning (#228's law):

1. **The 2D lunge is not along a screen axis — it is along a BOARD cardinal.** `AttackAction:65` takes its direction from `GridUtils.cardinal_direction_between(origin, target_cell)`, in cell space. So option 2's stated advantage ("a lunge along a screen axis is not a lunge along a board axis") does not exist: in the flat view the screen axes *are* the board axes, and mirroring the offset reproduces the swing exactly at any camera yaw. Option 1 it is, and its stated downside — "welds the 3D to a 2D pixel convention" — also evaporates, since the mirror is already built entirely on that convention (`PIXELS_PER_CELL`, the `map_to_local` metric) and the offset divides by the same number as the position beside it.
2. **There is no damage flash or damage shake to port.** Both are one method, `play_invalid_flash`, whose only caller is `OrderExecutor:49` — the invalid-plan alarm. Its `modulate` half already mirrored (#222 copies the product of both nodes); its shake half now crosses on the same channel. #188 is unbuilt in *both* views, so it is a missing feature rather than a parity gap.

So the whole un-mirrored vocabulary of `UnitVisuals` turned out to be exactly **one fact**: `sprite.position`.

## The change

- **`UnitVisuals.animation_offset()`** — the one read of that channel, measured against `base_position` (the snapshot this class already restores from) so the mirror never re-derives a base it has no business knowing.
- **`UnitSprite3D.art_offset`** — declares the split: position is always *board point + art offset*, one writer.
- **`UnitMirror._sync`** — computes the board point into a local, derives `cell` / `last_step` / `flip_h` from it, then adds the offset **last**. That ordering is the whole subtlety: fold the lunge in earlier (the obvious version of this fix) and an out-and-back swing registers as two steps, so a unit ends the swing **facing backwards**, and a mid-swing unit reports the cell it is leaning into.
- A 2D y maps to board **z** — depth, not height. Third time on this stack after #263's fence and #280's flowerbed.

**No 3D-side knob, deliberately.** The lunge distance stays the 2D `TILE_SIZE / 2`; a view-local multiplier would mean the two views disagree about how far a lunge goes, which is the second-authority problem one layer down. If it reads weakly at the pitched view, the honest fix is to move the 2D constant and both views move together — the same shape as the attack-reach colour the 3D mirrors rather than duplicating. Canon recorded in `docs/design/presentation-effects.md` (marker bumped to #328).

## Verification

`tests/presentation/test_unit_mirror.gd`, three new cases driving the **real** `play_attack_lunge` on the real Battle3D + Prolog fixture — never a hand-set sprite position. The suite file is 10/10; the whole `presentation` area is **229/229, 0 orphans**. CI owns the tree.

Falsified with three mutants, run isolated, each reddening only its own case:

| mutant | case that reds |
| --- | --- |
| no offset mirrored (the pre-fix mirror) | `test_the_attack_lunge_reaches_the_diorama` |
| offset mapped to y instead of z | `test_a_lunge_along_board_y_moves_the_sprite_in_depth` |
| offset folded in *before* the derivations (the naive fix) | `test_a_lunge_is_not_a_step` |

Two things stated honestly rather than glossed:

- The identity case **freezes the tween mid-flight** (kills it) before asserting. The displacement is still whatever the real animation produced — but a live tween moves between the mirror's sync and the test's read, so a live sample compares two instants of the same animation. That cost one red run to find.
- Within `test_a_lunge_is_not_a_step`, only the `last_step` half has teeth. A lunge is exactly half a cell, so it reaches the cell boundary without crossing it and the naive version passes the `cell` line; it is kept as a stated invariant, commented as such.

## For the feel-check

Half a cell of board-plane motion at a 40° pitch — does it read as a blow? If not, the fixes in order are: raise the 2D constant (both views move), or promote this to a real 3D attack animation off the `AttackAction` beat, which this leaves fully open.

You are on **`feature/321-attack-lunge-3d`**. Your own tree at `C:\Iosis\Godoiosis` was left untouched on purpose (several agents are running) — this was built in the worktree `C:\Iosis\worktrees\321-attack-lunge`, which has the branch checked out and is ready to launch, or `gh pr checkout` it wherever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
