### PR TITLE
The Prolog squad lesson: authored steps, beats, and Torv's voice (#182 slice 3)

### DIFF
--- a/Classes/flow/DialogBeat.gd
+++ b/Classes/flow/DialogBeat.gd
@@ -14,8 +14,12 @@ enum Trigger {
 	SQUAD_FORMED,         # the player forms any squad
 	UNIT_SELECTED,        # the player selects a unit (game.unit_selected)
 	SQUAD_MEMBER_ADDED,   # a unit joins a player squad (SquadManager.squad_member_joined)
+	STEP_COMPLETED,       # the lesson advanced past step N (`step` below) -- beats only, the
+	                      # payoff voice for tutorial progress (a board event fires at its FIRST
+	                      # occurrence; "the squad is COMPLETE" is a lesson fact, not a board one)
 }
 
 @export var trigger := Trigger.MISSION_START
 @export var turn := 1   # TURN_START only: which player turn fires this (1-based)
+@export var step := 1   # STEP_COMPLETED only: which lesson step (1-based)
 @export var timeline: DialogicTimeline

--- a/Classes/flow/ScenarioDirector.gd
+++ b/Classes/flow/ScenarioDirector.gd
@@ -145,6 +145,7 @@ func _on_squad_member_joined(squad: Squad, _unit: Unit) -> void:
 		return
 	var step := _active_step()
 	if step != null and step.done_when == DialogBeat.Trigger.SQUAD_MEMBER_ADDED \
+			and _name_matches(step.unit_name, leader) \
 			and squad.get_members().size() >= step.squad_size:
 		_advance_step()
 	for beat: DialogBeat in _beats:
@@ -163,6 +164,11 @@ func _active_step() -> TutorialStep:
 func _advance_step() -> void:
 	_step_idx += 1
 	game.refresh_mission_status()   # the write-point pattern (#134), not a signal
+	# THEN the payoff voice (the pinned order: HUD first). _step_idx is also how many steps
+	# are complete, which is exactly the 1-based index STEP_COMPLETED beats author against.
+	for beat: DialogBeat in _beats:
+		if beat.trigger == DialogBeat.Trigger.STEP_COMPLETED and beat.step == _step_idx:
+			_fire(beat)
 
 
 func _name_matches(wanted: String, unit: Unit) -> bool:

--- a/Scenarios/dialog/characters/torv.dch
+++ b/Scenarios/dialog/characters/torv.dch
@@ -1,0 +1,19 @@
+{
+"@path": "res://addons/dialogic/Resources/character.gd",
+"@subpath": NodePath(""),
+&"_translation_id": "",
+&"color": Color(0.85, 0.6, 0.25, 1),
+&"custom_info": {},
+&"default_portrait": "default",
+&"description": "",
+&"display_name": "Torv",
+&"mirror": false,
+&"nicknames": [],
+&"offset": Vector2(0, 0),
+&"portraits": {
+"default": {
+"image": "res://Art/Units/Portraits/hair_mcgee.png"
+}
+},
+&"scale": 1.0
+}

--- a/Scenarios/dialog/characters/torv.dch.uid
+++ b/Scenarios/dialog/characters/torv.dch.uid
@@ -1,0 +1,1 @@
+uid://cn4gwxh7at8q

--- a/Scenarios/dialog/prolog_intro.dtl
+++ b/Scenarios/dialog/prolog_intro.dtl
@@ -1,0 +1,3 @@
+torv: That alarm means mercenaries — six of them at least, and they aren't here to enroll.
+torv: Four of us. Bad odds for loners. Good odds for a squad.
+torv: Find me on the field — I'll show you how a squad fights.

--- a/Scenarios/dialog/prolog_intro.dtl.uid
+++ b/Scenarios/dialog/prolog_intro.dtl.uid
@@ -1,0 +1,1 @@
+uid://cf1608rn8r7tq

--- a/Scenarios/dialog/prolog_step_complete.dtl
+++ b/Scenarios/dialog/prolog_step_complete.dtl
@@ -1,0 +1,2 @@
+torv: All four of us, one plan. That's how four beats six.
+torv: Queue our moves, then clear the yard.

--- a/Scenarios/dialog/prolog_step_complete.dtl.uid
+++ b/Scenarios/dialog/prolog_step_complete.dtl.uid
@@ -1,0 +1,1 @@
+uid://cqrcmb86cmpny

--- a/Scenarios/dialog/prolog_step_first_join.dtl
+++ b/Scenarios/dialog/prolog_step_first_join.dtl
@@ -1,0 +1,2 @@
+torv: One with me — a squad shares one plan, so our orders queue together now.
+torv: Bring the other two in. Join Squad, same as before.

--- a/Scenarios/dialog/prolog_step_first_join.dtl.uid
+++ b/Scenarios/dialog/prolog_step_first_join.dtl.uid
@@ -1,0 +1,1 @@
+uid://clogivg63dj47

--- a/Scenarios/dialog/prolog_step_selected.dtl
+++ b/Scenarios/dialog/prolog_step_selected.dtl
@@ -1,0 +1,1 @@
+torv: That's me. Now Squad Up — pick one of the others and we'll move as one.

--- a/Scenarios/dialog/prolog_step_selected.dtl.uid
+++ b/Scenarios/dialog/prolog_step_selected.dtl.uid
@@ -1,0 +1,1 @@
+uid://cr1bbgk4q8ci1

--- a/Scenarios/missions/Prolog.tres
+++ b/Scenarios/missions/Prolog.tres
@@ -1,9 +1,15 @@
 [gd_resource type="Resource" script_class="ScenarioData" format=4]
 
+[ext_resource type="Script" path="res://Classes/flow/DialogBeat.gd" id="1_d2l1v"]
 [ext_resource type="Script" path="res://Classes/flow/ScenarioData.gd" id="1_s6fbn"]
+[ext_resource type="Resource" path="res://Scenarios/dialog/prolog_intro.dtl" id="2_ayygx"]
 [ext_resource type="Script" path="res://Classes/flow/ScenarioUnitEntry.gd" id="2_jc5jw"]
 [ext_resource type="Script" path="res://Classes/items/EquippableData.gd" id="3_d7l08"]
+[ext_resource type="Script" path="res://Classes/flow/TutorialStep.gd" id="3_jbpcb"]
+[ext_resource type="Resource" path="res://Scenarios/dialog/prolog_step_selected.dtl" id="3_rivbd"]
+[ext_resource type="Resource" path="res://Scenarios/dialog/prolog_step_first_join.dtl" id="4_hangl"]
 [ext_resource type="Script" path="res://Classes/weapons/instances/ChainswordWeaponInstance.gd" id="4_sox22"]
+[ext_resource type="Resource" path="res://Scenarios/dialog/prolog_step_complete.dtl" id="5_n3m7a"]
 [ext_resource type="Script" path="res://Classes/weapons/WeaponModData.gd" id="5_xnjrr"]
 [ext_resource type="Resource" path="res://Resources/Weapons/MainVarieties/ChainSword.tres" id="6_cgh5e"]
 [ext_resource type="Script" path="res://Classes/units/StatEffect.gd" id="7_ek4ng"]
@@ -23,6 +29,48 @@
 [ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Brigand_Downed.png" id="29_hangl"]
 [ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Brigand.png" id="30_n3m7a"]
 [ext_resource type="Texture2D" path="res://Art/Units/MapSprites/Brigand_Moving.png" id="31_ek4ng"]
+
+[sub_resource type="Resource" id="Resource_68ohh"]
+script = ExtResource("1_d2l1v")
+step = 0
+timeline = ExtResource("2_ayygx")
+
+[sub_resource type="Resource" id="Resource_fgy5v"]
+script = ExtResource("1_d2l1v")
+trigger = 5
+timeline = ExtResource("3_rivbd")
+
+[sub_resource type="Resource" id="Resource_2hb56"]
+script = ExtResource("1_d2l1v")
+trigger = 5
+step = 2
+timeline = ExtResource("4_hangl")
+
+[sub_resource type="Resource" id="Resource_7u1b0"]
+script = ExtResource("1_d2l1v")
+trigger = 5
+step = 3
+timeline = ExtResource("5_n3m7a")
+
+[sub_resource type="Resource" id="Resource_igeaa"]
+script = ExtResource("3_jbpcb")
+text = "Select Torv."
+done_when = 3
+unit_name = "Torv"
+
+[sub_resource type="Resource" id="Resource_jpl85"]
+script = ExtResource("3_jbpcb")
+text = "Squad Up: add an ally to Torv's squad."
+done_when = 4
+unit_name = "Torv"
+squad_size = 2
+
+[sub_resource type="Resource" id="Resource_p5auv"]
+script = ExtResource("3_jbpcb")
+text = "Join Squad: bring the other two into Torv's squad."
+done_when = 4
+unit_name = "Torv"
+squad_size = 4
 
 [sub_resource type="Resource" id="Resource_d2l1v"]
 script = ExtResource("14_n3m7a")
@@ -490,3 +538,5 @@ Vector2i(7, -1): Array[int]([4])
 }
 objectives = Array[int]([0])
 ai_factions = Array[int]([1])
+dialog_beats = Array[ExtResource("1_d2l1v")]([SubResource("Resource_68ohh"), SubResource("Resource_fgy5v"), SubResource("Resource_2hb56"), SubResource("Resource_7u1b0")])
+tutorial_steps = Array[ExtResource("3_jbpcb")]([SubResource("Resource_igeaa"), SubResource("Resource_jpl85"), SubResource("Resource_p5auv")])

--- a/project.godot
+++ b/project.godot
@@ -22,8 +22,15 @@ Dialogic="*uid://ds2q0uclmolvu"
 
 [dialogic]
 
-directories/dch_directory={}
-directories/dtl_directory={}
+directories/dch_directory={
+"torv": "res://Scenarios/dialog/characters/torv.dch"
+}
+directories/dtl_directory={
+"prolog_intro": "res://Scenarios/dialog/prolog_intro.dtl",
+"prolog_step_complete": "res://Scenarios/dialog/prolog_step_complete.dtl",
+"prolog_step_first_join": "res://Scenarios/dialog/prolog_step_first_join.dtl",
+"prolog_step_selected": "res://Scenarios/dialog/prolog_step_selected.dtl"
+}
 layout/style_directory={}
 
 [display]

--- a/tests/flow/test_scenario_director.gd
+++ b/tests/flow/test_scenario_director.gd
@@ -246,3 +246,47 @@ func test_disarm_clears_the_instruction() -> void:
 	assert_str(_director.active_instruction()).is_equal("Never seen on resume.")
 	_director.disarm()
 	assert_str(_director.active_instruction()).is_equal("")
+
+
+func test_payoff_beat_fires_when_its_step_completes() -> void:
+	_director.set_steps([
+		_step(DialogBeat.Trigger.UNIT_SELECTED, "Select Torv.", "Torv"),
+		_step(DialogBeat.Trigger.SQUAD_FORMED, "Squad up."),
+	])
+	var payoff := _beat(DialogBeat.Trigger.STEP_COMPLETED, "Both steps done.")
+	payoff.step = 2
+	_director.set_beats([payoff])
+	_director.mission_started()
+	_stub.unit_selected.emit(_named_unit("Torv", PLAYER))   # completes step 1 -- not the payoff's step
+	await get_tree().process_frame
+	assert_int(_starts).is_equal(0)
+	_stub.squad_manager.squad_created.emit(_player_squad())   # completes step 2 -- the payoff's
+	await _await_starts(1)
+
+
+func test_member_step_ignores_the_wrong_leaders_squad() -> void:
+	_director.set_steps([_step(DialogBeat.Trigger.SQUAD_MEMBER_ADDED, "Grow Torv's squad.", "Torv", 2)])
+	_director.mission_started()
+	var isaac_squad := auto_free(Squad.new()) as Squad
+	isaac_squad.set_leader(_named_unit("Isaac", PLAYER))
+	isaac_squad._add_member(_named_unit("Collette", PLAYER))
+	_stub.squad_manager.squad_member_joined.emit(isaac_squad, isaac_squad.get_members()[1])
+	assert_str(_director.active_instruction()).is_equal("Grow Torv's squad.")
+	var torv_squad := auto_free(Squad.new()) as Squad
+	torv_squad.set_leader(_named_unit("Torv", PLAYER))
+	torv_squad._add_member(_named_unit("Ross", PLAYER))
+	_stub.squad_manager.squad_member_joined.emit(torv_squad, torv_squad.get_members()[1])
+	assert_str(_director.active_instruction()).is_equal("")
+
+
+# --- authored content integrity (the Prolog lesson, #182 slice 3) ---
+
+# Not a content pin: empty arrays pass. What it guards is the WIRE from authored data to
+# playable dialog -- a renamed or moved .dtl leaves a beat with a null timeline and no error
+# until a player reaches that moment of the lesson.
+func test_prolog_authored_content_resolves() -> void:
+	var scenario: ScenarioData = load("res://Scenarios/missions/Prolog.tres")
+	for beat: DialogBeat in scenario.dialog_beats:
+		assert_object(beat.timeline).is_not_null()
+	for step: TutorialStep in scenario.tutorial_steps:
+		assert_str(step.text).is_not_empty()


### PR DESCRIPTION
Part of #182 -- **slice 3: the Prolog squad lesson**, authored content on top of #369's machinery. **STACKED on `feat/182-instruction-prompts`** -- merge #369 first (bottom-up, then delete its head branch and this PR retargets to main; the stacked-merge rule).

## The lesson, as you specified it

1. `> Select Torv.` -- completes on selecting Torv (UNIT_SELECTED, display_name match)
2. `> Squad Up: add an ally to Torv's squad.` -- completes when **Torv's** squad reaches 2
3. `> Join Squad: bring the other two into Torv's squad.` -- completes at 4

Instruction text uses the action menu's exact verbs (Squad Up / Join Squad). The cast was already named -- Isaac, Rebecca, Torv, Aldin -- so the roster is untouched. Each completion fires a short Torv line (placeholder text, 1-3 lines per beat), plus a mission-start intro framing the odds (4 vs 6).

## Two code additions the content demanded

- **`STEP_COMPLETED` trigger** (+ `step` param on DialogBeat): payoff dialog keys on *lesson progress*, not board events. A `SQUAD_MEMBER_ADDED` beat would fire at the *first* join -- "the squad is complete" is a fact only the step sequence knows.
- **Leader filter on member-join steps**: squadding Isaac with Rebecca cannot complete Torv's lesson (`unit_name` now matched against the squad leader).

## Content plumbing

- `Scenarios/dialog/*.dtl` -- four hand-written Dialogic timelines (plain text, reviewable in the diff).
- `torv.dch` -- Torv as a Dialogic character, `hair_mcgee` placeholder portrait, generated headless.
- `project.godot` gains only the Dialogic character/timeline directory entries (the same registration the editor plugin performs). A `ProjectSettings.save()` rewrite wanted to churn your existing input-event `device` fields -- reverted; only the intended lines shipped.
- **Custom dialog style deliberately not included**: the box's look is feel territory -- Dialogic's style editor is the knob, and authoring one blind violates the no-launching-to-check-UI rule. Default VN style until you tune it.

## Tests

Three new cases: STEP_COMPLETED fires on exactly its step, wrong-leader squads are ignored, and a load-integrity guard -- every authored beat's timeline must resolve (a moved `.dtl` otherwise dies silently at the exact moment a player reaches it) and every step carries text. Not a content pin: empty arrays pass, re-author freely. `flow` + `ui`: 377/377, 0 orphans.

## For your playthrough

Open the Prolog from Mission Select on this branch: the gold instruction row should walk you through the three steps with Torv's lines landing between. The known feel questions still stand from #364/#369 (left-click advance, board not paused) plus one new one: whether step 2's "with Torv selected" flow reads clearly when a player squads someone else first (the row simply doesn't advance -- silent by your #366 deferral).
