### PR TITLE
Dev mode says which state it is in: a banner in the window, a badge on screen

### DIFF
--- a/Classes/dev/DevOverlay.gd
+++ b/Classes/dev/DevOverlay.gd
@@ -17,6 +17,15 @@ class_name DevOverlay
 @onready var scenario_tool: ScenarioTool = get_node("%Scenario")
 @onready var look_tool: LookTool = get_node("%Look")
 @onready var dev_mode_toggle: CheckButton = %DevModeToggle
+@onready var dev_mode_banner: PanelContainer = %DevModeBanner
+
+# The banner's two faces. Dev chrome, not the HD-2D look stack -- no mission wears these and
+# LookKnobs has no business holding them, so they are consts here rather than Look-tab knobs.
+const DEV_MODE_ON_BG := Color(0.55, 0.16, 0.62)
+const DEV_MODE_OFF_BG := Color(0.14, 0.14, 0.16)
+
+var _banner_on: StyleBoxFlat
+var _banner_off: StyleBoxFlat
 
 # The running Battle3D, pushed in by attach_3d_host below; null under a flat Main.tscn launch.
 # Any tab needing the 3D world reads it from here.
@@ -26,6 +35,11 @@ func _ready() -> void:
 	if not DevTools.enabled():
 		queue_free()   # a demo build constructs no dev tools (#132)
 		return
+	_build_banner_styles()
+	# The toggle FOLLOWS the intent rather than being pushed at. set_dev_mode called this directly
+	# until the 3D badge needed the same fact; one emit, every listener.
+	game.dev_mode_changed.connect(sync_dev_mode_button)
+	sync_dev_mode_button(game.dev_mode_enabled)
 	scenario_tool.init(scenario_manager, game)
 	spawn.init(game)
 	unit_editor.init(game)
@@ -106,8 +120,26 @@ func show_beside():
 	show()
 	_update_zone_visibility()
 
+# The banner SAYS its state three ways -- switch position, word, and background colour -- because
+# the switch alone was what the dev could not read at a glance. The word is the load-bearing one.
 func sync_dev_mode_button(active: bool):
 	dev_mode_toggle.set_pressed_no_signal(active)
+	dev_mode_toggle.text = "DEV MODE: ON" if active else "DEV MODE: OFF        (F1)"
+	dev_mode_banner.add_theme_stylebox_override("panel", _banner_on if active else _banner_off)
+
+# Built rather than authored: a StyleBoxFlat in the scene would be one resource, and the banner
+# needs two to swap between. NOT a ColorPicker in sight -- that family is banned from this window
+# (CLAUDE.md "Sharp edges", #212).
+func _build_banner_styles() -> void:
+	_banner_on = _banner_style(DEV_MODE_ON_BG)
+	_banner_off = _banner_style(DEV_MODE_OFF_BG)
+
+func _banner_style(bg: Color) -> StyleBoxFlat:
+	var box := StyleBoxFlat.new()
+	box.bg_color = bg
+	box.set_content_margin_all(6.0)
+	box.set_corner_radius_all(4)
+	return box
 
 func _on_dev_mode_toggled(pressed: bool):
 	game.set_dev_mode(pressed)

--- a/Scenes/Battle3D/Battle3D.tscn
+++ b/Scenes/Battle3D/Battle3D.tscn
@@ -99,4 +99,14 @@ offset_right = 900.0
 offset_bottom = 44.0
 theme_override_font_sizes/font_size = 12
 
+[node name="DevMode" type="Label" parent="UI" unique_id=1734820957]
+visible = false
+offset_left = 8.0
+offset_top = 44.0
+offset_right = 900.0
+offset_bottom = 70.0
+theme_override_colors/font_color = Color(1, 0.45, 0.95, 1)
+theme_override_font_sizes/font_size = 18
+text = "● DEV MODE"
+
 [node name="Main" parent="." unique_id=933466344 instance=ExtResource("7")]

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -71,6 +71,7 @@ var _help_wheel_is_level := false
 @onready var _camera: Camera3D = $CameraRig/Pitch/Camera
 @onready var _help: Label = $UI/Help
 @onready var _checkout: Label = $UI/Checkout
+@onready var _dev_badge: Label = $UI/DevMode
 
 var game: Node2D
 var _game_container: SubViewportContainer
@@ -106,6 +107,8 @@ func _ready() -> void:
 	if dev_overlay is DevOverlay:
 		(dev_overlay as DevOverlay).attach_3d_host(self)
 	_show_checkout()
+	game.dev_mode_changed.connect(_show_dev_badge)
+	_show_dev_badge(game.dev_mode_enabled)
 	if demo_mode:
 		_game_container.visible = false
 		_help.text = "Battle3D mirror (demo mode, read-only)  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset"
@@ -647,6 +650,18 @@ func _show_checkout() -> void:
 	var stamp := Checkout.describe()
 	_checkout.visible = stamp != ""
 	_checkout.text = stamp
+
+
+# IS DEV MODE ON — the badge is PRESENT or it is not, so there is no off-state to misread. Reads
+# the INTENT off game.dev_mode_changed, never game_state == DEV_MODE: that one is derived and
+# drops out the moment any other mode is entered, so a badge on it would blink off mid-click.
+#
+# A third label in the same stack for _show_checkout's reason: this CanvasLayer draws above the 2D
+# game's container in every hosting view, so one node covers HD_2D and FLAT_2D alike (#292) --
+# and a word appended to the help line is invisible in a 140-character string, which is the
+# problem this is fixing rather than a shape to copy.
+func _show_dev_badge(active: bool) -> void:
+	_dev_badge.visible = active
 
 
 # SPACE means two things, and dev mode wins — exactly how game.gd's own SPACE arm resolves

--- a/Scenes/DevOverlay.tscn
+++ b/Scenes/DevOverlay.tscn
@@ -39,10 +39,15 @@ grow_vertical = 2
 [node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer" unique_id=2047553017]
 layout_mode = 2
 
-[node name="DevModeToggle" type="CheckButton" parent="Panel/MarginContainer/VBoxContainer" unique_id=1234134320]
+[node name="DevModeBanner" type="PanelContainer" parent="Panel/MarginContainer/VBoxContainer" unique_id=1234134321]
 unique_name_in_owner = true
 layout_mode = 2
-text = "Dev Mode Toggle"
+
+[node name="DevModeToggle" type="CheckButton" parent="Panel/MarginContainer/VBoxContainer/DevModeBanner" unique_id=1234134320]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 20
+text = "DEV MODE: OFF        (F1)"
 
 [node name="DevTabs" type="TabContainer" parent="Panel/MarginContainer/VBoxContainer" unique_id=1062693858]
 unique_name_in_owner = true
@@ -492,7 +497,7 @@ layout_mode = 2
 script = ExtResource("7_look1")
 metadata/_tab_index = 6
 
-[connection signal="toggled" from="Panel/MarginContainer/VBoxContainer/DevModeToggle" to="." method="_on_dev_mode_toggled"]
+[connection signal="toggled" from="Panel/MarginContainer/VBoxContainer/DevModeBanner/DevModeToggle" to="." method="_on_dev_mode_toggled"]
 [connection signal="text_changed" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/UnitNameInput" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" method="_on_unit_name_input_text_changed"]
 [connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/WeaponRow/WeaponDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" method="_on_weapon_dropdown_item_selected"]
 [connection signal="item_selected" from="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn/SpriteRow/SpriteDropdown" to="Panel/MarginContainer/VBoxContainer/DevTabs/Unit Authoring/AuthoringTabs/Spawn" method="_on_sprite_dropdown_item_selected"]

--- a/game.gd
+++ b/game.gd
@@ -48,6 +48,10 @@ enum GameState {
 }
 
 var game_state: GameState = GameState.IDLE
+# The dev INTENT changed. ONE notification path for it: set_dev_mode used to push straight into
+# dev_overlay.sync_dev_mode_button, and a second consumer (the 3D badge) would have made that push
+# one of two ways the same fact travels. Both listeners connect; nothing polls.
+signal dev_mode_changed(active: bool)
 # Dev INTENT (the toggle), written only by set_dev_mode. game_state == DEV_MODE is where the board
 # RESTS right now; the two split (declared, Law #4) because transient flows -- loads, turn handoffs,
 # mission ends -- reset game_state, and the board must return to _base_state() so dev mode survives
@@ -559,8 +563,7 @@ func set_dev_mode(active: bool):
 	# Intent first: exit_current_mode's clear_selection rests the board on _base_state.
 	dev_mode_enabled = active
 	exit_current_mode()
-	if dev_overlay != null:
-		dev_overlay.sync_dev_mode_button(active)
+	dev_mode_changed.emit(active)
 
 func exit_current_mode():
 	if game_state == GameState.ATTACK_TARGETING:

--- a/tests/dev/test_dev_mode_persistence.gd
+++ b/tests/dev/test_dev_mode_persistence.gd
@@ -57,3 +57,22 @@ func test_the_turn_handoff_returns_to_dev_mode() -> void:
 	await game.start_faction_turn(Team.Faction.PLAYER)
 
 	assert_int(game.game_state).is_equal(game.GameState.DEV_MODE)
+
+# The dev window's banner FOLLOWS the intent. set_dev_mode pushed straight into the overlay until
+# the 3D badge needed the same fact; it emits dev_mode_changed now and both listeners connect, so
+# this is a WIRE case -- drop DevOverlay's connect and the toggle silently stops tracking F1 while
+# every other case above still passes. The text is asserted only for the WORD, since the switch
+# graphic alone is what the dev could not read; nothing here pins wording beyond ON/OFF.
+func test_the_dev_window_banner_follows_the_toggle() -> void:
+	var overlay: DevOverlay = game.dev_overlay
+	assert_object(overlay).is_not_null()
+
+	game.set_dev_mode(true)
+
+	assert_bool(overlay.dev_mode_toggle.button_pressed).is_true()
+	assert_str(overlay.dev_mode_toggle.text).contains("ON")
+
+	game.set_dev_mode(false)
+
+	assert_bool(overlay.dev_mode_toggle.button_pressed).is_false()
+	assert_str(overlay.dev_mode_toggle.text).contains("OFF")

--- a/tests/presentation/test_dev_mode_readout.gd
+++ b/tests/presentation/test_dev_mode_readout.gd
@@ -1,0 +1,78 @@
+# The game window says when dev mode is on.
+#
+# A WIRE suite, the shape of test_build_readout.gd next door and for the same reason: game.gd can
+# emit dev_mode_changed perfectly and the badge can exist, while nothing joins the two. Delete the
+# connect line in battle3d._ready and every other suite in the tree still passes -- #103 exactly.
+#
+# The REAL scene, so what is asserted is the node that ships: a Label authored into Battle3D.tscn
+# under the UI CanvasLayer, which draws above the 2D game's container in every hosting view, so
+# one node serves HD_2D and FLAT_2D alike (#292). Whether it READS as unmissable is the dev's, by
+# playing; nothing here pins a colour, a size or an offset.
+extends GdUnitTestSuite
+
+const SCENE_PATH := "res://Scenes/Battle3D/Battle3D.tscn"
+
+var _scene: Node3D
+var _game: Node2D
+
+
+func before_test() -> void:
+	get_tree().root.size = Vector2i(1280, 720)
+	var packed := load(SCENE_PATH) as PackedScene
+	_scene = packed.instantiate() as Node3D
+	_scene.auto_play = false
+	get_tree().root.add_child(_scene)
+	await await_idle_frame()
+	_game = _scene.game
+
+
+func after_test() -> void:
+	get_tree().root.remove_child(_scene)
+	_scene.free()
+
+
+func test_the_badge_is_absent_until_dev_mode_is_turned_on() -> void:
+	# Presence IS the signal (dev call), so "off" has to be genuinely nothing on screen.
+	var badge: Label = _scene.get_node("UI/DevMode")
+	assert_bool(badge.visible).is_false()
+
+	_game.set_dev_mode(true)
+
+	assert_bool(badge.visible).is_true()
+	assert_str(badge.text).is_not_empty()
+
+
+func test_turning_dev_mode_off_takes_the_badge_away() -> void:
+	var badge: Label = _scene.get_node("UI/DevMode")
+	_game.set_dev_mode(true)
+
+	_game.set_dev_mode(false)
+
+	assert_bool(badge.visible).is_false()
+
+
+# The badge reads the INTENT, not game_state == DEV_MODE. The two split on purpose (game.gd's own
+# note): game_state is where the board RESTS, so it leaves DEV_MODE the moment any mode is entered
+# and a badge driven off it would blink out mid-interaction. Direct-set here deliberately -- the
+# claim under test is that this write does NOT reach the badge.
+func test_the_badge_follows_the_toggle_and_not_the_board_state() -> void:
+	var badge: Label = _scene.get_node("UI/DevMode")
+	_game.set_dev_mode(true)
+
+	_game.game_state = _game.GameState.CHOOSING_MOVE
+
+	assert_bool(badge.visible).is_true()
+
+
+func test_the_badge_is_a_label_of_its_own_and_not_a_field_of_the_help_line() -> void:
+	# Structural, and load-bearing for the same reason the checkout readout's twin case is: the
+	# help line is rewritten wholesale in demo_mode and rebuilt on every binding change, so a
+	# dev-mode word carried inside it is one edit away from vanishing again.
+	var help: Label = _scene.get_node("UI/Help")
+	var badge: Label = _scene.get_node("UI/DevMode")
+	assert_object(badge).is_not_same(help)
+
+	_game.set_dev_mode(true)
+
+	assert_bool(help.visible).is_true()   # the help line is untouched by the badge's arrival
+	assert_bool(badge.visible).is_true()

--- a/tests/presentation/test_dev_mode_readout.gd.uid
+++ b/tests/presentation/test_dev_mode_readout.gd.uid
@@ -1,0 +1,1 @@
+uid://xt8rlycx5hrf


### PR DESCRIPTION
You said you keep getting caught out not knowing whether dev mode is on. Two causes, both fixed here.

## What changed

**The dev-window toggle is now a banner.** It was a default `CheckButton` labelled "Dev Mode Toggle" — the only state signal was the small switch graphic, and the label named the control rather than its state. It is now 20pt, wrapped in a `PanelContainer` whose background flips colour, and it says what it *is*: `DEV MODE: ON` / `DEV MODE: OFF        (F1)`. Three redundant tells — switch, word, colour.

**The game window carries a badge.** A `● DEV MODE` label in `Battle3D`'s `UI` CanvasLayer, third in the stack under Help and the checkout readout. It is **present when dev mode is on and absent otherwise** — presence is the whole signal, so there is no off-state to misread and nothing added to the view during normal play.

One badge covers both hosting views: that CanvasLayer draws above the 2D game's container in every mode, which is the same fact `_show_checkout()` already relies on to survive F4 into `FLAT_2D` (#292 parity by construction). A bare `Main.tscn` launch has no badge — the same declared gap the checkout readout carries.

## The seam

`set_dev_mode` used to **push** straight into `dev_overlay.sync_dev_mode_button`. Adding a second consumer would have made that push one of two ways the same fact travels, so `game.gd` now declares `signal dev_mode_changed(active: bool)` and emits it; `DevOverlay` and `battle3d` both connect, the direct push is gone, and nothing polls.

Both surfaces read the **intent** (`game.dev_mode_enabled`), never the derived `game_state == DEV_MODE` — that one drops out the moment any other mode opens, so a badge on it would blink off mid-click. Note `battle3d._help_dev_mode` does read `game_state`, deliberately: the help line's question is "what does SPACE do right now", which is a different question and stays separate.

## Knobs, if these read wrong

Both colours are named consts, a one-line change each:

- `DevOverlay.DEV_MODE_ON_BG` / `DEV_MODE_OFF_BG` — the banner's two backgrounds.
- `theme_override_colors/font_color` on `UI/DevMode` in `Battle3D.tscn` — the badge, and its `offset_top`/`font_size` if the position or size is off.

These are dev chrome rather than the HD-2D look stack — no mission wears them — so they deliberately get no Look-tab knob.

## Verification

`tests/dev` 169/169 and `tests/presentation` 235/235 green. The full tree is CI's.

New wire suite `tests/presentation/test_dev_mode_readout.gd` (4 cases) and one case added to `tests/dev/test_dev_mode_persistence.gd`. Both wires falsified:

- Cutting `battle3d`'s connect reds the badge suite at its first case.
- Cutting `DevOverlay`'s connect reds the new banner case while the four pre-existing persistence cases stay green — that is the wire the direct push used to carry.

Nothing pins a colour, font size or offset (tuning razor). **Whether it now reads as unmissable is yours, by playing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
