### PR TITLE
One fact, one marking: retire the target reticle (#346)

### DIFF
--- a/Classes/actions/OrderExecutor.gd
+++ b/Classes/actions/OrderExecutor.gd
@@ -99,8 +99,10 @@ func execute_orders(unit):
 #
 # set_has_acted does most of the visual work for free -- Squad._set_has_acted clears the queue, and
 # every action_cancelled hop lands in game._on_unit_action_cancelled, which is what pulls a move's
-# ghost and arrow. The icon clear ahead of it is for the TARGET markers a queued attack drew; the
-# success path also clears them before it animates, and clearing twice is idempotent.
+# ghost and arrow. The icon clear ahead of it is for the crown/squadmate markers the squad's own
+# display left; the success path also clears them before it animates, and clearing twice is
+# idempotent. (It read "the TARGET markers a queued attack drew" until #346 -- TARGET was never
+# drawn by an attack, only by Squad Up, and it is retired now.)
 func _end_squad_turn(squad: Squad) -> void:
 	game.clear_selection_icons()
 	for action in squad.action_queue.duplicate():

--- a/Classes/board/OverlayIcon.gd
+++ b/Classes/board/OverlayIcon.gd
@@ -1,16 +1,21 @@
 extends Node2D
 class_name OverlayIcon
 
+# One marker hung on a UNIT rather than a cell: a Sprite2D plus the cell it was anchored to.
+# Built and pooled by OverlayManager (icons_by_unit), and mirrored into the 3D as a billboard
+# above the unit's head by OverlayMirror._icons -> BoardOverlays.Layer.ICONS.
+
 @onready var sprite = $Sprite2D
 var icon_type
 var target_cell: Vector2i
 
+# The above-the-head channel: what a unit IS, never what the current interaction is about
+# (#346 -- ground markup carries the interaction). CURSOR/TARGET/INVALID lived here and are
+# retired: CURSOR and INVALID never had a producer, and TARGET duplicated the target-pick
+# ground marker. Ordinals are read by OverlayMirror's z-stagger and persisted nowhere.
 enum IconType {
-	CURSOR,
 	CROWN,
-	TARGET,
-	INVALID,
-	SQUADMEMBER	
+	SQUADMEMBER
 }
 
 func setup(texture: Texture2D, cell: Vector2i, type: IconType):

--- a/Classes/board/OverlayManager.gd
+++ b/Classes/board/OverlayManager.gd
@@ -58,7 +58,6 @@ const ATLAS_COORDS = Vector2i(0,0)          # plain fill — what every overlay 
 # (1,0) is the marker tile on the AttackOverlay's sheet — #316: this read (3,0) since before the
 # reorg, a coord the one-tile sheet never had, so the highlight drew in NEITHER view.
 const TARGET_ATLAS_COORDS = Vector2i(1, 0)  # the "pick this unit" marker (PICKING_TARGET)
-const ICON_Z_INDEX = 15
 
 const PROJECTED_MODULATE := Color(0.7, 0.9, 1, 0.75)        # the planning-ghost tint
 const PROJECTED_HIGHLIGHT := Color(1.4, 1.4, 1.0, 1.0)      # brightened + opaque on hover
@@ -93,10 +92,7 @@ enum OverlayType {
 }
 
 const ICON_TEXTURES = {
-	OverlayIcon.IconType.CURSOR: preload("res://Art/Icons/BoardIcons/CursorIcon.png"),
 	OverlayIcon.IconType.CROWN: preload("res://Art/Icons/BoardIcons/CrownIcon.png"),
-	OverlayIcon.IconType.TARGET: preload("res://Art/Icons/BoardIcons/SelectedIcon.png"),
-	OverlayIcon.IconType.INVALID: preload("res://Art/Icons/BoardIcons/NegativeIcon.png"),
 	OverlayIcon.IconType.SQUADMEMBER: preload("res://Art/Icons/BoardIcons/SquadHighlightIcon.png")
 }
 
@@ -405,7 +401,7 @@ func redraw_planned_paths():
 	for action in planned_move_by_unit.values():
 		draw_path_arrows(action)
 
-func create_unit_icon(unit: Unit, type: OverlayIcon.IconType, offset := Vector2i.ZERO) -> OverlayIcon:
+func create_unit_icon(unit: Unit, type: OverlayIcon.IconType) -> OverlayIcon:
 	if unit == null:
 		return null
 		
@@ -419,7 +415,7 @@ func create_unit_icon(unit: Unit, type: OverlayIcon.IconType, offset := Vector2i
 	icon_overlay.add_child(icon)
 	var cell := unit.get_projected_destination()
 	icon.setup(ICON_TEXTURES[type], cell, type)
-	icon.position = board_tilemap.map_to_local(cell) #+ offset
+	icon.position = board_tilemap.map_to_local(cell)
 	
 	icons_by_unit[unit][type] = icon
 	return icon

--- a/Classes/presentation/OverlayMirror.gd
+++ b/Classes/presentation/OverlayMirror.gd
@@ -38,7 +38,7 @@ var _last_markers: Dictionary[BoardOverlays.Layer, Array] = {}
 var _last_ghosts: Array[Dictionary] = []
 var _last_fire: Array[Vector2i] = []
 var _last_cover: Array[Vector2i] = []
-var _pick_texture: Texture2D   # the (3,0) "pick this unit" tile art, cut lazily
+var _pick_texture: Texture2D   # the (1,0) "pick this unit" tile art, cut lazily
 
 # Every value-diff below is blind to the board's HEIGHTS (#308): a fill's tilt and a flame's
 # footing both come from BoardHeights, and neither is in the cells being compared. Gated on the
@@ -166,7 +166,7 @@ func _fill(layer: BoardOverlays.Layer, used: Array[Vector2i]) -> void:
 	overlays.set_cells(layer, cells, _heights())
 
 
-# ATTACK is dual-use in 2D: reach fill at (0,0), target-pick markers at (3,0) on the
+# ATTACK is dual-use in 2D: reach fill at (0,0), target-pick markers at (1,0) on the
 # same layer — split by atlas coords; the heal-green arrives as the layer modulate.
 #
 # The reach half hands its cells to _fill rather than lifting and diffing them here: a hand-copied

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -7,7 +7,7 @@ its child [#49 Action Queue UX](https://github.com/Phaazoid/Godoiosis/issues/49)
 This is a *guidelines* doc, not a spec — it captures the principles we're holding the work to,
 plus the running order of the queue-UX checklist. Update it as items land.
 
-**Canon checked through #314 (2026-08-15).**
+**Canon checked through #346 (2026-08-16).**
 
 ## Principles
 
@@ -172,7 +172,8 @@ The rulings, all dev calls, all made before building:
   belongs to the scene, not to the glass. Consequence to accept: it shrinks as you zoom out.
 - **Two flat colours, never a ramp.** Fill is what the unit HAS, red backing is what it has lost.
   A bar that also changes hue as it shortens says the same thing twice.
-- **It stacks UNDER the selection icons.** Crown/squadmate/target on top, health tucked beneath.
+- **It stacks UNDER the selection icons.** Crown/squadmate on top, health tucked beneath. (The
+  target reticle was in that list until #346 retired it to the ground channel — see below.)
 
 Three findings that generalise past this ticket:
 
@@ -197,6 +198,34 @@ Three findings that generalise past this ticket:
 Law #2 made visible) and [#314](https://github.com/Phaazoid/Godoiosis/issues/314) (Fire Emblem-style
 tick blocks that explosively fall away). [#188](https://github.com/Phaazoid/Godoiosis/issues/188)
 wants damage numbers in the same volume and should share whatever event seam #313 needs.
+
+## Two marker channels, one rule ([#346](https://github.com/Phaazoid/Godoiosis/issues/346))
+
+The volume above finally has a rule about what may occupy it, and it came from measuring rather
+than arguing. [#316](https://github.com/Phaazoid/Godoiosis/issues/316) made the target-pick GROUND
+marker visible for the first time (it had pointed at an atlas coord the sheet never had), and Squad
+Up then marked every candidate twice — a tile under the recruit and an `IconType.TARGET` billboard
+over its head. Seeing both at once, the dev's call was that **the ground one reads better**.
+
+- **Ground / tile = what this INTERACTION is about.** Transient, mode-scoped, cursor-driven:
+  pickable candidates, reach, selection, the cells a thing would affect.
+- **Above the head = what this UNIT IS.** Persistent, mode-independent: element states, downed /
+  maimed, Crisis, and the hover health readout #229 already put there.
+
+**Retired by this rule:** `IconType.TARGET`, whose only producer was `draw_create_squad` — the
+target-pick ground marker is now the single answer to *which unit may I pick*. `CURSOR` and
+`INVALID` went with it as never-produced leftovers. **Not decided here:** `CROWN` and
+`SQUADMEMBER`, which are [#325](https://github.com/Phaazoid/Godoiosis/issues/325)'s call — that
+ticket picks squad membership's 3D form, and this rule is an input to it, not a ruling over it.
+
+Two things the retirement exposed, both worth keeping in mind. **The head icon was never the
+general answer**: TARGET was created in exactly one flow, so rescue, intimidate and join-squad had
+their candidates marked *nowhere in either view* until #316, and Squad Up only looked right because
+someone had patched that one screen. And **the first real occupant of the freed channel is blocked
+on art, not on design** — a unit's `element_states` are hover-only today (`StateIcons.populate`,
+called from the two panels and nowhere else), so a Wet unit and a dry one are identical on the
+board; `StateIcons.ICONS` carries art for WET alone and everything else falls back to a text label.
+Making it always-on is also exactly the trigger #229 named for the crowding question it deferred.
 
 ## #44 board-side items (cross-referenced, not in this doc's running order)
 

--- a/game.gd
+++ b/game.gd
@@ -937,14 +937,13 @@ func draw_squad_leader_range(squad: Squad, cell: Vector2i):
 
 func draw_create_squad(unit: Unit):
 	var cells: Array[Vector2i] = []
-	# Subject = the forming leader; the per-RECRUIT gate is can_squad_up below, which asks the
-	# recruit's own path. The bubble is where a squad could stand, the icons are who may join.
+	# Subject = the forming leader; the per-RECRUIT gate is can_squad_up, asked by the
+	# enter_target_pick_mode candidate query below. The bubble is where a squad could stand;
+	# WHO may join is marked on the ground by that mode (#346 -- this loop used to hang a
+	# TARGET icon over each recruit as well, two markings of one fact).
 	for cell in SquadCohesion.cells(unit.squad, unit.get_projected_destination(), unit, _board()):
-		var target_unit = get_unit_at_cell(cell)
 		if cell != unit.movement.cell:
 			cells.append(cell)
-		if target_unit != null and squad_manager.can_squad_up(target_unit, unit.squad):
-			overlay_manager.create_unit_icon(target_unit, OverlayIcon.IconType.TARGET)
 	overlay_manager.show_overlay(OverlayManager.OverlayType.SQUAD, cells, OverlayManager.ATLAS_COORDS)
 
 func draw_joinable_squads(joining_unit: Unit):
@@ -977,7 +976,7 @@ func clear_icons(icons: Array[OverlayIcon.IconType]):
 # literal sent that way never gets coerced to clear_icons' typed parameter (it fails at
 # runtime, not at parse time). Keeping the literal on this side of the boundary avoids it.
 func clear_selection_icons() -> void:
-	clear_icons([OverlayIcon.IconType.CROWN, OverlayIcon.IconType.SQUADMEMBER, OverlayIcon.IconType.TARGET])
+	clear_icons([OverlayIcon.IconType.CROWN, OverlayIcon.IconType.SQUADMEMBER])
 
 # ==============================================================================
 #  Board queries

--- a/tests/ui/test_target_pick_projection.gd
+++ b/tests/ui/test_target_pick_projection.gd
@@ -195,3 +195,31 @@ func test_a_two_tile_shove_draws_an_unbroken_arrow_trail() -> void:
 	for cell in [BODY_CELL, Vector2i(2, 0), LANDING_CELL]:
 		assert_bool(drawn.has(cell)) \
 			.override_failure_message("no arrow sprite on %s -- the trail has a gap" % cell).is_true()
+
+
+# One fact, one marking (#346). Squad Up used to hang an IconType.TARGET billboard over every
+# recruit AND mark its cell through enter_target_pick_mode -- invisible while #316 had the ground
+# marker pointing at an atlas coord the sheet never had, and two markings the moment it wasn't.
+# Driven through game.create_squad rather than the overlay calls, because the duplicate lived in
+# the ORDER of one flow's two halves, which is exactly what a direct call skips.
+func test_squad_up_marks_a_candidate_on_the_ground_and_not_over_its_head() -> void:
+	var leader := _spawn(Team.Faction.PLAYER, Vector2i(2, 0))
+	var recruit := _spawn(Team.Faction.PLAYER, Vector2i(3, 0))
+	await await_idle_frame()
+
+	game.create_squad(leader)
+	await await_idle_frame()
+
+	assert_int(game.game_state).override_failure_message(
+			"Squad Up did not open the pick mode -- the rest of this case proves nothing") \
+			.is_equal(game.GameState.PICKING_TARGET)
+	assert_array(game.target_pick_cells).override_failure_message(
+			"the recruit is not a candidate -- fixture, not the rule under test") \
+			.contains([recruit.movement.cell])
+
+	var om: OverlayManager = game.overlay_manager
+	assert_that(om.attack_overlay.get_cell_atlas_coords(recruit.movement.cell)) \
+		.override_failure_message("the recruit's cell carries no ground marker") \
+		.is_equal(OverlayManager.TARGET_ATLAS_COORDS)
+	assert_bool(om.icons_by_unit.has(recruit)).override_failure_message(
+			"the recruit is ALSO marked over the head -- two markings of one fact").is_false()


### PR DESCRIPTION
Slice 1 of #346 — the retirement plus the canon entry. The element-states half stays out (it needs art for every state but WET, and it trips the crowding question #229 deferred).

## The duplicate

Since #316 made the target-pick ground marker visible, `create_squad` marked every candidate **twice**: `draw_create_squad` hung an `IconType.TARGET` billboard over each recruit, then `enter_target_pick_mode` marked the same cells. Two answers to *which unit may I pick*. Seeing both at once, the dev's call was that the ground one reads better.

Worth recording what the retirement exposed: **`IconType.TARGET` had exactly one producer in the whole codebase**, that Squad Up flow. Rescue, Intimidate and Join Squad all ride the same pick mode and never got it — so before #316 their candidates were marked *nowhere in either view*, and Squad Up only looked right because someone had patched that one screen. The head reticle was never the general answer.

## What changed

- `draw_create_squad` creates no icons; the ground marker is the single answer. TARGET leaves `clear_selection_icons` with it.
- `IconType` drops TARGET, and **CURSOR and INVALID go too** — both had entries in `ICON_TEXTURES` and **no `create_unit_icon` caller anywhere**. CROWN and SQUADMEMBER stay; they are #325's business, not this ticket's.
- Adjacent dead code in the same block: `ICON_Z_INDEX` (zero readers) and `create_unit_icon`'s `offset` parameter (assignment commented out, no caller passes it). Say the word if you'd rather those rode a separate diff.
- `docs/design/visual-clarity.md` carries the rule beside #229's *volume above a unit*: **ground = what the interaction is about, head = what the unit IS.** Marker bumped to #346; the one stale phrase elsewhere in that doc ("crown/squadmate/target on top") corrected.
- `OverlayMirror`'s two comments still called the pick tile (3, 0) — stale from my own #316, fixed here.

**Renumbering consequence, accepted:** `OverlayMirror._icons` staggers billboards by `float(type) * 0.02`, so CROWN moves 0.02 → 0.00 and SQUADMEMBER 0.08 → 0.02. They stay 0.02 apart, which is all the stagger is for, and both sit under `billboard_lift` 1.1. The ordinals are persisted nowhere — grepped `Resources/` and `Scenarios/`, no `IconType` in any `.tres`.

## Verification

- New case in `tests/ui/test_target_pick_projection.gd`, driven through `game.create_squad` rather than the overlay calls — the duplicate lived in the *order of one flow's two halves*, which a direct call skips. It asserts both: the recruit's cell carries `TARGET_ATLAS_COORDS`, and `icons_by_unit` holds nothing for that recruit.
- **Falsified twice, each alone:** re-marking the recruit over the head reds it, and painting the pick cells with the plain fill instead of the marker tile reds it. Only that case goes red either way.
- `tests/ui` + `tests/presentation` **429/429**. CI owns the tree.
- **Not checked here:** whether Squad Up still reads clearly with only the ground marker. That's a look, and it's yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
