### PR TITLE
A dip is a column, not a miss: the picker stops reading level 0 as nothing (#294)

### DIFF
--- a/Classes/presentation/BoardPicker.gd
+++ b/Classes/presentation/BoardPicker.gd
@@ -20,6 +20,16 @@ class_name BoardPicker
 #   as an analytic plane intersection before or after it, so a real column in front
 #   of a hole still wins by ray order rather than by a hand-written comparison.
 #   The rect is the caller's policy (board + authoring apron), never derived here.
+# - A LEVEL IS A NUMBER, NOT A TRUTH VALUE (#294): "nothing here" is NO_COLUMN, so every level in
+#   range — 0 and below included — is an ordinary answer. Nothing may gate on `level > 0`.
+
+# "There is no column here" (#294). A DECLARED sentinel because 0 is a legitimate top — a cell one
+# deep occupies [-1..0], so its surface sits at 0 — and while 0 meant both, a dip was
+# unrepresentable: inside the plane it read as flat, outside it it was unclickable. Widening the
+# comparisons instead would only move the collision down to -1. -999 is BoardSpace.NO_CELL's
+# convention on the level axis (far outside any authorable board; the brush spans -99..99), and
+# _top_cell already turns a level near it into a cell whose y IS NO_CELL.y.
+const NO_COLUMN := -999
 
 const _EPS := 1e-8
 const _MAX_STEPS := 4096
@@ -32,8 +42,9 @@ static func column_tops_from(board: GridMap) -> Dictionary[Vector2i, int]:
 	for cell in board.get_used_cells():
 		var column := BoardSpace.flat(cell)
 		var top := cell.y + 1
-		var existing: int = tops.get(column, 0)
-		if top > existing:
+		# ABSENCE is the table's own "no column", so the seed has to be the key test rather than a
+		# value: seeded at 0, a dipped column's top of 0 lost `0 > 0` and never entered the table.
+		if not tops.has(column) or top > tops[column]:
 			tops[column] = top
 	return tops
 
@@ -43,13 +54,13 @@ static func column_tops_from(board: GridMap) -> Dictionary[Vector2i, int]:
 #
 # Walks UP from the shared floor and stops at the first gap. That is exact rather than approximate
 # because BoardMirror._write_column fills floor..level contiguously; a column with a hole in it
-# would be a bug there, not a case to tolerate here. Returns 0 for "no column", matching the
-# absent-key reading the tops table already has.
+# would be a bug there, not a case to tolerate here. Returns NO_COLUMN for "no column" — the
+# scalar twin of the absent key the tops table uses, and never a level a real column could have.
 static func top_of(board: GridMap, column: Vector2i, floor_level: int) -> int:
 	var y := floor_level
 	while board.get_cell_item(Vector3i(column.x, y, column.y)) != GridMap.INVALID_CELL_ITEM:
 		y += 1
-	return y if y > floor_level else 0
+	return y if y > floor_level else NO_COLUMN
 
 
 # The columns a tops table covers, as a rect — position = lowest column, and the rect
@@ -66,7 +77,11 @@ static func used_rect(tops: Dictionary[Vector2i, int]) -> Rect2i:
 	return Rect2i(lo, hi - lo + Vector2i.ONE)
 
 
-# The tallest column's top level; 0 for an empty table (no column, no height).
+# The tallest column's top level, never below 0 — an empty table has no height, and an all-dipped
+# board rises no further than the ground plane it was cut into. That floor is a DECLARED clamp and
+# not the #294 sentinel: both readers want it. pick_cell uses this as an early-out ceiling, where
+# over-estimating costs a few walk steps and under-estimating loses hits; battle3d._board_volume
+# measures its AABB upward from 0, and a negative height is not a volume.
 static func max_top(tops: Dictionary[Vector2i, int]) -> int:
 	var tallest := 0
 	for column: Vector2i in tops.keys():
@@ -107,7 +122,7 @@ static func pick_cell(ray_origin: Vector3, ray_direction: Vector3, tops: Diction
 	if absf(dir.x) < _EPS and absf(dir.z) < _EPS:
 		var column := Vector2i(floori(ray_origin.x / cs), floori(ray_origin.z / cs))
 		var level := _top_level(column, tops, plane)
-		if level == 0:
+		if level == NO_COLUMN:
 			return BoardSpace.NO_CELL
 		var h: float = level * cs
 		if ray_origin.y <= h or dir.y < 0.0:
@@ -128,7 +143,7 @@ static func pick_cell(ray_origin: Vector3, ray_direction: Vector3, tops: Diction
 			return BoardSpace.NO_CELL  # level or rising, already above every top
 		var t_exit := minf(t_max_x, t_max_z)
 		var level := _top_level(col, tops, plane)
-		if level > 0:
+		if level != NO_COLUMN:
 			var h: float = level * cs
 			var y_exit := ray_origin.y + dir.y * t_exit
 			if y_enter <= h or y_exit <= h:
@@ -147,13 +162,13 @@ static func pick_cell(ray_origin: Vector3, ray_direction: Vector3, tops: Diction
 
 
 # What the ray can hit in this column: the painted column's top level, else the plane's
-# implicit floor, else 0 = nothing here. The one place the fallback is decided.
+# implicit floor, else NO_COLUMN = nothing here. The one place the fallback is decided.
 static func _top_level(column: Vector2i, tops: Dictionary[Vector2i, int], plane: Rect2i) -> int:
 	if tops.has(column):
 		return tops[column]
 	if plane.has_point(column):
 		return BoardSpace.FLAT_TOP_LEVEL
-	return 0
+	return NO_COLUMN
 
 
 # The columns the walk may visit. Generous is safe (the hit test still needs a level),

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -249,7 +249,9 @@ func _update_tops(columns: Array[Vector2i], floor_level: int) -> void:
 	var shrank := false
 	for column in columns:
 		var top := BoardPicker.top_of($Board, column, floor_level)
-		if top > 0:
+		# NO_COLUMN, never `> 0` (#294): a dipped column's top IS 0, so the old gate sent it down
+		# the erase branch — the poll did not merely miss a dip, it removed one already in _tops.
+		if top != BoardPicker.NO_COLUMN:
 			var known := _tops.has(column)
 			_tops[column] = top
 			if not known:

--- a/docs/design/verticality.md
+++ b/docs/design/verticality.md
@@ -389,7 +389,11 @@ Godot emits a press *and* a release per notch. Four rulings worth keeping:
 
 - **Negative levels are reachable, deliberately.** The dev: *"if I start designing a level and want a
   dip, without allowing negatives, I would have to shift everything up. no bueno."* Nothing in
-  `can_step` cares — its only arithmetic is equality and ±1, which is symmetric about zero.
+  `can_step` cares — its only arithmetic is equality and ±1, which is symmetric about zero. The 3D
+  PICKER did care, until [#294](https://github.com/Phaazoid/Godoiosis/issues/294): a column one
+  deep tops out at level `0`, which was also its "there is no column here" answer, so a dip read as
+  flat inside the authoring apron and was unclickable outside it. `BoardPicker.NO_COLUMN` separates
+  the two — **a level is a number, not a truth value**, and nothing may gate on `level > 0`.
 - **Elevation goes with the ground.** `BoardHeights.prune_groundless` runs at both sites the tile-state
   sweep does (brush erase, `resize_map`), because a height under no tile is invisible junk that
   resurrects the moment ground is repainted there. The predicate is a **parameter**, not an injected

--- a/tests/presentation/test_board_picker.gd
+++ b/tests/presentation/test_board_picker.gd
@@ -26,6 +26,13 @@ var _holed_tops: Dictionary[Vector2i, int] = {
 	Vector2i(0, 0): 1, Vector2i(2, 0): 1,
 }
 
+# The same strip with (1, 0) DIPPED one deep — #260's negative elevation, and the shape a top
+# level of 0 could not describe while 0 also meant "nothing here". Note it is a different fixture
+# from _holed_tops on purpose: a dip and a hole are the two answers the sentinel used to conflate.
+var _dipped_tops: Dictionary[Vector2i, int] = {
+	Vector2i(0, 0): 1, Vector2i(1, 0): 0, Vector2i(2, 0): 1,
+}
+
 
 func _apron_of(tops: Dictionary[Vector2i, int]) -> Rect2i:
 	return BoardPicker.used_rect(tops).grow(APRON)
@@ -156,6 +163,39 @@ func test_used_rect_and_max_top_describe_the_tops_table() -> void:
 	assert_int(BoardPicker.max_top(empty)).is_equal(0)
 
 
+# --- A dip is a column, not a miss (#294) --------------------------------------
+#
+# Level 0 used to be BOTH a legitimate top (a cell one deep: it occupies [-1..0], so its surface
+# sits at 0) and the "no column here" answer, which made a dip unrepresentable by construction.
+# NO_COLUMN is the separation; these are the cases that can tell the two apart.
+
+func test_a_one_deep_dip_is_a_column_and_not_a_hole() -> void:
+	# Columns only, so no plane can answer on the dip's behalf — a top of 0 has to stand alone.
+	var cell := BoardPicker.pick_cell(Vector3(1.5, 10.0, 0.5), Vector3.DOWN, _dipped_tops, Rect2i())
+	assert_that(cell).is_equal(BoardSpace.of_cell(Vector2i(1, 0), -1))
+
+
+func test_a_dip_inside_the_plane_reads_as_the_dip_and_not_as_flat() -> void:
+	# The dev-authoring case, and the one that fails PLAUSIBLY rather than loudly: with the column
+	# missing from the table, _top_level falls through to the plane's FLAT_TOP_LEVEL and the click
+	# resolves one level too high. A wrong cell, not a miss — so the brush paints the wrong thing.
+	var cell := BoardPicker.pick_cell(Vector3(1.5, 10.0, 0.5), Vector3.DOWN, _dipped_tops,
+			_apron_of(_dipped_tops))
+	assert_that(cell).is_equal(BoardSpace.of_cell(Vector2i(1, 0), -1))
+	assert_int(cell.y).override_failure_message(
+			"the dip resolved at its flat neighbours' level").is_equal(-1)
+
+
+func test_a_ray_clearing_the_rim_strikes_the_dips_own_cell() -> void:
+	# The walk's hit test at h == 0, reached the way a real camera reaches it: over the near rim
+	# (both ends above the neighbours' top, so they do not answer) and down through the dip's
+	# surface. Skipping the column entirely walks the ray on to the FAR rim, which is a wrong
+	# answer rather than a miss.
+	var cell := BoardPicker.pick_cell(Vector3(0.0, 3.2, 0.5), Vector3(1.0, -2.0, 0.0),
+			_dipped_tops, Rect2i())
+	assert_that(cell).is_equal(BoardSpace.of_cell(Vector2i(1, 0), -1))
+
+
 # --- The seam where it lives: the look-dev scene -------------------------------
 
 var _scene: Node3D
@@ -247,3 +287,41 @@ func test_occluded_cell_yields_the_blocker_not_the_hidden_cell() -> void:
 	assert_that(BoardPicker.pick_cell(
 			camera.project_ray_origin(screen), camera.project_ray_normal(screen), tops,
 			BoardPicker.used_rect(tops).grow(APRON))).is_equal(picked)
+
+
+# --- The two adapters, against a real GridMap (#294) ---------------------------
+
+# One cell written at `level` in a column clear of everything the board already holds. The
+# column is DERIVED from the board's own footprint and the item id read off a real cell, so
+# nothing authored is named or asserted — and the scene is instantiated per test and freed
+# after, so nothing authored is mutated either.
+func _dip_a_fresh_column(board: GridMap, level: int) -> Vector2i:
+	var used := board.get_used_cells()
+	assert_bool(used.is_empty()).override_failure_message(
+			"the look-dev board is empty, so writing beside it proves nothing").is_false()
+	var column := BoardPicker.used_rect(BoardPicker.column_tops_from(board)).end + Vector2i(2, 2)
+	board.set_cell_item(BoardSpace.of_cell(column, level), board.get_cell_item(used[0]))
+	return column
+
+
+func test_column_tops_from_reads_a_column_that_dips_below_zero() -> void:
+	# A cell at y = -1 tops out at 0, which is a real surface. The accumulator seeded at 0 and
+	# compared with `>` dropped exactly the columns whose top IS 0, and only those.
+	var board := _scene.get_node("Board") as GridMap
+	var column := _dip_a_fresh_column(board, -1)
+	var tops := BoardPicker.column_tops_from(board)
+	assert_bool(tops.has(column)).override_failure_message(
+			"the dipped column is missing from the tops table").is_true()
+	assert_int(tops[column]).is_equal(0)
+
+
+func test_top_of_answers_a_dip_and_keeps_no_column_a_separate_answer() -> void:
+	# The incremental twin (#319) carried the same sentinel, and its caller ERASES on it — so a
+	# dip painted onto an already-dipped board was actively removed, not merely never added.
+	# The pair is the claim: a real top of 0 and "nothing here" must not be the same int.
+	var board := _scene.get_node("Board") as GridMap
+	var column := _dip_a_fresh_column(board, -1)
+	assert_int(BoardPicker.top_of(board, column, -1)).override_failure_message(
+			"a column one cell deep read as no column at all").is_equal(0)
+	assert_int(BoardPicker.top_of(board, column + Vector2i(1, 0), -1)).override_failure_message(
+			"an empty column stopped saying it was empty").is_equal(BoardPicker.NO_COLUMN)

--- a/tests/presentation/test_input_bridge.gd
+++ b/tests/presentation/test_input_bridge.gd
@@ -784,3 +784,38 @@ func test_the_other_paint_modes_leave_the_wheel_to_the_camera() -> void:
 
 		assert_float(_rig()._target_distance).override_failure_message(
 				"an armed brush in mode %d swallowed the camera's zoom" % mode).is_less(zoom_before)
+
+
+# ---- a dip stays on the board (#294) ----
+#
+# Driven through the AUTHORITY -- game.board_heights -> DirtyCells -> the DEV_MODE authoring poll
+# -> BoardPicker.top_of -> battle3d._update_tops. Poking _tops or calling _update_tops by hand
+# would prove both ends and not the wire, which is #103's shape.
+#
+# TWO cells, in this order, and the order is the whole point: the FIRST dip lowers the shared
+# floor, and a moved floor is the one edit no cell list can describe, so the poll full-syncs
+# through column_tops_from. Only the SECOND dip -- floor already negative -- is reconciled
+# incrementally, which is the only way to reach top_of at all.
+
+func test_painting_a_dip_leaves_its_column_on_the_board() -> void:
+	var cells: Array[Vector2i] = _game.grid.get_used_cells()
+	assert_bool(cells.size() > 1).override_failure_message(
+			"the mission paints fewer than two cells, so the two-dip ordering proves nothing").is_true()
+	var floor_first := cells[0]
+	var incremental := cells[1]
+	_game.game_state = _game.GameState.DEV_MODE
+
+	_game.board_heights.set_cell(floor_first, -1, Terrain.RampRise.NONE)
+	await _pump()
+	_game.board_heights.set_cell(incremental, -1, Terrain.RampRise.NONE)
+	await _pump()
+
+	# A cell one deep occupies [-1..0], so its top level IS 0 -- the value that used to mean
+	# "no column here" and take the column out of the picker's reach.
+	var tops: Dictionary[Vector2i, int] = _scene._tops
+	assert_bool(tops.has(floor_first)).override_failure_message(
+			"the first dip left the tops table: column_tops_from dropped it on the full sync").is_true()
+	assert_int(tops[floor_first]).is_equal(0)
+	assert_bool(tops.has(incremental)).override_failure_message(
+			"the second dip left the tops table: the incremental poll erased it").is_true()
+	assert_int(tops[incremental]).is_equal(0)


### PR DESCRIPTION
Closes #294.

## The bug

`0` did double duty in `BoardPicker` — a column whose top surface sits at `y = 0`, and *"there is no column here"*. A cell one deep occupies `[-1..0]`, so its top level **is** 0, which made a dip **unrepresentable by construction**: the type could not tell it from a miss.

That is authorable today. #260 made negative elevation deliberate — *"if I start designing a level and want a dip, without allowing negatives, I would have to shift everything up. no bueno."* — `BoardMirror._write_column` drops the shared floor to hold one, and #285/#340 made painting it in the 3D view the natural way to author it.

| cell | column cells written | top cell | `top` | in the tops table? |
|---|---|---|---|---|
| elevation `0` | `y = -1, 0` | `0` | `1` | yes |
| elevation `-1` (dip) | `y = -1` only | `-1` | `0` | **no** |

**Two symptoms, and the wrong one is the worse one.** Inside the authoring apron the dipped column was absent from the table, so `_top_level` fell through to the plane's `FLAT_TOP_LEVEL` — the cell read as **flat** and a click resolved one level too high. A wrong answer, not a refusal, so the brush paints the wrong thing. Outside the apron the walk's `level > 0` gate skipped the column and the ray passed straight through.

## The fix

Widening `>` to `>=` was rejected: it moves the collision down one and leaves the identical bug at `-1`. The fix is the sentinel — **`BoardPicker.NO_COLUMN`** (`-999`, `BoardSpace.NO_CELL`'s convention on the level axis), the scalar twin of the absent key the tops table already uses, so a level's value range stops carrying two meanings. Stated in the file header as a semantics rule: **a level is a number, not a truth value**, and nothing may gate on `level > 0`.

**Six sites, re-derived from the code — the issue's own list was short by two,** because #319 landed `BoardPicker.top_of` after #294 was filed:

1. `column_tops_from`'s accumulator seed → the key test, not a value
2. `top_of`'s return
3. `_top_level`'s fallthrough
4. `pick_cell`'s near-vertical branch
5. `pick_cell`'s DDA walk gate
6. `battle3d._update_tops`

That last one matters more than it looks: it gates on `top > 0` and **erases** in its `elif`, so on a board whose floor is already negative the authoring poll did not merely fail to add a dip — it *removed* one `column_tops_from` had put there.

**`max_top` is deliberately unchanged, and now says so.** Its `0` floor is not this sentinel: it is a clamp both readers want. `pick_cell` uses it as an early-out ceiling (over-estimating is free, under-estimating loses hits), and `battle3d._board_volume` measures an AABB upward from 0.

Checked and untouched: `used_rect`/`_extent` read keys only, `_top_cell` is pure arithmetic, and both LookDev demos use `tops.has()` throughout.

## Tests

`test_board_picker` had **no negative-level case at all** — every fixture sat at or above 0. Five added:

- three pure ray cases against a dipped strip: straight down, the plane-fallback case that fails *plausibly*, and a ray clearing the rim to reach the hit test at `h == 0`;
- the two adapters against a real `GridMap`, writing one cell beside the look-dev board's own footprint so nothing authored is named, asserted or mutated (the content razor). The `top_of` case asserts the **pair** — a real top of 0 *and* "nothing here" — because either half alone goes green under a collapsed sentinel.

The **wire** case is in `test_input_bridge`, driven through `game.board_heights` → `DirtyCells` → the DEV_MODE poll → `top_of` → `_update_tops`. **Two cells, and the order is the point:** the first dip *lowers the shared floor*, which no cell list can describe, so the poll full-syncs through `column_tops_from`. Only the second dip reaches the incremental path at all.

**presentation 250/250, 0 orphans.** Three mutants, each run in isolation, each redding only the case aimed at:

| mutant | reds |
|---|---|
| `top_of` → `else 0` | the empty-column half of the pair, and only that |
| `column_tops_from`'s seed | the adapter case |
| `battle3d`'s gate → `top > 0` | the wire case, on its `incremental` assert — while the full-sync assert still passes, confirming the two-cell ordering reaches the path it claims to |

## Not built, flagged

`battle3d._board_volume` still measures its AABB upward from `y = 0`, so a dipped board's camera bounds do not reach below the ground plane. Unchanged by this PR (dipped columns don't beat `max_top`'s 0) and a different question — framing, not picking. Worth its own ticket if it bothers you once a dip is authored.

## To feel-check

You are on `294-dip-sentinel`. Paint a cell to elevation `-1` in the 3D dev view, then click it — before this it either read as flat (inside the apron) or ignored the click entirely.

— Claude (Opus 5) · 2026-08-16
