### PR TITLE
The height readout asks the one live-brush predicate, not a mode of its own

### DIFF
--- a/Classes/dev/DevController.gd
+++ b/Classes/dev/DevController.gd
@@ -187,6 +187,18 @@ func _mouse_cell() -> Vector2i:
 # ghost shows exactly when a click would paint.
 func _process(_delta: float) -> void:
 	_sync_brush_ghost()
+	_sync_height_readout()
+
+# The height readout answers the SAME question the ghost does -- "is the level brush live?" -- so it
+# reads the one predicate instead of comparing the paint mode itself (#340). Polled for the same
+# reason the ghost is: brush_armed() has three inputs (DEV_MODE, the overlay, the checkbox) and not
+# one of them announces, so a push would need a caller at each. set_brush_active early-returns when
+# unchanged, so a frame that moved nothing costs one compare. Deliberately OUTSIDE the freeze guard
+# above -- a modal drops game_state out of DEV_MODE, and a readout under a card is worth nothing.
+func _sync_height_readout() -> void:
+	if game == null or game.height_debug_overlay == null:
+		return
+	game.height_debug_overlay.set_brush_active(elevation_brush_live())
 
 func _sync_brush_ghost() -> void:
 	if game == null or game.process_mode == Node.PROCESS_MODE_DISABLED:

--- a/Classes/dev/HeightDebugOverlay.gd
+++ b/Classes/dev/HeightDebugOverlay.gd
@@ -33,7 +33,7 @@ var heights: BoardHeights
 # that carries a level lights this on its own; but if F5 already asked for it, leaving that paint
 # mode must not silently switch it off.
 var _toggled := false        # F5
-var _brush_active := false   # the Tile Brush is in Terrain mode, which carries the level (#340)
+var _brush_active := false   # the level brush is LIVE -- DevController.elevation_brush_live (#340)
 
 func _ready() -> void:
 	visible = false

--- a/Classes/dev/TileBrushTool.gd
+++ b/Classes/dev/TileBrushTool.gd
@@ -487,16 +487,10 @@ func _set_paint_mode(mode: PaintMode) -> void:
 	_elevation_row.visible = mode == PaintMode.TERRAIN
 	_rise_row.visible = mode == PaintMode.TERRAIN
 	update_zone_highlight()   # draws on entering ZONE mode, clears on leaving it
-	update_height_readout()   # the same, for the terrain brush's level
 
-# Painting height into an invisible store is blind, so the readout lights with the brush that writes
-# it — the twin of update_zone_highlight above. The overlay derives its own visibility from this AND
-# F5, so leaving the mode cannot switch off a readout F5 asked for. Null in a build with dev tools
-# stripped, and while _build_extra_controls runs before init() hands us the game.
-func update_height_readout() -> void:
-	if game == null or game.height_debug_overlay == null:
-		return
-	game.height_debug_overlay.set_brush_active(paint_mode == PaintMode.TERRAIN)
+# NB the height readout is NOT lit from here. Painting height into an invisible store is blind, so it
+# follows the brush — but "is the level brush live?" is DevController's predicate, and it polls it
+# (_sync_height_readout). A mode compare here would be a second answer that cannot see the checkbox.
 
 # The board-wide wipe (dev ask 2026-08-11); per-cell erase stays right-click. Confirmed because
 # unsaved paint dies with it; the wipe pair is clear_board's own (clear + full redraw).

--- a/tests/dev/test_height_brush.gd
+++ b/tests/dev/test_height_brush.gd
@@ -350,22 +350,59 @@ func test_a_tile_that_stands_up_paints_flat_however_the_rise_is_set() -> void:
 
 
 # ---- the readout ----
+#
+# These wait on a FRAME rather than reading straight back, because the readout is DevController's
+# per-frame derive off elevation_brush_live() and not a push from _set_paint_mode. That is the
+# point: the mode is only half the predicate, and the half these cases used to miss is the brush
+# being down -- see test_the_readout_goes_dark_when_the_brush_does.
+
+# Two frames, not one: process_frame can fire either side of DevController._process inside a single
+# idle frame, so one await races the poll it is waiting on.
+func _polled() -> void:
+	await await_idle_frame()
+	await await_idle_frame()
+
 
 func test_the_height_readout_lights_with_the_terrain_brush() -> void:
 	var readout: HeightDebugOverlay = game.height_debug_overlay
 	assert_object(readout).is_not_null()
+
+	await _polled()
 	assert_bool(readout.visible).is_true()   # before_test entered TERRAIN mode
 
 	_brush._set_paint_mode(TileBrushTool.PaintMode.ZONE)
+
+	await _polled()
 	assert_bool(readout.visible).is_false()
+
+
+func test_the_readout_goes_dark_when_the_brush_does() -> void:
+	# The twin of test_the_rise_keys_are_inert_when_the_brush_is_down. That one pins that the KEYS go
+	# inert with the brush down; this pins that the READOUT does. Both ask elevation_brush_live, and
+	# that is the whole fix -- a mode compare of its own left the glyphs painted over a board whose
+	# wheel and Z/C were already dead, until a paint-mode round trip happened to clear them.
+	var readout: HeightDebugOverlay = game.height_debug_overlay
+
+	await _polled()
+	assert_bool(readout.visible).override_failure_message(
+			"armed in TERRAIN, and the readout never lit").is_true()
+
+	_brush.brush_active = false
+
+	await _polled()
+	assert_bool(readout.visible).override_failure_message(
+			"the brush is down and the keys are inert, but the readout is still lit").is_false()
 
 
 func test_an_f5_readout_survives_leaving_the_terrain_brush() -> void:
 	# Visibility is DERIVED from both reasons, not assigned by either: a brush that switched off a
-	# readout F5 asked for is the second-authority bug this shape exists to prevent.
+	# readout F5 asked for is the second-authority bug this shape exists to prevent. Load-bearing
+	# against the poll too -- it runs every frame, so an assignment there would fight F5 forever.
 	var readout: HeightDebugOverlay = game.height_debug_overlay
 	readout.toggle()                                           # F5 on, on top of the brush's own
 	_brush._set_paint_mode(TileBrushTool.PaintMode.ZONE)
+
+	await _polled()
 
 	assert_bool(readout.visible).is_true()
 


### PR DESCRIPTION
Found in a spot-check review of #268's merged diff. **Law #4: one question, two answers.**

## The question, and the two answers it had

*Is the level brush live?*

| | predicate | reads |
|---|---|---|
| **Input gate** — the wheel, Z/C, Battle3D's zoom suppression | `DevController.elevation_brush_live()` | `brush_armed()` **and** `paint_mode == TERRAIN` |
| **The glyphs** | `TileBrushTool.update_height_readout()` | `paint_mode == TERRAIN` **only** |

`brush_armed()` is DEV_MODE **and** the overlay exists **and** the brush checkbox is ticked. The readout saw none of that. So: arm the terrain brush, then untick it or F1 out of DEV_MODE — the wheel and Z/C correctly go dead, and the height numbers stay painted over the board until you round-trip the paint mode. A key that does nothing is bad; a readout that says the brush is live when it isn't is worse.

## The fix

`DevController._process` already polls `_sync_brush_ghost()` off this exact question — its comment even says *"the ghost shows exactly when a click would paint."* The readout now rides the same poll, one line down, off the same predicate. `TileBrushTool.update_height_readout` is deleted.

A **poll** rather than a push because `brush_armed()` has three inputs and not one of them announces — a push needs a caller at each, which is how the drift got there in the first place. It is close to free: `set_brush_active` already early-returns when unchanged, so a frame that moved nothing costs one bool compare, and `visible` is still DERIVED (`_toggled or _brush_active`), so F5 still wins over a disarmed brush.

Declared: the readout sync sits **outside** `_sync_brush_ghost`'s modal-freeze guard. A modal drops `game_state` out of DEV_MODE so the readout hides while a card is up, and returns when it closes. Self-correcting, and nothing is hidden that anyone could be looking at.

## It also closes a latent half that #340 made reachable

`update_height_readout`'s only caller was `_set_paint_mode`, and its build-time call at `_build_extra_controls` is eaten by its own `game == null` guard — `init()` never re-fired it. Harmless while ELEVATION was its own mode. Since **#340 made TERRAIN the default**, a fresh session's readout stayed dark until you switched modes away and back. A per-frame derive has no first call to miss.

## Verification

`run_tests.ps1 dev` — **198 cases, 16 suites, 0 failures, exit 0.**

**Falsified.** This is a poll driving a node, which is exactly the wire-shaped change a test can be blind to. Restoring the old mode-only gate as a mutant reds `test_the_readout_goes_dark_when_the_brush_does` and **only** that case — 21/21 executed on the one suite file, so nothing earlier truncated the case I was aiming at.

## Two things worth knowing before you read the test diff

**1. The suite already had a readout section, and it was pinning the wrong half.** `test_the_height_readout_lights_with_the_terrain_brush` and `test_an_f5_readout_survives_leaving_the_terrain_brush` both existed and both only ever moved the paint *mode* — the exact half that was never broken. Neither could see the checkbox. The new case is the twin of `test_the_rise_keys_are_inert_when_the_brush_is_down`, which pins the same predicate from the input side.

**2. The two existing cases now wait a frame.** They read `visible` back synchronously off the push, and a poll has no synchronous answer to give. That is a real cost of the shape, not a workaround, so it is commented at the section head rather than buried. Two frames, not one: `process_frame` can fire either side of `_process` in a single idle frame.

## Worth a feel-check

Arm the terrain brush (heights show), untick **Brush active** — the numbers should go with it. Then F5 them on and untick again: they should stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
