### PR TITLE
Fix #354: the predicted readout belongs to the plan, not to live HP

### DIFF
--- a/Classes/actions/OrderExecutor.gd
+++ b/Classes/actions/OrderExecutor.gd
@@ -23,6 +23,14 @@ var game   # the Game coordinator (Node2D); set by game._ready()
 # take_damage carries that rung out directly and the unit never goes DOWNED.)
 var _downed_pending: Array[Unit] = []
 
+# The plan THIS pass is playing out, non-null only while one is running (#354). It exists because
+# SquadManager._last_resolved_plan is not stable across a pass: a kill mid-pass fires unit_died ->
+# game._on_unit_died -> refresh_action_queue -> resolve_plan, which re-resolves a queue whose earlier
+# attacks have already landed. Anything PREVIEWING the pass has to read the plan being executed, not
+# whatever the last resolve left behind. Nothing here consumes it -- execute_orders holds its own
+# local -- so this is a published fact, not a second source of truth.
+var executing_plan: ResolvedPlan = null
+
 # ==============================================================================
 #  Resolving a plan
 # ==============================================================================
@@ -54,6 +62,7 @@ func execute_orders(unit):
 	# Explicit types throughout: `game` is untyped (game.gd has no class_name), so every
 	# game.* call reads as Variant and `:=` cannot infer from it.
 	var plan: ResolvedPlan = game.squad_manager.resolve_plan(squad, game._board())
+	executing_plan = plan
 	var move_actions := []
 	var side_channel: Dictionary[BaseAction.ActionType, Array] = {}
 
@@ -79,6 +88,10 @@ func execute_orders(unit):
 	for type in BaseAction.SIDE_CHANNEL_ORDER:
 		var batch: Array = side_channel.get(type, [])
 		await _execute_action_sequence(batch, beat)
+	# The last await has returned, so the pass is played out: released HERE rather than beside
+	# _end_squad_turn because everything below is synchronous (no frame renders between them) and
+	# the squad-validity bail below skips that call entirely.
+	executing_plan = null
 	_process_downed_pending()
 	# Loss-of-contact ejection (#151), right after downed ejection and for the same reason: the
 	# pass has settled, and a member a shove displaced out of its leader's path-bubble is no

--- a/Classes/actions/resolution/LethalityRules.gd
+++ b/Classes/actions/resolution/LethalityRules.gd
@@ -115,8 +115,10 @@ static func lifecycle_for(rung: ResolvedOutcome.Lethality,
 # different numbers for one plan is Law #2 broken at the point it is being rendered.
 #
 # It mirrors execution rather than inventing a convention — _go_downed clings at 1, a kill leaves
-# the board — which is also what makes a prediction converge with the live value once the pass has
-# run, so a readout gated on "predicted differs from current" puts itself away.
+# the board. #313 read that convergence as a free teardown and #354 found it was a trap: the clamp
+# flattens a sentenced unit's prediction ONTO the HP it already has, so a readout gated on "predicted
+# differs from current" both put itself away mid-pass and never appeared for a unit at exactly 1 HP.
+# DRAW with this number; never decide with it — PlanResolver.plan_changes is the membership answer.
 static func displayed_hp(raw_hp: int, lifecycle: Unit.LifecycleState) -> int:
 	match lifecycle:
 		Unit.LifecycleState.DEAD:

--- a/Classes/actions/resolution/PlanResolver.gd
+++ b/Classes/actions/resolution/PlanResolver.gd
@@ -294,14 +294,31 @@ static func projected_lifecycle(unit: Unit, hypo: Dictionary) -> Unit.LifecycleS
 		return unit.lifecycle_state
 	return (hypo[unit] as _Hypo).lifecycle
 
-# The gambit's own rung, which lifecycle cannot report: a CRISIS target is never DOWNED (#158), so
-# a readout asking "does this plan change where the unit stands" has to ask here too (#313).
-static func projected_in_crisis(unit: Unit, hypo: Dictionary) -> bool:
-	if unit == null or not is_instance_valid(unit):
+# Does this pass MOVE the unit's rung -- the alarm's question (#313), re-asked against the hypo's own
+# baseline rather than the live unit (#354). DOWNED and MAIMED move the lifecycle, KILLED moves it
+# further, and CRISIS moves neither (it is never DOWNED, #158), which is why crisis is asked
+# separately. A unit already down, or already in Crisis, stays put and does not alarm.
+static func plan_fells(unit: Unit, hypo: Dictionary) -> bool:
+	if unit == null or not is_instance_valid(unit) or not hypo.has(unit):
 		return false
-	if not hypo.has(unit):
-		return unit.in_crisis
-	return (hypo[unit] as _Hypo).in_crisis
+	var h := hypo[unit] as _Hypo
+	return h.lifecycle != h.start_lifecycle or (h.in_crisis and not h.start_in_crisis)
+
+# Does this pass change the unit at all -- WHO the readout is for (#354). Wholly internal to the
+# hypo, so the answer is settled when the plan is and cannot go false as execution applies the very
+# damage it predicted. That is the whole bug: asked against live HP, each bar switched off at the
+# instant its own hit landed.
+#
+# Asking the RAW threaded number rather than the displayed one also fixes the boundary the display
+# clamp hides: a unit at 1 HP felled by this pass threads to zero-or-below and shows as 1, so the
+# two displayed numbers collide and "differs from current" reported no change at all. Same shape at
+# CRISIS_REVIVE_HP, where the hypo's hp lands back on the number it started from and only the crisis
+# flag moves -- which is what plan_fells is doing in this expression.
+static func plan_changes(unit: Unit, hypo: Dictionary) -> bool:
+	if unit == null or not is_instance_valid(unit) or not hypo.has(unit):
+		return false
+	var h := hypo[unit] as _Hypo
+	return h.hp != h.start_hp or plan_fells(unit, hypo)
 
 static func _hypo_for(unit: Unit, hypo: Dictionary) -> _Hypo:
 	if not hypo.has(unit):
@@ -311,8 +328,10 @@ static func _hypo_for(unit: Unit, hypo: Dictionary) -> _Hypo:
 		h.hp = unit.get_current_hp()
 		h.start_hp = unit.get_current_hp()
 		h.lifecycle = unit.lifecycle_state
+		h.start_lifecycle = unit.lifecycle_state
 		h.will = unit.unit_instance.get_current_will()
 		h.in_crisis = unit.in_crisis
+		h.start_in_crisis = unit.in_crisis
 		h.can_maim = unit.unit_instance.next_maim_slot() != -1
 		h.crisis_armed = LethalityRules.crisis_armed_for(unit)
 		hypo[unit] = h
@@ -341,6 +360,12 @@ static func _hypo_for(unit: Unit, hypo: Dictionary) -> _Hypo:
 class _Hypo extends LethalityRules.Situation:
 	var position: Vector2i
 	var states: Array[Elemental.State] = []
+	# The rung the unit stood at when this hypo was seeded, beside the base's start_hp (#354). The
+	# threaded lifecycle/in_crisis above are mutated as the pass resolves, so without these the
+	# question "did this pass MOVE the unit" can only be asked against the live board — which drifts
+	# the moment execution starts applying what the plan predicted.
+	var start_lifecycle: Unit.LifecycleState = Unit.LifecycleState.ACTIVE
+	var start_in_crisis := false
 
 # Cell-effect stage (#50 / the #47 cell-effect channel). A map-hitting attack deposits its
 # element(s) across EVERY cell of its blast footprint — AoE parity with damage, which already

--- a/Classes/presentation/UnitMirror.gd
+++ b/Classes/presentation/UnitMirror.gd
@@ -22,6 +22,11 @@ class_name UnitMirror
 # answers a different question for a unit struck twice. This node computes no damage; if it ever
 # needs to, that is the bug.
 #
+# #354 split that second reason in two. WHO wears one is PlanResolver.plan_changes, asked of the
+# plan's own hypothetical; WHAT it draws is the live HP under a frozen prediction. Only the fill
+# tracks the board, so a bar drains down to its notch as the hit lands instead of vanishing at the
+# moment of impact — and the readout leaves when the PASS does, because the plan does.
+#
 # It reads the MODEL for that, not the 2D — the departure from OverlayMirror's "the 2D stays the one
 # authority" that #229 already made, and for the same reason: the flat view draws no HP over units
 # at all, so there is no retained 2D state to mirror.
@@ -294,34 +299,24 @@ func _plan() -> ResolvedPlan:
 
 # What the plan leaves this unit at, ALREADY CLAMPED for display — the raw threaded number goes
 # negative on a fatal hit, and LethalityRules.displayed_hp is the one answer to what a preview shows
-# for it, shared with the queue panel's own "before -> after" (#313). The clamp is also what makes
-# this readout put itself away: once the pass has run, a downed unit really is at 1, so the
-# "differs from current" test below goes false on its own.
+# for it, shared with the queue panel's own "before -> after" (#313). Drawn ONLY; the clamp flattens
+# a felled unit's prediction onto the HP it already has, so it can never be asked who gets a bar
+# (#354) — that question goes to the hypo, which still knows the difference.
 func _predicted_hp(unit: Unit, plan: ResolvedPlan) -> int:
 	return LethalityRules.displayed_hp(PlanResolver.projected_hp(unit, plan.hypo),
 			PlanResolver.projected_lifecycle(unit, plan.hypo))
 
 
-# The alarm asks whether the plan CHANGES where a unit stands, not where it stands now: a unit
-# already down or already in Crisis must not pulse for staying there. That is exactly the three
-# named rungs — DOWNED and MAIMED move the lifecycle, KILLED moves it further, and CRISIS moves
-# neither (it is never DOWNED, #158), which is why in_crisis is asked separately.
-func _plan_fells(unit: Unit, plan: ResolvedPlan) -> bool:
-	if PlanResolver.projected_lifecycle(unit, plan.hypo) != unit.lifecycle_state:
-		return true
-	return PlanResolver.projected_in_crisis(unit, plan.hypo) and not unit.in_crisis
-
-
 func _sync_bar(unit: Unit, sprite: UnitSprite3D, bar: UnitHealthBar, hovered: bool,
 		plan: ResolvedPlan) -> void:
 	# Two reasons to be up (#313), and the SECOND is the whole ticket: a readout stays over a unit
-	# because a plan is about to happen to it. "Predicted differs from current" is the rule — which
-	# reaches everyone the plan touches, enemies your own attack will hit included, and reaches
-	# nobody it doesn't.
-	var predicted := unit.get_current_hp()   # no plan is the same answer as a plan that changes nothing
-	if plan != null:
-		predicted = _predicted_hp(unit, plan)
-	var foretold := predicted != unit.get_current_hp()
+	# because a plan is about to happen to it. That reaches everyone the plan touches, enemies your
+	# own attack will hit included, and nobody it doesn't.
+	#
+	# WHO is a question about the plan and is asked of the plan (#354). It used to be "predicted
+	# differs from current", which made membership a function of LIVE HP — so every bar switched
+	# itself off at the instant its own hit landed, mid-pass, one at a time.
+	var foretold := plan != null and PlanResolver.plan_changes(unit, plan.hypo)
 	bar.set_shown(hovered or foretold)
 	if not (hovered or foretold):
 		return
@@ -333,7 +328,7 @@ func _sync_bar(unit: Unit, sprite: UnitSprite3D, bar: UnitHealthBar, hovered: bo
 	bar.set_hp(unit.get_current_hp(), unit.get_max_hp())
 	bar.set_number_shown(hovered or ghost_shows_number)
 	if foretold:
-		bar.set_prediction(predicted, _plan_fells(unit, plan))
+		bar.set_prediction(_predicted_hp(unit, plan), PlanResolver.plan_fells(unit, plan.hypo))
 	else:
 		bar.clear_prediction()
 	bar.position = _bar_anchor(unit, sprite)

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -805,7 +805,16 @@ func _hovered_unit() -> Unit:
 # squad identity, so this is null whenever nothing is being commanded — no active squad, and an AI
 # squad's own resolve (which never matches the player's active squad) — and the ghosts are simply
 # absent rather than showing somebody else's intentions.
+#
+# While a pass is RUNNING that question has a better answer than the last resolve (#354): the plan
+# being executed. A kill mid-pass re-resolves the queue (game._on_unit_died), and a queue whose
+# earlier attacks have already landed re-simulates them — so the last resolve stops describing the
+# exchange the player is watching. One function still answers "which plan"; it just knows a live
+# pass outranks a stale resolve.
 func _previewed_plan() -> ResolvedPlan:
+	var executing: ResolvedPlan = game.order_executor.executing_plan
+	if executing != null:
+		return executing
 	var squads: SquadManager = game.squad_manager
 	return squads.resolved_plan_for(squads.active_squad)
 

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -7,7 +7,7 @@ its child [#49 Action Queue UX](https://github.com/Phaazoid/Godoiosis/issues/49)
 This is a *guidelines* doc, not a spec — it captures the principles we're holding the work to,
 plus the running order of the queue-UX checklist. Update it as items land.
 
-**Canon checked through #350 (2026-08-16).**
+**Canon checked through #355 (2026-08-18).**
 
 ## Principles
 
@@ -211,9 +211,10 @@ The rulings, all dev calls, all made before building:
 
 - **A notch on ONE bar**, not a ghost twin beside it. Current and predicted are one fact about one
   unit, and a second bar over everybody the plan touches is exactly the crowding #229 deferred.
-- **Anyone the plan CHANGES** — predicted HP differs from current. That reaches enemies your own
-  attack will hit, allies caught in splash, and anyone a derived counter strikes, which is most of
-  the value; and it reaches nobody the plan leaves alone, with no second rule to maintain.
+- **Anyone the plan CHANGES** — which reaches enemies your own attack will hit, allies caught in
+  splash, and anyone a derived counter strikes, which is most of the value; and it reaches nobody
+  the plan leaves alone, with no second rule to maintain. *(Spelled "predicted HP differs from
+  current" until #354 below, which is where that spelling failed.)*
 - **The alarm is the NAMED RUNGS ONLY** — predicted DOWNED, KILLED or CRISIS. "Too low" as a
   fraction would have been a new game rule needing a home and a justified number; the ladder
   already names the outcomes worth flinching at.
@@ -230,8 +231,8 @@ Three things that generalise past this ticket:
    on a fatal hit; the queue panel had been clamping that to 1-for-a-down and 0-for-a-kill inline.
    A second spelling over the unit's head is Law #2 broken at the point it is being rendered, so the
    ladder moved to `LethalityRules.displayed_hp` and both surfaces read it. It **mirrors execution**
-   (`_go_downed` clings at exactly 1), which is also what makes the readout put itself away: once
-   the pass has run, predicted equals current and the "differs" test goes false on its own.
+   (`_go_downed` clings at exactly 1) — which this ticket also read as a free teardown, *"the readout
+   puts itself away"*, and #354 below is that claim being wrong.
 3. **A pulse must not become a second writer of the thing it pulses.** The existing rule is that a
    live pulse OWNS `sprite.modulate`; a 3D readout has no modulate, its colour is a material. So
    `Pulse` now takes the PROPERTY name (the cadence is the one thing every "look at this" cue must
@@ -239,15 +240,61 @@ Three things that generalise past this ticket:
    single writer of albedo. The redraw had to become value-diffed for the same reason — an
    unguarded rebuild repainted over the tween sixty times a second.
 
-**No prediction during an AI turn**, and that falls out rather than being enforced:
-`resolved_plan_for` guards on squad identity, so an AI squad's own resolve never matches the
-player's active squad. Enemy plans were not previewed before either; this keeps it that way.
+**"No prediction during an AI turn" is what this ticket claimed, and it is FALSE — measured
+2026-08-18 while building #354.** The reasoning was that `resolved_plan_for` guards on squad
+identity so an AI squad's resolve never matches the player's active squad; but `active_squad` is set
+by `SquadManager.queue_action`, which Law #3 makes the AI's own door, and `execute_orders` resolves
+for whatever squad it is running. So both sides name the AI squad and they match: an enemy order
+puts a doomed bar over the player unit it is about to hit. Whether that is a leak or a *feature* (it
+lands during `Pacing.AI_PLAN_READ`, the beat that exists so a drawn AI plan can be read) is an open
+dev call, filed rather than decided.
 
 Successor filed the same day: [#350](https://github.com/Phaazoid/Godoiosis/issues/350) — a player
 toggle pinning **every** bar on, which is one more disjunct in the same visibility expression and
 then almost entirely a legibility problem. Note also that the predicted-down alarm is a **pulse**,
 so it joins [#217](https://github.com/Phaazoid/Godoiosis/issues/217)'s photosensitivity registry the
 moment that registry exists.
+
+## The readout belongs to the PLAN, not to the board ([#354](https://github.com/Phaazoid/Godoiosis/issues/354), FIXED 2026-08-18)
+
+#313's readout was gated on *predicted HP differs from current*, and that one comparison was
+answering three questions at once. Two of its answers were wrong, and the dev found the loud one in
+play: **bars winked out one at a time, each at the exact moment of impact.** Nothing re-resolves
+during a pass, so the prediction stays frozen while live HP drains to meet it — and the instant a
+unit's hit lands the two numbers agree and *its* bar switches off, at the single moment the bar is
+most worth looking at. The quiet one was the same collision standing still: a unit at exactly 1 HP
+that the plan fells has a predicted HP of 1 (the display clamp mirrors `_go_downed`'s cling), so it
+never wore a bar at all and never raised the felling alarm.
+
+**Dev call: through the end of the resolution PASS**, not the mission — every bar that was up when
+Execute was pressed stays up until the whole exchange finishes, then they drop together. The
+mission-long reading would have been [#350](https://github.com/Phaazoid/Godoiosis/issues/350)
+arriving as a default rather than a toggle, inheriting its unanswered crowding problem.
+
+- **Membership is a question about the PLAN, so it is asked of the plan.** `PlanResolver.plan_changes`
+  compares the hypo's end state to the hypo's *own* baseline — `_Hypo.start_hp` was already threaded,
+  and `start_lifecycle`/`start_in_crisis` join it — so the answer is settled when the plan is and
+  cannot go false as execution applies the very damage it predicted. No latch, no new owner, no
+  "the pass is over" event to fire.
+- **Only the FILL tracks the board.** A bar now drains down to its notch as the hit lands, instead of
+  vanishing at impact. Membership, notch, span and alarm are all the plan's.
+- **Nothing new dismisses them**, because `OrderExecutor._end_squad_turn` already did: it is the one
+  terminal state of a pass and it always empties the queue, which nulls `active_squad` and takes the
+  previewed plan with it. That covers the AI concede (same call) and a mission ending mid-pass
+  (`MissionController.check()` is not awaited, so the end-of-turn still runs in the same frame).
+
+Two things that generalise past this ticket:
+
+1. **A display CLAMP can never also be a membership test.** `displayed_hp` exists to flatten a
+   sentenced unit's number onto what execution will really leave it at — which is exactly the
+   information a "did anything change?" question needs, destroyed. Ask the raw threaded value.
+2. **The previewed plan and the last resolve are different questions while a pass is running.** A
+   kill mid-pass fires `unit_died` → `game._on_unit_died` → `refresh_action_queue` → `resolve_plan`,
+   re-resolving a queue whose earlier attacks have already landed. `OrderExecutor.executing_plan` is
+   the plan being played out, and `battle3d._previewed_plan` prefers it. **That re-resolve is also a
+   live Law #2 break in EXECUTION** — it overwrites `AttackAction.resolved` on attacks that have not
+   run yet, and `execute` is pure playback of that field — filed separately; this change only makes
+   the readout immune to it.
 
 ## Two marker channels, one rule ([#346](https://github.com/Phaazoid/Godoiosis/issues/346))
 

--- a/tests/presentation/test_predicted_health.gd
+++ b/tests/presentation/test_predicted_health.gd
@@ -49,8 +49,8 @@ func _settle() -> void:
 	await await_idle_frame()
 
 
-func _spawn(faction: Team.Faction, cell: Vector2i, armed := true) -> Unit:
-	var unit: Unit = game.spawn_unit(H.make_unit_data({}, faction), cell)
+func _spawn(faction: Team.Faction, cell: Vector2i, armed := true, overrides := {}) -> Unit:
+	var unit: Unit = game.spawn_unit(H.make_unit_data(overrides, faction), cell)
 	assert_object(unit).is_not_null()   # fixture setup, not the claim under test
 	if armed:
 		unit.equipped_weapon = H.make_weapon()   # pattern-less: Reach falls back to adjacency
@@ -247,3 +247,114 @@ func test_the_queue_panel_and_the_bar_predict_the_same_hp() -> void:
 	assert_int(panel_says).is_equal(_predicted(victim))
 	assert_float(bar.notch_fraction()).is_equal_approx(
 			float(panel_says) / float(victim.get_max_hp()), 1.0 / bar.track_texels())
+
+
+# ------------------------------------------------------------------------------
+#  It stays up THROUGH the pass (#354)
+# ------------------------------------------------------------------------------
+
+# The real pass, started but deliberately NOT awaited, so the case can look at the board WHILE it
+# runs. `done` is a one-slot array because a coroutine has no other way to hand a fact back.
+func _start_pass(unit: Unit, done: Array) -> void:
+	await game.order_executor.execute_orders(unit)
+	done[0] = true
+
+
+# The regression the ticket was filed for. Every case above asserts on a plan that never RUNS, which
+# is exactly why the suite stayed green while bars winked out one at a time in play.
+#
+# Two attackers on purpose: a lone attack applies its damage and calls finish_execution() in the same
+# synchronous block, so there would be no mid-pass frame to look at. With two, the first hit lands
+# while the second is still lunging — the dev's report ("disappearing as soon as each individual unit
+# is done") is precisely that gap.
+func test_a_readout_survives_its_own_hit_landing_and_leaves_when_the_pass_does() -> void:
+	var first := _spawn(PLAYER, Vector2i(2, 2))
+	var second := _spawn(PLAYER, Vector2i(2, 3))
+	game.squad_manager.join_squad(second, first.squad)   # ONE squad, so ONE plan resolves both aims
+	var struck := _spawn(ENEMY, Vector2i(3, 2))
+	var waiting := _spawn(ENEMY, Vector2i(3, 3))
+	_aim_at(first, struck.movement.cell)
+	_aim_at(second, waiting.movement.cell)
+	await _settle()
+
+	var struck_hp := struck.get_current_hp()
+	var waiting_hp := waiting.get_current_hp()
+	assert_bool(_unit_mirror.bar_for(struck).visible).override_failure_message(
+			"no readout appeared before the pass, so its surviving one would prove nothing").is_true()
+
+	var done := [false]
+	_start_pass(first, done)
+	var landed := false
+	for _frame in 600:
+		await await_idle_frame()
+		if done[0] or not is_instance_valid(struck):
+			break
+		if struck.get_current_hp() != struck_hp:
+			landed = true
+			break
+	assert_bool(landed).override_failure_message(
+			"the first hit never landed mid-pass, so there is no moment of impact to check").is_true()
+	# One more frame: the mirror POLLS, so the bar the old rule would have hidden is only actually
+	# hidden a frame after the HP moved. Asserting on the frame the damage lands passes either way.
+	await await_idle_frame()
+
+	assert_bool(done[0]).override_failure_message(
+			"the pass finished before the assert, so this case cannot see mid-pass at all").is_false()
+	assert_int(waiting.get_current_hp()).override_failure_message(
+			"the second hit had already landed, so the pass is not staggered here").is_equal(waiting_hp)
+	assert_bool(_unit_mirror.bar_for(struck).visible).override_failure_message(
+			"the readout went away at the moment of impact — #354").is_true()
+
+	while not done[0]:
+		await await_idle_frame()
+	await _settle()
+	# And the other half of the ticket: they leave TOGETHER, when the pass ends, not one at a time.
+	assert_array(_shown_bars()).is_empty()
+
+
+# The boundary the display clamp hides. A unit at exactly 1 HP that the plan puts on the floor has a
+# predicted HP of 1 (LethalityRules.displayed_hp mirrors _go_downed's cling) and a current HP of 1 —
+# so a rule comparing those two numbers reads "this plan does nothing to them" for the single unit
+# the plan hurts most. The suite's other down case sits at 2 HP, one point clear of the collision.
+func test_a_unit_at_one_hp_the_plan_fells_still_wears_a_readout() -> void:
+	var attacker := _spawn(PLAYER, Vector2i(2, 2))
+	var victim := _spawn(ENEMY, Vector2i(3, 2))
+	victim.set_current_hp(1)
+	_aim_at(attacker, victim.movement.cell)
+	await _settle()
+
+	assert_int(PlanResolver.projected_lifecycle(victim, _plan().hypo)).override_failure_message(
+			"the fixture attack did not fell the victim, so the clamp collision is not in play"
+			).is_equal(Unit.LifecycleState.DOWNED)
+	# The precondition IS the bug: assert the two displayed numbers really do collide, or this case
+	# quietly stops testing the boundary the moment the clamp or the ladder moves.
+	assert_int(_predicted(victim)).is_equal(victim.get_current_hp())
+
+	var bar := _unit_mirror.bar_for(victim)
+	assert_bool(bar.visible).override_failure_message(
+			"a unit this plan fells wears no readout at all — #354").is_true()
+	assert_bool(bar.alarm_running()).override_failure_message(
+			"the felling alarm never raised, because the visibility gate ran ahead of it").is_true()
+
+
+# The same collision one rung along, and the reason membership cannot be an HP question alone: a
+# Crisis stands the unit back up at exactly CRISIS_REVIVE_HP, so a unit sitting on that number ends
+# the pass at the HP it started with. Nothing about its HP moved; everything about its situation did.
+func test_a_crisis_at_the_revive_hp_still_wears_a_readout() -> void:
+	var attacker := _spawn(PLAYER, Vector2i(2, 2))
+	var victim := _spawn(ENEMY, Vector2i(3, 2), true, {Stats.Stat.WIL: UnitInstance.MAX_WILL})
+	victim.unit_instance.jobs.append("berserker")   # arms Crisis the way content does (#158)
+	victim.set_current_hp(Abilities.CRISIS_REVIVE_HP)
+	_aim_at(attacker, victim.movement.cell)
+	await _settle()
+
+	var hypo: Dictionary = _plan().hypo
+	assert_bool(PlanResolver.plan_fells(victim, hypo)).override_failure_message(
+			"the fixture attack did not drive the victim into Crisis, so this case proves nothing"
+			).is_true()
+	assert_int(PlanResolver.projected_hp(victim, hypo)).override_failure_message(
+			"the projection moved the victim's HP, so the collision under test is absent"
+			).is_equal(victim.get_current_hp())
+
+	assert_bool(_unit_mirror.bar_for(victim).visible).override_failure_message(
+			"a unit this plan drives into Crisis wears no readout at all — #354").is_true()


### PR DESCRIPTION
Closes #354. Your call on the fork: **through the end of the resolution PASS**, not the mission — so this does not touch #350.

## What was wrong, and it was one line doing three jobs

`UnitMirror._sync_bar` gated a bar on `predicted != unit.get_current_hp()`. That makes *who wears a readout* a function of the **live board**, and it fails two ways:

- **Your report.** Nothing re-resolves during a pass, so the prediction stays frozen while live HP drains to meet it. The instant a unit's hit lands the two numbers agree and **that** bar switches off — staggered, one per impact, at the single moment the bar is worth looking at.
- **The 2026-08-18 comment on the issue.** A unit at exactly 1 HP that the plan fells has a predicted HP of **1** (the display clamp mirrors `_go_downed`'s cling to 1). Same number, so it never wore a bar at all and never raised the felling alarm. Same shape at `CRISIS_REVIVE_HP` (5) → Crisis, where the hypo puts the unit back on the HP it started from and only its crisis flag moves.

## The structural call, stated plainly

**"Does this plan change this unit?" is a question about the plan, so it is asked of the plan.** The resolver already threads `_Hypo.start_hp` — the HP the plan resolved against — and resolution is synchronous and pure, so that value *is* HP-at-pass-start. `start_lifecycle` and `start_in_crisis` join it, and `PlanResolver.plan_changes` compares the hypo's end state to the hypo's own baseline.

That means **no latch, no new owner, and no "the pass is over" event to fire.** The issue expected the fix to cost #313's free teardown; it doesn't, because membership stops drifting rather than being pinned. Dismissal still comes from `_end_squad_turn` — the one terminal state of a pass, which always empties the queue, nulls `active_squad`, and takes the previewed plan with it. That covers the AI concede (same call) and a mission ending mid-pass (`MissionController.check()` is not awaited, so the end-of-turn runs in the same frame).

Only the bar's **fill** still tracks the board — so you now watch a bar drain down to its notch as the hit lands, instead of it vanishing.

## Things worth ruling on

1. **`UnitMirror._plan_fells` moved to `PlanResolver.plan_fells`.** It had the same drift one field over (it compared the projection against the *live* unit). `projected_in_crisis` is **deleted** — that was its only caller.
2. **`OrderExecutor.executing_plan` is new, and `battle3d._previewed_plan` prefers it while a pass runs.** A kill mid-pass fires `unit_died` → `game._on_unit_died` → `refresh_action_queue` → `resolve_plan`, re-resolving a queue whose earlier attacks have already landed. The last resolve stops describing the exchange you are watching, so the readout reads the plan being executed instead.
3. **The alarm stops at impact and I left it that way.** Once the hit lands the doomed span is zero-width, so there is nothing for the pulse to colour; the warning has come true and the bar stays as the record. One line to flip if it reads wrong.

## Filed separately, not fixed here

That mid-pass re-resolve is **also a live Law #2 break in execution, and a worse one than the readout.** `resolve_plan` overwrites `AttackAction.resolved` on attacks that have not run yet, and `AttackAction.execute` is pure playback of that field — so one kill mid-pass can change the damage the *remaining* attacks deal, away from what the queue previewed. Change 2 makes the readout immune to it; it does not fix it. Filed as its own issue rather than folded into a presentation ticket.

Also **corrected in canon while sweeping**: #313 recorded *"no prediction during an AI turn"* on the grounds that `resolved_plan_for` guards on squad identity. **Measured false** — `active_squad` is set by `queue_action`, which Law #3 makes the AI's own door, so both sides name the AI squad and an enemy order puts a doomed bar over the player unit it is about to hit. Whether that is a leak or a feature is yours; filed, not decided.

## Verification

- `tests/presentation` + `law` + `squad` + `ai` — **583 cases green** (the resolver and the one path every plan executes through are both touched).
- **Falsified, three ways.** With the old predicate restored, each new case reds on its own assertion — *"the readout went away at the moment of impact"*, *"a unit this plan fells wears no readout at all"*, *"a unit this plan drives into Crisis wears no readout at all"* — and **the six existing cases stay green under that same mutant**, which is the point: they all assert on a plan that never runs. The mid-pass case therefore starts a real `execute_orders` pass without awaiting it, waits for the first hit to land, and asserts while the second attacker is still lunging.
- **Not checked by the suite:** how any of it looks. The bar-drains-to-its-notch motion and the alarm's behaviour at impact are eye calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
