### PR TITLE
Fix #318: a board reload no longer wipes the 3D overlays

### DIFF
--- a/Classes/presentation/BoardOverlays.gd
+++ b/Classes/presentation/BoardOverlays.gd
@@ -16,6 +16,12 @@ class_name BoardOverlays
 # the cell's top-face ANCHOR (the mirror's geometry), and the LAYER adds its own
 # lift — board shape stays the caller's business.
 #
+# The layers are PARTITIONED BY WRITER, which is why there is no whole-sink wipe: battle3d owns
+# HOVER (the pointer bracket, the one layer deliberately not mirrored) and OverlayMirror owns the
+# rest, caching what it has pushed. Emptying every layer at once is therefore always one writer
+# reaching across that line and desyncing the other's cache — the clear_all() this used to carry
+# did exactly that on every board load (#318). Clear the layers you own.
+#
 # The mask contract: fill/sprite quads render on WORLD_RENDER_LAYER only, and
 # UnitSprite3D lives on UNIT_RENDER_LAYER. Both constants live HERE; a drift test
 # pins them disjoint.
@@ -179,11 +185,6 @@ func clear(layer: Layer) -> void:
 		set_markers(layer, [])
 	else:
 		set_cells(layer, [])
-
-
-func clear_all() -> void:
-	for layer: Layer in LAYERS.keys():
-		clear(layer)
 
 
 func cells_of(layer: Layer) -> Array[Vector3i]:

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -147,12 +147,18 @@ func load_mission(path: String) -> void:
 # Load Game (any mission), F2/Restart, Mission Select, sandbox. Rebuild the mirror
 # world and drop pointer state aimed at the dead board — _update_pointer's dedup
 # would otherwise eat the first repaint on a same-coordinate cell.
+#
+# HOVER and nothing else: BoardOverlays is partitioned by writer — this file owns the pointer
+# bracket, OverlayMirror owns every other layer AND caches what it has pushed there. The
+# clear_all() that used to sit here emptied the mirror's layers behind its back, so reloading an
+# UNCHANGED board diffed equal and never repainted (#318). Zones were the visible casualty for
+# being the only markup static across a whole board.
 func _on_board_loaded() -> void:
 	rebuild()
 	_apply_board_look()   # before fit_camera: the preset carries pitch/FOV, which framing reads
 	fit_camera()
 	_pointer_cell = BoardSpace.NO_CELL
-	_overlays.clear_all()
+	_overlays.clear(BoardOverlays.Layer.HOVER)
 
 
 # A board wears the look it names (#253 part 2). Deliberately "apply this preset" rather than

--- a/tests/presentation/test_board_overlays.gd
+++ b/tests/presentation/test_board_overlays.gd
@@ -27,6 +27,14 @@ func _overlays() -> BoardOverlays:
 	return _scene.get_node("BoardOverlays") as BoardOverlays
 
 
+# The sink deliberately has no whole-board wipe (#318): its layers are partitioned by writer, so
+# emptying all of them is always one writer reaching across that line. A sweep over every visible
+# quad still needs isolation, and arranging that is this suite's own business, not the sink's.
+func _empty_every_layer(overlays: BoardOverlays) -> void:
+	for layer: BoardOverlays.Layer in BoardOverlays.LAYERS.keys():
+		overlays.clear(layer)
+
+
 # --- Bracket tinting (#245) ---------------------------------------------------------
 
 func test_a_bracket_layer_can_be_recoloured_at_runtime() -> void:
@@ -117,7 +125,7 @@ func test_fill_quads_never_render_on_the_unit_layer() -> void:
 
 func test_set_cells_places_tinted_fills_at_the_cells() -> void:
 	var overlays := _overlays()
-	overlays.clear_all()  # the demo's zone patch legitimately coexists; isolate for the color sweep
+	_empty_every_layer(overlays)  # the demo's zone patch legitimately coexists; isolate for the color sweep
 	var cells: Array[Vector3i] = [Vector3i(2, 0, 2), Vector3i(3, 0, 2), Vector3i(9, 2, 3)]
 	overlays.set_cells(BoardOverlays.Layer.MOVE, cells)
 	assert_int(overlays.marker_count(BoardOverlays.Layer.MOVE)).is_equal(3)
@@ -186,15 +194,16 @@ func test_a_smaller_set_replaces_the_previous_one() -> void:
 	assert_int(overlays.cells_of(BoardOverlays.Layer.MOVE).size()).is_equal(1)
 
 
-func test_clear_and_clear_all_empty_the_layers() -> void:
+# Clearing is PER LAYER and reaches no further — the property the writer partition rests on
+# (#318). A clear that spilled into a neighbouring layer would desync whichever writer caches
+# for it, which is exactly the board-load bug in miniature.
+func test_clear_empties_its_own_layer_and_leaves_the_others_standing() -> void:
 	var overlays := _overlays()
 	overlays.set_cells(BoardOverlays.Layer.MOVE, [Vector3i(2, 0, 2)])
 	overlays.set_cells(BoardOverlays.Layer.ATTACK, [Vector3i(3, 0, 2)])
 	overlays.clear(BoardOverlays.Layer.MOVE)
 	assert_int(overlays.marker_count(BoardOverlays.Layer.MOVE)).is_equal(0)
 	assert_int(overlays.marker_count(BoardOverlays.Layer.ATTACK)).is_equal(1)
-	overlays.clear_all()
-	assert_int(overlays.marker_count(BoardOverlays.Layer.ATTACK)).is_equal(0)
 
 
 func test_hover_is_a_bracket_mesh_at_the_cell() -> void:

--- a/tests/presentation/test_input_bridge.gd
+++ b/tests/presentation/test_input_bridge.gd
@@ -77,6 +77,37 @@ func _click_lands_on(cell: Vector2i) -> bool:
 	return BoardSpace.flat(_scene._pick(_screen_of(cell))) == cell
 
 
+# A player unit that actually has somewhere to go. A different question from _pickable_player_unit
+# above (can the pointer reach it), and the one a case needs when it wants the move overlay PAINTED:
+# a unit stranded on a terrace with no ramp off it is perfectly clickable and produces no markup.
+func _mobile_player_unit() -> Unit:
+	for unit in _live_units():
+		if unit.get_faction() != Team.Faction.PLAYER:
+			continue
+		var reachable: Array[Vector2i] = _game.get_move_range(_game.compute_move_range(unit), unit)
+		if not reachable.is_empty():
+			return unit
+	return null
+
+
+# Markup aimed at the board that is about to die, painted through the MIRROR rather than poked into
+# the 3D sink by hand (#318): battle3d owns HOVER and nothing else now, so the guarantee that stale
+# markup does not survive a swap is carried by the mirror's own next push, and a precondition
+# reached by writing the sink directly would exercise a path production no longer has. MOVE is the
+# layer to watch precisely because no mission can paint one — "empty after" reads the swap, never
+# the content. selected_unit alongside enter_move_mode is the suite's idiom: the mode paints from
+# the unit it is handed, while HoverPresenter's own branch reads the stored selection every frame.
+func _paint_move_markup() -> void:
+	var unit := _mobile_player_unit()
+	assert_object(unit).is_not_null()   # fixture setup, not the claim under test
+	_game.selected_unit = unit
+	_game.enter_move_mode(unit)
+	await await_idle_frame()
+	await await_idle_frame()
+	assert_bool(_overlays.marker_count(BoardOverlays.Layer.MOVE) > 0).override_failure_message(
+			"no move markup to lose, so the swap assertion would pass vacuously").is_true()
+
+
 func _under_ui(screen_pos: Vector2) -> bool:
 	for node in _game.ui_layer.get_children():
 		var control := node as Control
@@ -395,7 +426,7 @@ func test_a_board_swap_rebuilds_the_mirror_through_the_load_funnel() -> void:
 	# closes: turn_started never fires on menu arrivals (#144), so before #222 the
 	# mirror, picker and pointer state stayed aimed at the dead board.
 	_scene._pointer_cell = Vector3i(0, 0, 0)   # stale pointer state aimed at Prolog
-	_overlays.set_cells(BoardOverlays.Layer.MOVE, [Vector3i(0, 0, 0)])
+	await _paint_move_markup()
 	_game.mission_controller.begin_mission(LEVEL_1)
 	await await_idle_frame()   # the swap's clear_board queue_frees the old roster
 	await await_idle_frame()
@@ -421,7 +452,7 @@ func test_spawn_sandbox_emits_the_same_rebuild() -> void:
 	# The one board build outside apply_scenario — reachable from the 3D view via the
 	# hidden Mission Select's Sandbox row, so it must speak the same signal.
 	_scene._pointer_cell = Vector3i(0, 0, 0)
-	_overlays.set_cells(BoardOverlays.Layer.MOVE, [Vector3i(0, 0, 0)])
+	await _paint_move_markup()
 	_game.spawn_sandbox()
 	await await_idle_frame()
 	await await_idle_frame()

--- a/tests/presentation/test_overlay_mirror.gd
+++ b/tests/presentation/test_overlay_mirror.gd
@@ -436,3 +436,35 @@ func test_exit_current_mode_clears_the_mirrored_layers() -> void:
 	assert_int(_overlays.cells_of(BoardOverlays.Layer.INVALID_MOVE).size()).is_equal(0)
 	assert_int(_overlays.cells_of(BoardOverlays.Layer.AIM).size()).is_equal(0)
 	assert_int(_overlays.markers_of(BoardOverlays.Layer.TARGET_PICK).size()).is_equal(0)
+
+
+# --- Board reload (#318) ------------------------------------------------------------
+
+# battle3d._on_board_loaded used to empty EVERY 3D layer while the mirror's push cache went on
+# saying it had already drawn them. apply_scenario is synchronous end to end, so the mirror never
+# observes the intermediate empty — it sees the same cells before and after, diffs equal, and the
+# wiped layer stays wiped for the life of the board. Zones are the visible casualty for being the
+# only markup static across a whole board; a gameplay layer self-heals within a click or two.
+#
+# Asserting the settled end state of a FIRST load passes against that bug (the cache starts empty),
+# so this reloads an UNCHANGED board through the real funnel: capture_scenario -> apply_scenario ->
+# board_loaded -> battle3d. The zones are hand-built rather than read off a mission, so nothing here
+# pins authored content — they round-trip through ScenarioData.zones like any other board content.
+func test_a_reload_of_an_unchanged_board_leaves_the_zone_fills_drawn() -> void:
+	game.zone_manager.load_dict({
+		"cap": {"kind": ZoneManager.Kind.CAPTURE, "cells": [Vector2i(1, 1), Vector2i(2, 1)]},
+	})
+	_om().redraw_zones(game.zone_manager)
+	await _settle()
+	var drawn := _sorted_3d(BoardOverlays.Layer.ZONE_CAPTURE)
+	assert_array(drawn).override_failure_message(
+			"nothing was drawn before the reload, so the reload could not lose it").is_not_empty()
+
+	var manager: ScenarioManager = game.scenario_manager
+	manager.apply_scenario(manager.capture_scenario("reload-test"))
+	await _settle()
+	# The 2D kept them, or the 3D would be right to be empty — assert the authority first.
+	assert_that(_lifted(_om().capture_overlay)).override_failure_message(
+			"the 2D lost the zones on reload, which is a different bug").is_equal(drawn)
+	assert_that(_sorted_3d(BoardOverlays.Layer.ZONE_CAPTURE)).override_failure_message(
+			"the board reloaded and its zones never came back in 3D").is_equal(drawn)


### PR DESCRIPTION
Closes #318.

## What was wrong

`battle3d._on_board_loaded` ended with `_overlays.clear_all()`, emptying every 3D layer while `OverlayMirror`'s push cache went on saying it had already drawn them. `apply_scenario` is synchronous end to end, so the mirror never observes the intermediate empty state — it sees the same cells before and after, diffs equal, and never re-pushes. Reloading an **unchanged** board left the layer empty for the life of that board.

Zones were the visible casualty for being the only markup static across a whole board. The gameplay layers repaint within a click or two, which is why it read as intermittent.

## The fix is an ownership rule, not a second reset

`BoardOverlays` has exactly two writers, and they partition it by layer:

- `battle3d` writes **one** layer — `HOVER`, the pointer bracket, the one layer deliberately not mirrored.
- `OverlayMirror` writes the other sixteen, caching what it has pushed.

So the defect is a one-layer writer issuing a whole-sink operation. `_on_board_loaded` now clears `HOVER` alone, which is all the pointer reset beside it ever needed — and it matches the idiom the same file already uses at its two other pointer-drop sites (`_apply_input_ownership`, `_update_pointer`).

Nothing wipes the mirror's layers any more, so cache and sink agree by construction. **`BoardOverlays.clear_all()` is deleted with it**: under the partition, emptying every layer at once is always one writer reaching across the line. A `reset()` list on the mirror — the other obvious fix — would have been the same hazard moved indoors, since the next cached channel someone forgets to add to it brings this bug straight back.

## Verification

`tests/presentation` — 227/227, 16/16 suites, in a clean worktree off `main`.

The regression case reloads an **unchanged** board through the real funnel (`capture_scenario -> apply_scenario -> board_loaded -> battle3d`) and asserts the zone fills are still drawn. Asserting the settled end state of a *first* load passes against this bug, since the cache starts empty. Zones are hand-built rather than read off a mission, so no authored content is pinned.

**Falsified**: with the old whole-sink clear restored, all 16 earlier cases in that suite still pass and exactly the new one reds — so it is not a truncation, and the case has teeth.

Two cases in `test_input_bridge` reached their precondition by poking the 3D sink directly, which is the path production no longer has. Both now paint through the mirror via a real move mode, and `MOVE` is the layer they watch because no mission can paint one — so "empty after the swap" reads the swap and never the content.

## Two things to know

**This stops masking #308.** A reload where a ramp's *rise* changed while the cell's `Vector3i` did not now leaves a stale tilt — #308's own mechanism, unchanged, previously invisible only because nothing repainted at all.

**Touches two files #329 also touches** (`BoardOverlays.gd`, `test_overlay_mirror.gd`), in different regions — the header and `clear_all` here, the render-priority band and an appended case there. Whichever lands second should check `git diff main...<branch> --stat` shows only its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
