### PR TITLE
Measure how the 3D authoring poll scales with board size (#319)

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -12,6 +12,12 @@ what you learn here so the next person doesn't repeat the run.
 2560 cells). Almost nothing is slow because of *data volume*. It's slow because a cheap operation
 is being repeated far more often than anyone intended — usually via a signal fan-out.
 
+**One measured exception, added 2026-08-16 — the 3D authoring poll (#319).** It is O(board) *per
+frame*, so it is the one place where data volume alone is the whole cost, and at 2560 cells it is
+already over a 60 fps frame budget. See that section below before assuming the paragraph above
+covers something you are looking at. The resize tool can also author boards **15× larger** than the
+2560 the sentence is written against.
+
 ---
 
 ## How to re-measure
@@ -235,3 +241,83 @@ A cheaper half-measure, if the cache looks like too much: flip `followable_desti
 to iterate *destinations × diamond* rather than *standable cells × diamond*. Same answer, and the
 single-cell query stops paying for the whole footprint — worth ~2.6 ms of the 6.8. It does not touch
 the duplicated `compute_move_range`, which is the real cost.
+
+---
+
+## 2026-08-16 — board size and the 3D authoring poll (#319)
+
+Reported as *"Resize Map does not work in 3D"*. It does — the dev re-tested and the board updates.
+What he actually hit is that a 200×200 board **lags the game to a crawl**, and the diagnosis he
+produced in play is what made this measurable: *dev mode on* → severe lag, *dev mode off* → mild,
+*zoom in* → gone. So the residual is rendering (GridMap frustum culling doing its job on 40,000
+visible tiles — correct behaviour, no fix owed), and the severe half is the poll.
+
+`battle3d._sync_terrain_while_authoring` runs **every frame** while `game_state == DEV_MODE` and
+performs **three full-board walks with no change detection**: `BoardMirror.sync`'s walk over
+`grid.get_used_cells()`, `sync`'s erase sweep over `board.get_used_cells()`, and `_refresh_tops()`'s
+third `get_used_cells()` inside `BoardPicker.column_tops_from` + `used_rect`.
+
+Re-measure with `tools/profile_board_scale.gd`. Three runs, agreeing inside this harness's usual
+~25% spread; ranges below span all three.
+
+| board | cells | poll per frame | µs/cell |
+|---|---|---|---|
+| **Prolog, as authored** | 2,560 (1,400 props) | **17.3 – 21.2 ms** | 7.4 |
+| 20×12 flat | 240 | 1.3 – 2.0 ms | 6.9 |
+| 40×40 flat | 1,600 | 9.3 – 11.5 ms | 6.5 |
+| 60×60 flat | 3,600 | 20.7 – 22.1 ms | 5.9 |
+| 80×80 flat | 6,400 | 38.3 – 42.4 ms | 6.3 |
+| 100×100 flat | 10,000 | 58.9 – 81.1 ms | 6.6 |
+| 150×150 flat | 22,500 | 136.2 – 203.0 ms | 6.7 |
+| 200×200 flat | 40,000 | 248.1 – 265.2 ms | 6.4 |
+| 100×100 all fence props | 10,000 | 80.2 – 106.6 ms | 8.6 |
+| 60×60 all tufts | 3,600 | 29.0 – 32.1 ms | 8.5 |
+
+**It is flatly linear at ~6.5 µs/cell**, props adding ~2 µs/cell on top. There is no algorithmic
+cliff to find and no cache-shaped surprise — the cost *is* the cell count, so the only levers are
+"walk fewer cells" or "walk them less often".
+
+### The number that matters: the authored board is already over budget
+
+**Prolog costs 17–21 ms per frame, and one 60 fps frame is 16.7 ms.** The 16.7 ms line falls at
+**~2,600 flat cells (≈51×51)**, and Prolog is 2,560 cells with 1,400 props. So this is not a
+200×200-only problem discovered by stress-testing: **sitting in dev mode on the shipped mission
+already spends a whole frame budget on a diff that usually finds nothing changed.** 200×200 is the
+same curve continued — ~255 ms/frame, about 15 frames of work per frame, which is the reported
+crawl and is exactly what linear scaling predicts.
+
+**This falsifies the natural first answer**, which was to cap the resize SpinBox
+(`TileBrushTool._build_extra_controls`, `max_value = 200`) and leave the poll alone. A cap set
+honestly against this curve would have to land near 50×50 — below sizes the dev may well want, and
+*still* leaving the authored board at 100% of frame budget. The cap is a guardrail; it is not the
+fix.
+
+**FIRST vs STEADY, because they are different costs.** The `sync` that actually writes a resized
+board is a one-off hitch (243 ms at 200×200, 304 ms for a 10,000-cell prop fill) — that one is
+inherent, it is the work of building the board. The steady figure above is the same walk on an
+**unchanged** board, i.e. pure tax. At 200×200 they are within a few percent of each other: the
+diff finds nothing and costs virtually the same as doing everything.
+
+### Reading these numbers honestly
+
+- **They are a FLOOR.** Headless does no drawing; a real frame also pays the render the dev's
+  zoom-in test isolated. The true knee sits at or below where this puts it.
+- **Debug build.** Measured through the Godot binary, not an export template, and GDScript is
+  slower in debug. An exported build would be cheaper by some unmeasured factor — but the dev
+  plays the debug build, so these are the numbers he experiences.
+- **Direct calls, not real frames**, so this cannot see a cost that only appears with
+  `OverlayMirror` and `_poll_pointer` running alongside. Both are proportional to overlay cells and
+  pointer movement rather than board size, so they should not bend the *shape* of the curve.
+
+### Why the poll is a poll (do not "fix" this by hooking the paint sites blindly)
+
+The `DEV_MODE` gate and the polling design are both deliberate and documented at
+`battle3d.gd:179`: `TileMapLayer.changed` does **not** fire on `set_cell`/`erase_cell` in 4.7
+(measured, with a property write as the control), so there was no engine signal to hang this on,
+and polling means no trigger site to remember when a future writer appears. That reasoning is
+still sound — what it never did was *bound* the cost, because every board it was designed against
+was small.
+
+If this is fixed by a dirty flag, note the writers it must cover: `DevController._paint`/`_erase`
+(terrain, states, zones, elevation) and `DevController.resize_map`. Board swaps do **not** need it
+— they already route through `board_loaded` → `battle3d.rebuild()`.

--- a/tools/profile_board_scale.gd
+++ b/tools/profile_board_scale.gd
@@ -1,0 +1,211 @@
+extends SceneTree
+
+# Headless profiler for how the 3D authoring poll scales with BOARD SIZE (#319).
+# See docs/performance.md for the recorded numbers and what they were used to decide.
+#
+#   godot --headless --path <repo> --script res://tools/profile_board_scale.gd
+#
+# Lives outside tests/ for the same reason profile_group_move.gd does: it extends SceneTree, not
+# GdUnitTestSuite, and the suite runner scans res://tests recursively. Shape copied from that file
+# per its own header -- boot the REAL scene, load a REAL mission, wrap the REAL call in
+# Time.get_ticks_usec().
+#
+# WHAT IS BEING MEASURED, and why these three calls. battle3d._sync_terrain_while_authoring runs
+# every frame while game_state == DEV_MODE and performs three full-board walks with no change
+# detection: BoardMirror.sync's walk over grid.get_used_cells(), sync's erase sweep over
+# board.get_used_cells(), and _refresh_tops()'s third get_used_cells() inside
+# BoardPicker.column_tops_from + used_rect. All three are O(board), so the poll's cost is set by
+# map size alone.
+#
+# FIRST vs STEADY is the split that matters, and they answer different questions:
+#   first  -- the one-off cost of the sync that actually writes the new board (the resize hitch).
+#   steady -- what the same walk costs on an UNCHANGED board, i.e. the per-frame tax you pay for
+#             every frame you sit in dev mode. This is the number the cap decision rests on.
+#
+# The figures are a FLOOR: headless skips the draw a real frame also pays.
+
+const MISSION := "res://Scenarios/missions/Prolog.tres"
+
+# Ascending on purpose: each resize GROWS the board, so no measurement is polluted by erasing the
+# previous size's leftover columns.
+const SIZES := [
+	Vector2i(20, 12),    # ~Prolog scale, the size every design assumption is written against
+	Vector2i(40, 40),
+	Vector2i(60, 60),
+	Vector2i(80, 80),
+	Vector2i(100, 100),
+	Vector2i(150, 150),
+	Vector2i(200, 200),  # what the SpinBox currently allows, and what the dev hit in play
+]
+
+const STEADY_SAMPLES := 4
+const PROP_SIZE := Vector2i(100, 100)
+# Smaller than PROP_SIZE deliberately: a tuft is one sprite PER DRAWN CLUSTER rather than one per
+# cell (#280), so a 10k-cell tuft fill is tens of thousands of nodes. 3600 is enough to read the
+# per-cell cost off, and the curve above is linear enough to scale it.
+const TUFT_SIZE := Vector2i(60, 60)
+
+var _scene: Node3D
+var _game: Node2D
+var _mirror: BoardMirror
+var _board: GridMap
+
+
+func _init() -> void:
+	_run.call_deferred()
+
+
+func _stamp(label: String, usec: int) -> void:
+	print("  %-44s %8.2f ms" % [label, usec / 1000.0])
+
+
+func _frames(n: int) -> void:
+	for i in range(n):
+		await process_frame
+
+
+# A tile to fill with, found in the TILESET rather than on the loaded board: whether Prolog happens
+# to paint a prop is authored content, and this must not depend on it (the content razor). `want` is
+# the PropShape to match, or -1 for "any flat ground". Returns {} when the sheet carries no such
+# tile, which the caller reports rather than guesses at.
+func _find_tile(want: int) -> Dictionary:
+	var tiles: TileSet = _game.grid.tile_set
+	for s in tiles.get_source_count():
+		var source_id := tiles.get_source_id(s)
+		var atlas := tiles.get_source(source_id) as TileSetAtlasSource
+		if atlas == null:
+			continue
+		for i in atlas.get_tiles_count():
+			var coords := atlas.get_tile_id(i)
+			var data := atlas.get_tile_data(coords, 0)
+			if data == null:
+				continue
+			if want == -1:
+				# A flat fill must be real ground, or the board is a field of unnamed decoration.
+				if GridUtils.stands_up_of(data) or GridUtils.terrain_kind_of(data) == Terrain.Kind.NONE:
+					continue
+			elif GridUtils.prop_shape_of(data) != want:
+				continue
+			return {"source": source_id, "coords": coords, "name": GridUtils.authored_tile_display_name(data)}
+	return {}
+
+
+# The poll's cost on the board exactly as the mission authored it -- no resize, no synthetic fill.
+# The most directly useful number here: it says what sitting in dev mode costs on real content
+# today, which is the thing any cap has to be judged against.
+func _measure_as_loaded() -> void:
+	print("\nAS AUTHORED (%s, no resize)" % MISSION.get_file())
+	var lo := 1 << 62
+	var hi := 0
+	for i in range(STEADY_SAMPLES):
+		var t := Time.get_ticks_usec()
+		_mirror.sync(_game.grid, _game.board_heights)
+		var spent := Time.get_ticks_usec() - t
+		lo = mini(lo, spent)
+		hi = maxi(hi, spent)
+	var t2 := Time.get_ticks_usec()
+	var tops := BoardPicker.column_tops_from(_board)
+	BoardPicker.used_rect(tops)
+	var tops_usec := Time.get_ticks_usec() - t2
+	print("  %-44s %8.2f - %.2f ms" % ["POLL TOTAL per frame", (lo + tops_usec) / 1000.0,
+		(hi + tops_usec) / 1000.0])
+	print("    2D cells = %d   3D cells = %d   props = %d" % [
+		_game.grid.get_used_cells().size(), _board.get_used_cells().size(), _mirror.prop_count()])
+
+
+# One board size, end to end. Returns nothing -- everything it learns it prints, because the whole
+# artifact of this tool is its transcript.
+func _measure(size: Vector2i, fill: Dictionary, label: String) -> void:
+	print("\n%s  %d x %d  (%d cells)" % [label, size.x, size.y, size.x * size.y])
+
+	var t := Time.get_ticks_usec()
+	_game.dev_controller.resize_map(size.x, size.y, fill.source, fill.coords)
+	_stamp("resize_map (the 2D store)", Time.get_ticks_usec() - t)
+
+	t = Time.get_ticks_usec()
+	_mirror.sync(_game.grid, _game.board_heights)
+	_stamp("sync -- FIRST (writes the new board)", Time.get_ticks_usec() - t)
+
+	var lo := 1 << 62
+	var hi := 0
+	for i in range(STEADY_SAMPLES):
+		t = Time.get_ticks_usec()
+		_mirror.sync(_game.grid, _game.board_heights)
+		var spent := Time.get_ticks_usec() - t
+		lo = mini(lo, spent)
+		hi = maxi(hi, spent)
+	print("  %-44s %8.2f - %.2f ms" % ["sync -- STEADY (per frame, unchanged board)", lo / 1000.0, hi / 1000.0])
+
+	# _refresh_tops split into its two halves, so the third walk is attributed rather than lumped
+	# in with the two inside sync().
+	t = Time.get_ticks_usec()
+	var tops := BoardPicker.column_tops_from(_board)
+	var tops_usec := Time.get_ticks_usec() - t
+	_stamp("column_tops_from (the third walk)", tops_usec)
+
+	t = Time.get_ticks_usec()
+	BoardPicker.used_rect(tops)
+	var rect_usec := Time.get_ticks_usec() - t
+	_stamp("used_rect", rect_usec)
+
+	print("  %-44s %8.2f - %.2f ms" % ["POLL TOTAL per frame (steady + tops + rect)",
+		(lo + tops_usec + rect_usec) / 1000.0, (hi + tops_usec + rect_usec) / 1000.0])
+	print("    2D cells = %d   3D cells = %d   props = %d" % [
+		_game.grid.get_used_cells().size(), _board.get_used_cells().size(), _mirror.prop_count()])
+
+
+func _run() -> void:
+	var packed := load("res://Scenes/Battle3D/Battle3D.tscn") as PackedScene
+	_scene = packed.instantiate() as Node3D
+	_scene.auto_play = false   # no AI churning mid-measure (the tests/presentation fixture's setting)
+	root.add_child(_scene)
+	await _frames(5)
+
+	_game = _scene.game
+	_scene.load_mission(MISSION)
+	await _frames(5)
+
+	_mirror = _scene.get_node("BoardMirror") as BoardMirror
+	_board = _scene.get_node("Board") as GridMap
+
+	# The gate the poll itself checks. Without it nothing below would ever run in the real game.
+	_game.game_state = _game.GameState.DEV_MODE
+
+	var flat := _find_tile(-1)
+	var prop := _find_tile(GridUtils.PropShape.PLANE)
+	var tuft := _find_tile(GridUtils.PropShape.TUFT)
+	if flat.is_empty():
+		print("ABORT: the tileset offers no flat ground tile to fill with")
+		quit(1)
+		return
+
+	print("mission   = ", MISSION)
+	print("fill      = %s (source %d, %s)" % [flat.name if flat.name != "" else "unnamed",
+		flat.source, flat.coords])
+	print("build     = ", Build.version())
+	print("\nAll figures are a FLOOR: headless does no drawing, a real frame also pays that.")
+
+	await _measure_as_loaded()
+
+	for size: Vector2i in SIZES:
+		await _measure(size, flat, "FLAT")
+		await process_frame
+
+	# The worse case the cap has to survive, if it exists. The dev's zoom-in test already argues
+	# props were not his cause, but a cap set against the cheap fill would be set too high.
+	if prop.is_empty():
+		print("\nPROP RUN SKIPPED: the tileset carries no PLANE-prop tile")
+	else:
+		print("\n--- solid prop fill: %s ---" % [prop.name if prop.name != "" else "unnamed"])
+		await _measure(PROP_SIZE, prop, "PROP")
+
+	# The expensive prop shape, and the reason #311 exists: one sprite per drawn cluster, not one
+	# per cell. Measured separately because a cap set against the fence would be set too high.
+	if tuft.is_empty():
+		print("\nTUFT RUN SKIPPED: the tileset carries no TUFT tile")
+	else:
+		print("\n--- tuft fill: %s ---" % [tuft.name if tuft.name != "" else "unnamed"])
+		await _measure(TUFT_SIZE, tuft, "TUFT")
+
+	print("\nPROFILE DONE")
+	quit(0)

--- a/tools/profile_board_scale.gd.uid
+++ b/tools/profile_board_scale.gd.uid
@@ -1,0 +1,1 @@
+uid://f6ravgp0fo3m


### PR DESCRIPTION
Measures how the 3D authoring poll scales with board size, so the #319 decision is made from a curve rather than from judgment. **No production behaviour changes.**

## Why this is a measurement and not a fix

#319's stated mechanism is void. It claims `resize_map` never reaches the 3D board because the live poll is `DEV_MODE`-gated — but `DevController.brush_armed()` reads the *same* predicate, so "the poll is dead" and "painting is dead" are one state, and painting in 3D works. The dev re-tested: the resize does reach the board. What he hit at 200×200 was lag.

His own three data points split the cause cleanly: dev mode **on** → severe lag, **off** → mild, **zoom in** → gone. That isolates the poll from rendering, and shows the rendering residual is GridMap frustum culling working correctly on 40,000 visible tiles — no fix owed there.

## What it found

`tools/profile_board_scale.gd` follows `profile_group_move.gd`'s shape (its header says to copy it): boot the real `Battle3D` scene, load real Prolog, wrap the real calls in `Time.get_ticks_usec()`. Three runs, agreeing inside this harness's usual ~25% spread.

| board | cells | poll per frame |
|---|---|---|
| **Prolog, as authored** | 2,560 | **17.3 – 21.2 ms** |
| 40×40 flat | 1,600 | 9.3 – 11.5 ms |
| 60×60 flat | 3,600 | 20.7 – 22.1 ms |
| 100×100 flat | 10,000 | 58.9 – 81.1 ms |
| 200×200 flat | 40,000 | 248.1 – 265.2 ms |

Flatly linear at **~6.5 µs/cell** — no algorithmic cliff, the cost *is* the cell count.

**The headline is not the 200×200 case.** One 60 fps frame is 16.7 ms; that line falls at ~2,600 cells, and Prolog is 2,560. **Sitting in dev mode on the shipped mission already spends a whole frame budget on a diff that usually finds nothing changed.** 200×200 is just the same line continued to ~15 frames of work per frame, which is the reported crawl.

## What that rules out

Capping the resize SpinBox and leaving the poll alone — the cheap answer going in, and the one I expected to recommend. A cap set honestly against this curve lands near 50×50, below sizes that may be wanted, and *still* leaves the authored board at 100% of budget. The cap is a guardrail, not the fix.

The doc records what a dirty-flag fix would have to cover, and why the polling design was right to begin with (`TileMapLayer.changed` does not fire on `set_cell` in 4.7 — measured; the poll's flaw is that it was never *bounded*, not that it was a poll).

## Verification

- Probe run 3×; ranges above span all three runs.
- Non-vacuity: 240 → 40,000 cells is 167×, and 1.7 → 255 ms is 150× — the curve tracks cell count, so the probe is measuring the thing it claims to.
- Cross-checks against play: 200×200 predicting ~4 fps matches the reported crawl, and the dev-mode-on/off split matches which half this measures.
- Stated in the doc rather than buried: these are a **floor** (headless does no drawing) and a debug build.
- No suite run — nothing under `Classes/`, `Scenes/` or `tests/` is touched. CI owns the tree.

## Follow-ups this hands over, both the dev's call

1. The SpinBox cap, now that there is a number to set it from.
2. Whether to bound the poll (dirty flag) — which the Prolog figure argues is the real ticket.

#319 needs its body rewritten either way; its current text sends the next reader after a wire that works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
