### PR TITLE
Post-review cleanup: a dead seam, two typing nits, two test guards

### DIFF
--- a/Classes/board/BoardContext.gd
+++ b/Classes/board/BoardContext.gd
@@ -59,12 +59,6 @@ func projected_unit_at_cell(cell: Vector2i) -> Unit:
 func terrain_kind_at(cell: Vector2i) -> Terrain.Kind:
 	return GridUtils.get_terrain_kind_at_cell(grid, cell)
 
-# The rules' single read-point for "is there ground here" (#245) — sibling of terrain_kind_at,
-# same rationale: a method, not an inline grid read, so a fixture board can stub it. A tile state
-# modifies what happens when a unit WALKS on a tile, so a cell with no tile has nothing to modify.
-func has_ground(cell: Vector2i) -> bool:
-	return GridUtils.has_ground(grid, cell)
-
 # The rules' single read-point for a cell's terrain DEF (#84): a Burrow-dug COVER tile shelters
 # whoever stands on it. Sibling of terrain_kind_at, same rationale — the resolver's mitigation
 # stage and the inspect panel's DEF readout both come through here, so they can't drift.

--- a/Classes/board/CursorController.gd
+++ b/Classes/board/CursorController.gd
@@ -1,6 +1,9 @@
 extends Node2D
 class_name CursorController
 
+# The 2D board cursor: one sprite marking the hovered cell, and what KIND of thing sits under the
+# pointer. A child of Game, written only by HoverPresenter -- one set_state per hover branch.
+
 @onready var sprite: Sprite2D = $CursorSprite
 @onready var board_tilemap = $"../Grid"
 
@@ -19,11 +22,10 @@ const CURSOR_TEXTURES = {
 	CursorState.VALID: preload("res://Art/Icons/BoardIcons/PositiveIcon.png")
 }
 
-# Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	sprite.texture = CURSOR_TEXTURES[CursorState.DEFAULT]
 
-func set_cursor_pos(cell: Vector2i):
+func set_cursor_pos(cell: Vector2i) -> void:
 	sprite.position = board_tilemap.map_to_local(cell)
 
 # The last state set. STORED, because the 3D bracket mirrors this answer instead of re-deriving
@@ -31,12 +33,12 @@ func set_cursor_pos(cell: Vector2i):
 # the #232 shape. This used to swap the texture and throw the fact away.
 var state: CursorState = CursorState.DEFAULT
 
-func set_state(new_state: CursorState):
+func set_state(new_state: CursorState) -> void:
 	state = new_state
 	sprite.texture = CURSOR_TEXTURES[new_state]
 
-func hide_cursor():
+func hide_cursor() -> void:
 	sprite.visible = false
-	
-func show_cursor():
+
+func show_cursor() -> void:
 	sprite.visible = true

--- a/Classes/core/GridUtils.gd
+++ b/Classes/core/GridUtils.gd
@@ -56,8 +56,9 @@ static func cardinal_direction_i_between(from_cell: Vector2i, to_cell: Vector2i)
 	var dir := cardinal_direction_between(from_cell, to_cell)
 	return Vector2i(int(dir.x), int(dir.y))
 
-# Is there a tile here AT ALL (#245)? The one implementation of the question; BoardContext.has_ground
-# is the rules layer's read-point onto it and TerrainStateManager's ground_source is wired from it.
+# Is there a tile here AT ALL (#245)? The one implementation of the question, called directly by
+# everyone who asks it -- TerrainStateManager's ground_source is wired from it, and the dev pruner
+# and BoardMirror reach it from where they stand.
 # Deliberately the SOURCE id, not get_cell_tile_data: a headless fixture grid has cells placed but no
 # TileSet to read custom data from, so the tile-data form would call every fixture cell groundless.
 # A null grid cannot judge, so it does not — no board means no forbid, which is what keeps the

--- a/Classes/presentation/UnitHealthBar.gd
+++ b/Classes/presentation/UnitHealthBar.gd
@@ -70,6 +70,7 @@ var _has_prediction := false
 var _number_shown := true
 
 var _alarm: Tween
+var _alarm_peak_live := Color(1.0, 1.0, 1.0, 1.0)   # the peak the RUNNING tween was started with
 # Every input the drawing reads, snapshotted (#313). UnitMirror pushes style, HP and prediction
 # every frame for every SHOWN bar, and a redraw resizes five meshes and measures the label's AABB —
 # fine for the single hovered bar #229 shipped, N times a frame once a plan puts one over everybody.
@@ -190,15 +191,24 @@ func set_shown(shown: bool) -> void:
 
 # Idempotent because it is TOLD every frame: start once, stop once. Pulse.stop writes the base value
 # back through alarm_color's setter, so the segment lands on its resting colour with no extra paint.
+# A tween carries the peak it STARTED with, so a peak retuned mid-pulse restarts it -- a Look knob
+# that only lands at the next alarm reads as a dead slider.
 func set_alarm(on: bool) -> void:
+	if on and _alarm != null and _alarm_peak_live != _alarm_peak_color:
+		_stop_alarm()
 	if on == (_alarm != null):
 		return
 	if on:
 		alarm_color = _segment_color()
+		_alarm_peak_live = _alarm_peak_color
 		_alarm = Pulse.start(self, self, &"alarm_color", _segment_color(), _alarm_peak_color)
 	else:
-		Pulse.stop(_alarm, self, &"alarm_color", _segment_color())
-		_alarm = null
+		_stop_alarm()
+
+
+func _stop_alarm() -> void:
+	Pulse.stop(_alarm, self, &"alarm_color", _segment_color())
+	_alarm = null
 
 
 # Turn the WHOLE readout to face the camera, once, instead of letting each part billboard itself.

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -430,8 +430,8 @@ func _setup_corner() -> void:
 func _position_pip() -> void:
 	if view != View.CORNER:
 		return
-	var view: Vector2 = get_viewport().get_visible_rect().size
-	_game_container.position = view - _pip_native * pip_scale - pip_margin
+	var viewport_size: Vector2 = get_viewport().get_visible_rect().size
+	_game_container.position = viewport_size - _pip_native * pip_scale - pip_margin
 
 
 # The board-visual set, hidden as a unit so the 2D layer reads as pure UI.

--- a/tests/ui/test_right_click_cancel.gd
+++ b/tests/ui/test_right_click_cancel.gd
@@ -179,7 +179,7 @@ func test_a_group_move_pops_as_one_gesture() -> void:
 	# reason BaseAction.batch_id exists. Popping member-by-member would leave a half-dissolved
 	# formation the validator then has to refuse.
 	var units := _player_units()
-	assert_int(units.size()).is_greater(1)   # the sandbox must field a squad-able pair
+	assert_int(units.size()).is_greater(2)   # the sandbox must field units[1] and units[2]
 
 	# join_squad is the production call the squad-up target pick closes over (game.gd:792).
 	var leader := units[1]
@@ -211,7 +211,12 @@ func test_hold_fillers_are_never_what_a_press_pops() -> void:
 	# Activating a squad queues a hold for every member with no move. Those are not orders, and
 	# cancelling one only makes cancel_move_for_unit queue another -- a press that "undid" one
 	# would look like a dead button. Nothing to undo must stay nothing to undo.
+	#
+	# The FILTER is asserted directly below, and that is deliberate: a filler is stamped batch_id 0
+	# because setup_hold_move_actions calls squad._queue_action past queue_action's door, so
+	# last_gesture_actions is the whole rule. The press half cannot reach it -- see the note there.
 	var units := _player_units()
+	assert_int(units.size()).is_greater(2)   # the sandbox must field units[1] and units[2]
 	var leader := units[1]
 	game.squad_manager.join_squad(units[2], leader.squad)
 	game.squad_manager.setup_hold_move_actions(leader.squad)
@@ -220,6 +225,13 @@ func test_hold_fillers_are_never_what_a_press_pops() -> void:
 	assert_int(_real_orders(leader.squad).size()).is_equal(0)
 
 	assert_array(game.squad_manager.last_gesture_actions(leader.squad)).is_empty()
+
+	# A squad holding NOTHING BUT fillers is unreachable in play -- revert_if_only_hold clears the
+	# queue and drops active_squad the moment the last real order leaves. So this press runs against
+	# a null active_squad and returns at _pop_last_gesture's first guard; it pins that the outer
+	# guard holds, NOT that the filter does. Asserted rather than left implied, because a reader
+	# would otherwise take the untouched queue below for evidence the filter ran.
+	assert_object(game.squad_manager.active_squad).is_null()
 
 	game._on_right_click()
 


### PR DESCRIPTION
Cleanup from a spot-check review of six merged PRs (#230, #248, #268, #305, #331, #349). Five items, each too small to carry a ticket. **No behaviour change except the last one.**

## What's in it

**1. `BoardContext.has_ground()` deleted** — added by #248, zero callers ever since. Every real caller reaches `GridUtils.has_ground` directly (`game.gd:133`, `play/board_builder.gd:63`, `BoardMirror.gd:365`, `DevController.gd:405`), and the rules layer asks through `TerrainStateManager.ground_source`. Its `terrain_kind_at`/`cover_def_at` siblings stay — they have callers. `GridUtils`' own comment pointed at it and now doesn't.

**2. The `view` shadow** (#230) — `battle3d._position_pip` declared `var view: Vector2` two lines under a read of the `@export var view: View` member it shadows. Renamed to `viewport_size`. #230 renamed this same local in its test and missed the source.

**3. `CursorController`** — the file had no header comment, so per `CLAUDE.md` a touched `Classes/` file gets one; plus `-> void` on its four setters.

**4. Two test size guards** (#305) — `test_right_click_cancel` indexes `units[2]` in two cases while asserting only `size() > 1`. On a trimmed sandbox that is an out-of-bounds crash rather than a clean failure. Both guard for 3 now.

**5. The alarm peak knob** (#349) — `UnitHealthBar.set_alarm` early-returns when on/off is unchanged, so a running tween kept the `_alarm_peak_color` it captured at start: turning the Look tab's *Alarm peak* mid-pulse did nothing until the next alarm. It now restarts the pulse when the peak moves. Tuning latency rather than the silently-reverting-knob failure, but it's a knob and it should land when you drag it.

## One deviation from the plan, deliberately

The plan said I'd make `test_hold_fillers_are_never_what_a_press_pops`'s press half non-vacuous by activating the squad first. **It can't be done, and that turned out to be the more interesting finding.** The press currently passes trivially because `active_squad` is null, so `_pop_last_gesture` returns at its first guard — and a squad holding *nothing but fillers* is unreachable in play by design: `revert_if_only_hold` clears the queue and drops `active_squad` the moment the last real order leaves.

So rather than manufacture the state with a direct set — which is exactly the kind of precondition `CLAUDE.md` says produces a blind test — the vacuity is now **asserted and explained** in place. The filter itself is still genuinely covered by the `last_gesture_actions` call above it, which is the whole rule (a filler is `batch_id` 0 because `setup_hold_move_actions` goes past `queue_action`'s door). A reader would otherwise have taken the untouched queue as evidence the filter ran.

## Verification

`tests/run_tests.ps1 ui presentation` — **441 cases, 40 suites, 0 failures, exit 0.** Those two areas load every surface touched here (`ui` builds the real game scene, so `BoardContext`/`GridUtils`/`CursorController` are all exercised; `presentation` covers `battle3d` and `UnitHealthBar`). Full tree is CI's.

**No falsification run.** Every assertion here sits one hop from its change, and nothing touches ordering, a wire, or a Godot quirk — the four cases `CLAUDE.md` reserves it for. The deletion's own proof is a grep, not a test.

**Not checked:** the alarm-peak restart is not pinned by a new test. Pinning it would mean asserting a colour, and feel-tuned values don't get pinned. It wants a drag of the Look tab's *Alarm peak* slider while a predicted-down alarm is pulsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
