### PR TITLE
#357: a unit's element states read above its health bar

### DIFF
--- a/Classes/presentation/LookKnobs.gd
+++ b/Classes/presentation/LookKnobs.gd
@@ -219,6 +219,13 @@ const KNOBS: Array[Dictionary] = [
 		"tip": "Whether a readout that is up for any reason OTHER than hover -- a queued plan, or the always-show setting -- also carries the HP digits. Off by default: either one can put a bar over half the board or all of it, and pointing at any of them reveals its number anyway."},
 	{"group": "Unit HUD", "node": "UnitMirror", "prop": "crown_badge_scale", "label": "Crown badge scale", "min": 0.5, "max": 4.0, "step": 0.1,
 		"tip": "Size of the leader's crown beside the health bar, as a multiple of the bar's height (#325 -- ring mode only; the squares style keeps its floating crown). At 1.0 the crown matches the bar line; push it up if the glyph turns to mush at distance."},
+	# --- The element-state row (#357) ---
+	{"group": "Unit HUD", "node": "UnitMirror", "prop": "state_icon_texels", "label": "State icon size", "min": 2.0, "max": 32.0, "step": 1.0,
+		"tip": "Size of each element-state icon above the health bar, in texels -- 16 is one cell. The source art is 32px (wet) and 16px (the frozen-tile stand-in for chilled), so powers of two land on exact reductions and anything else will shimmer as the camera moves. This is the first dial to reach for if the icons stop reading at play distance."},
+	{"group": "Unit HUD", "node": "UnitMirror", "prop": "state_icon_gap_texels", "label": "State row clearance", "min": 0.0, "max": 16.0, "step": 1.0,
+		"tip": "Gap between the top of the health bar's outline and the bottom of the state icons, in texels. Zero stacks them flush against the bar so the two read as one display; push it up to separate what a unit IS from how hurt it is, at the cost of climbing toward the selection icons above."},
+	{"group": "Unit HUD", "node": "UnitMirror", "prop": "state_icon_spacing_texels", "label": "State icon spacing", "min": 0.0, "max": 16.0, "step": 1.0,
+		"tip": "Gap between neighbouring state icons, in texels. Only visible on a unit holding more than one state, which today means wet AND chilled at once -- with two states the row cannot crowd, and this is the dial that matters when the vocabulary grows."},
 ]
 
 # A preset is SCENE MOOD, not game settings (dev, 2026-08-15). Everything in KNOBS is captured
@@ -281,6 +288,9 @@ const PRESET_EXCLUDED: Array[String] = [
 	"UnitMirror|alarm_peak_color",
 	"UnitMirror|unhovered_shows_number",
 	"UnitMirror|crown_badge_scale",
+	"UnitMirror|state_icon_texels",
+	"UnitMirror|state_icon_gap_texels",
+	"UnitMirror|state_icon_spacing_texels",
 ]
 
 # --- Identity ---------------------------------------------------------------------------

--- a/Classes/presentation/UnitHealthBar.gd
+++ b/Classes/presentation/UnitHealthBar.gd
@@ -24,6 +24,12 @@ class_name UnitHealthBar
 # World-scaled, not screen-constant (dev, 2026-08-15): it shrinks with distance like the icons
 # beside it, because it belongs to the scene rather than to the glass.
 #
+# Since #357 it also carries the ELEMENT-STATE row: one icon per state the unit holds, sitting just
+# above the bar and flush with its left edge. That is the first deliberate occupant of the channel
+# #346 freed — above the head is what this unit IS — and it is a CHILD of this group rather than a
+# display of its own precisely so it cannot grow a second visibility rule: a hidden bar hides it by
+# construction, which is what #350's one-gate ruling asks for.
+#
 # A dumb idempotent sink: it is TOLD a style, an HP pair and a prediction, and draws them. It never
 # reads a Unit, the plan, the board or the pointer — UnitMirror owns all of that, and owns the knobs
 # too, since the Look panel can only address nodes that exist in the scene.
@@ -50,6 +56,10 @@ var _doomed: MeshInstance3D    # #313: the span between current HP and what the 
 var _notch: MeshInstance3D     # #313: the marker AT the predicted level
 var _badge: MeshInstance3D     # #325: the leader's crown at bar height, left of the bar
 var _label: Label3D
+# #357: the element-state row above the bar. A POOL, grown on demand and hidden rather than freed —
+# the same contract UnitMirror.set_ghosts and BoardOverlays use, for the same reason: the count
+# changes every time a state lands or expires.
+var _state_icons: Array[MeshInstance3D] = []
 
 var _width := 32.0
 var _height := 6.0
@@ -74,6 +84,10 @@ var _has_prediction := false
 var _number_shown := true
 var _badge_texture: Texture2D = null
 var _badge_scale := 1.0
+var _state_textures: Array[Texture2D] = []
+var _state_icon_texels := 8.0
+var _state_gap_texels := 2.0
+var _state_spacing_texels := 1.0
 
 var _alarm: Tween
 var _alarm_peak_live := Color(1.0, 1.0, 1.0, 1.0)   # the peak the RUNNING tween was started with
@@ -203,6 +217,21 @@ func set_leader_badge(texture: Texture2D, scale: float) -> void:
 	_rebuild()
 
 
+# The element-state row (#357). Textures only: StateIcons stays the one answer to which art means
+# which state, and this node keeps reading no game state at all.
+#
+# The array is DUPLICATED on the way in because it joins the _drawn signature. That signature holds
+# a reference, so a caller reusing one buffer across frames would mutate the very thing the redraw
+# gate compares against and the row would freeze on whatever it drew first.
+func set_state_icons(textures: Array[Texture2D], size_texels: float, gap_texels: float,
+		spacing_texels: float) -> void:
+	_state_textures = textures.duplicate()
+	_state_icon_texels = size_texels
+	_state_gap_texels = gap_texels
+	_state_spacing_texels = spacing_texels
+	_rebuild()
+
+
 func set_shown(shown: bool) -> void:
 	visible = shown
 	if not shown:
@@ -286,6 +315,27 @@ func badge_size() -> Vector2:
 	return (_badge.mesh as QuadMesh).size
 
 
+# The state row's rendered facts (#357), read off the meshes like every accessor above. The count is
+# of SHOWN slots, not pooled ones: the pool only ever grows, so its size answers a different
+# question than "how many states is this unit wearing".
+func state_icon_count() -> int:
+	var count := 0
+	for quad: MeshInstance3D in _state_icons:
+		if quad.visible:
+			count += 1
+	return count
+
+
+func state_icon_size() -> Vector2:
+	if _state_icons.is_empty():
+		return Vector2.ZERO
+	return (_state_icons[0].mesh as QuadMesh).size
+
+
+func state_icon_offset(index: int) -> Vector3:
+	return (_state_icons[index].mesh as QuadMesh).center_offset
+
+
 func track_texels() -> float:
 	return roundf(_width)
 
@@ -304,7 +354,8 @@ func _rebuild() -> void:
 	var signature: Array = [_width, _height, _outline_texels, _fill_color, _missing_color,
 			_number_height, _number_outline, _number_color, _gap, _shows_max, _number_shown,
 			_doomed_color, _heal_color, _notch_color, _notch_texels,
-			_current, _maximum, _predicted, _has_prediction, _badge_texture, _badge_scale]
+			_current, _maximum, _predicted, _has_prediction, _badge_texture, _badge_scale,
+			_state_textures, _state_icon_texels, _state_gap_texels, _state_spacing_texels]
 	if signature == _drawn:
 		return
 	_drawn = signature
@@ -366,6 +417,44 @@ func _draw() -> void:
 		badge_material.albedo_texture = _badge_texture
 		badge_material.albedo_color = Color.WHITE
 
+	_draw_state_row(texel, track_w, bar_h, edge)
+
+
+# The element-state row (#357): square icons ABOVE the bar, the first one flush with the outline's
+# left edge and the rest growing rightward. Sized in texels rather than as a multiple of the bar's
+# height — the crown is bar-height because the dev asked for it AT bar height, while nothing ties
+# this row to how thick the gauge happens to be.
+#
+# Local space again, and that is the whole reason this lives inside the group: face() turns the
+# parent, so an offset written here is a real offset at every camera angle. Priority is the group's
+# base — the row is coplanar with nothing, so it has no sibling to sort against.
+func _draw_state_row(texel: float, track_w: float, bar_h: float, edge: float) -> void:
+	while _state_icons.size() < _state_textures.size():
+		var quad := _make_quad(BoardOverlays.UNIT_HUD_RENDER_PRIORITY)
+		var fresh := quad.material_override as StandardMaterial3D
+		fresh.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST   # pixel art, like the badge
+		add_child(quad)
+		_state_icons.append(quad)
+	var icon: float = maxf(roundf(_state_icon_texels), 1.0)
+	var gap: float = maxf(roundf(_state_gap_texels), 0.0)
+	var spacing: float = maxf(roundf(_state_spacing_texels), 0.0)
+	# Clear of the outline's TOP edge, and flush with its LEFT one — the same reference the crown
+	# measures from, so the two marks share a silhouette rather than each finding their own.
+	var row_y: float = (bar_h * 0.5 + edge + gap + icon * 0.5) * texel
+	var left: float = -(track_w * 0.5 + edge)
+	for i in _state_icons.size():
+		var quad: MeshInstance3D = _state_icons[i]
+		# Occupancy, NOT visibility: extras are parked rather than freed, and the bar's own
+		# visible flag is what decides whether any of this is seen.
+		quad.visible = i < _state_textures.size()
+		if not quad.visible:
+			continue
+		_size_quad(quad, icon * texel, icon * texel,
+				(left + icon * 0.5 + float(i) * (icon + spacing)) * texel, row_y)
+		var material := quad.material_override as StandardMaterial3D
+		material.albedo_texture = _state_textures[i]
+		material.albedo_color = Color.WHITE
+
 
 # The prediction (#313). The SPAN runs between where the bar is now and where the plan leaves it,
 # so the same two quads say "this much is coming off" and "this much is coming back" — the colour is
@@ -400,10 +489,13 @@ func _segment_color() -> Color:
 	return _heal_color if _has_prediction and _predicted > _current else _doomed_color
 
 
-func _size_quad(quad: MeshInstance3D, width: float, height: float, offset_x: float) -> void:
+# offset_y defaults to 0 because everything in the bar proper is vertically centred on it; the
+# state row is the one thing that sits OFF the line, so it is the only caller that passes it.
+func _size_quad(quad: MeshInstance3D, width: float, height: float, offset_x: float,
+		offset_y := 0.0) -> void:
 	var mesh := quad.mesh as QuadMesh
 	mesh.size = Vector2(width, height)
-	mesh.center_offset = Vector3(offset_x, 0.0, 0.0)
+	mesh.center_offset = Vector3(offset_x, offset_y, 0.0)
 
 
 func _quad_width(quad: MeshInstance3D) -> float:

--- a/Classes/presentation/UnitMirror.gd
+++ b/Classes/presentation/UnitMirror.gd
@@ -30,8 +30,9 @@ class_name UnitMirror
 # #350 adds the THIRD and last reason: a player who has asked for every bar, always. That one is a
 # PREFERENCE rather than a derivation, so it comes off PlayerSettings rather than off anything on
 # the board — one more disjunct in the same expression, no new per-unit state, nothing to compute.
-# The expression is now THE gate for this volume: #357's state-icon row is specified to ride it
-# rather than grow its own, so a second visibility rule in this file would be the bug.
+# The expression is now THE gate for this volume, and #357's state-icon row rides it: the icons are
+# CHILDREN of the bar, so a hidden bar hides them with nothing to keep in step. A second visibility
+# rule in this file would be the bug.
 #
 # It reads the MODEL for that, not the 2D — the departure from OverlayMirror's "the 2D stays the one
 # authority" that #229 already made, and for the same reason: the flat view draws no HP over units
@@ -117,6 +118,17 @@ const PIXELS_PER_CELL := float(GridUtils.TILE_SIZE)  # 16 — grid.map_to_local'
 @export var unhovered_shows_number := false
 # #325: the leader's crown badge beside the bar, as a multiple of the bar's own height.
 @export var crown_badge_scale := 1.0
+
+# --- The element-state row (#357) ------------------------------------------------------
+# One icon per state the unit holds, just above the bar. In TEXELS, at the same pixel density as
+# the bar and every sprite — the crown is measured against the bar's height because the dev asked
+# for it at bar height, and nothing ties these to how thick the gauge is.
+#
+# 8 is half a cell, and deliberate rather than arbitrary: both source icons are powers of two (the
+# wet drop 32px, the frozen-tile placeholder 16px), so both land on exact 4:1 and 2:1 reductions.
+@export var state_icon_texels := 8.0
+@export var state_icon_gap_texels := 2.0        # clearance above the bar's outline
+@export var state_icon_spacing_texels := 1.0    # between neighbouring icons
 
 # Which unit the pointer resolves to, injected by battle3d — the same idiom as pointer_source and
 # board_source. A Callable rather than a game back-ref keeps this node testable and keeps the
@@ -333,8 +345,8 @@ func _sync_bar(unit: Unit, sprite: UnitSprite3D, bar: UnitHealthBar, hovered: bo
 	# differs from current", which made membership a function of LIVE HP — so every bar switched
 	# itself off at the instant its own hit landed, mid-pass, one at a time.
 	var foretold := plan != null and PlanResolver.plan_changes(unit, plan.hypo)
-	# THE gate: three reasons, ONE expression (#350). #357's state-icon row is specified to ride
-	# this rather than grow its own, so a second visibility rule anywhere in this file is the bug.
+	# THE gate: three reasons, ONE expression (#350). #357's state-icon row rides it structurally —
+	# the icons hang off the bar — so a second visibility rule anywhere in this file is the bug.
 	var shown := hovered or foretold or always_on
 	bar.set_shown(shown)
 	if not shown:
@@ -351,6 +363,11 @@ func _sync_bar(unit: Unit, sprite: UnitSprite3D, bar: UnitHealthBar, hovered: bo
 			and unit.squad.get_leader() == unit and unit.has_squad()
 	var crown: Texture2D = OverlayManager.ICON_TEXTURES[OverlayIcon.IconType.CROWN] if leads else null
 	bar.set_leader_badge(crown, crown_badge_scale)
+	# #357: what this unit IS, in the channel #346 freed. Below the early return above, so the row
+	# rides THE gate rather than growing one — and the art comes from StateIcons, which stays the
+	# one answer to which icon means which state for all three surfaces that draw them.
+	bar.set_state_icons(StateIcons.textures_for(unit.element_states), state_icon_texels,
+			state_icon_gap_texels, state_icon_spacing_texels)
 	if foretold:
 		bar.set_prediction(_predicted_hp(unit, plan), PlanResolver.plan_fells(unit, plan.hypo))
 	else:

--- a/Classes/ui/panels/StateIcons.gd
+++ b/Classes/ui/panels/StateIcons.gd
@@ -2,13 +2,35 @@ extends Object
 class_name StateIcons
 
 # Single source of truth for elemental-state icon art, shared by every surface that shows a
-# unit's held states (hover card, inspect bar). Append-only alongside Elemental.State.
+# unit's held states (hover card, inspect bar, and since #357 the world-space row over the health
+# bar). Append-only alongside Elemental.State.
 const ICONS := {
 	Elemental.State.WET: preload("res://Art/Icons/StateIcons/WetIcon.png"),
+	# PLACEHOLDER (dev call, #357): the FROZEN terrain tile standing in until a 16px CHILLED icon
+	# exists. It lands here rather than at any one surface, so all three pick it up at once.
+	Elemental.State.CHILLED: preload("res://Art/Icons/TerrainIcons/Ice.png"),
 }
-const ICON_SIZE := Vector2i(16, 16)
+# The size every icon RENDERS at, not the size the source art happens to be — those disagree (the
+# wet drop is 32px, the ice tile 16px) and an unnormalised row shows one at half the other's size.
+# 32 is the larger source, so existing surfaces are untouched and only the placeholder scales.
+const ICON_SIZE := Vector2i(32, 32)
 
-# Clears `container` and refills it with one 16x16 icon per non-NONE state the unit holds.
+# The art a state list resolves to, in the caller's own order — what a surface that draws its own
+# icons reads, so nothing outside this file indexes ICONS directly (#357's 3D row). A state with no
+# art is SKIPPED here rather than falling back the way populate does below: a world-space row has no
+# text to fall back to. With CHILLED covered that skip is a guard for the next state, not live.
+static func textures_for(states: Array) -> Array[Texture2D]:
+	var textures: Array[Texture2D] = []
+	for state in states:
+		if state == Elemental.State.NONE:
+			continue
+		var tex: Texture2D = ICONS.get(state, null)
+		if tex != null:
+			textures.append(tex)
+	return textures
+
+
+# Clears `container` and refills it with one ICON_SIZE icon per non-NONE state the unit holds.
 # A state with no art yet falls back to a short text label, so nothing is silently dropped.
 # Every entry carries the state's glossary short text as its tooltip (#135) — the unit half of
 # visual-clarity.md's tooltip doctrine: hovering an elemental effect explains it in place.
@@ -24,9 +46,13 @@ static func populate(container: Node, states: Array) -> void:
 		if tex != null:
 			var rect := TextureRect.new()
 			rect.texture = tex
+			# Rendered AT ICON_SIZE whatever the source resolution — the same recipe
+			# HoverInfoPanelControl already draws these 16px terrain icons at 32 with. Nearest
+			# because the scale is a clean power of two and this is pixel art.
 			rect.custom_minimum_size = ICON_SIZE
-			rect.expand_mode = TextureRect.EXPAND_KEEP_SIZE
-			rect.stretch_mode = TextureRect.STRETCH_KEEP
+			rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+			rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+			rect.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 			rect.tooltip_text = tip
 			rect.mouse_filter = Control.MOUSE_FILTER_STOP
 			container.add_child(rect)

--- a/Classes/ui/queue/ActionQueueRow.gd
+++ b/Classes/ui/queue/ActionQueueRow.gd
@@ -9,10 +9,6 @@ class_name ActionQueueRow
 
 const CROWN_ICON := preload("res://Art/Icons/BoardIcons/CrownIcon.png")
 
-const STATE_ICONS := {
-	Elemental.State.WET: preload("res://Art/Icons/StateIcons/WetIcon.png"),
-}
-
 var action: BaseAction
 var draggable := false
 var is_volley_header := false
@@ -84,9 +80,11 @@ func _draw() -> void:
 func _show_elemental_overlays(atk: AttackAction) -> void:
 	if atk.resolved == null:
 		return
+	# StateIcons.ICONS, not a local copy: this file kept its own one-entry twin until #357 added
+	# CHILLED, at which point the two would have disagreed about what a chill attack shows.
 	for state in atk.resolved.states_added:
-		if STATE_ICONS.has(state):
-			_overlay_behind(action_icon, STATE_ICONS[state], Vector2(0, -8))
+		if StateIcons.ICONS.has(state):
+			_overlay_behind(action_icon, StateIcons.ICONS[state], Vector2(0, -8))
 	for icon in atk.resolved.reaction_icons:
 		if icon != null:
 			_overlay_behind(target_texture, icon)

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -7,7 +7,7 @@ its child [#49 Action Queue UX](https://github.com/Phaazoid/Godoiosis/issues/49)
 This is a *guidelines* doc, not a spec — it captures the principles we're holding the work to,
 plus the running order of the queue-UX checklist. Update it as items land.
 
-**Canon checked through #365 (2026-08-19).**
+**Canon checked through #368 (2026-08-19).**
 
 ## Principles
 
@@ -342,8 +342,9 @@ Two things that generalise past this ticket:
    where the toggle is on. Both bar suites now call `reset_for_test()` in `before_test`. Any future
    store with a disk fallback owes the same seam on the same day it is written.
 2. **The gate is ONE named expression, deliberately.** [#357](https://github.com/Phaazoid/Godoiosis/issues/357)'s
-   state-icon row is specified to ride it rather than grow its own, so a second visibility rule in
-   `UnitMirror` is the bug — the ticket said so before it was built and the code says so now.
+   state-icon row rides it rather than growing its own, so a second visibility rule in `UnitMirror`
+   is the bug — the ticket said so before it was built, and what shipped is stronger than the
+   ticket asked: the icons hang off the bar, so there is no second rule to keep in step.
 
 **Still open, and named rather than fixed: `render_priority` is a GLOBAL sort key in the alpha
 queue, not a per-bar one.** Each `UnitHealthBar` claims `UNIT_HUD_RENDER_PRIORITY + 0..+6` for its
@@ -396,15 +397,33 @@ member wider.
 Two things the retirement exposed, both worth keeping in mind. **The head icon was never the
 general answer**: TARGET was created in exactly one flow, so rescue, intimidate and join-squad had
 their candidates marked *nowhere in either view* until #316, and Squad Up only looked right because
-someone had patched that one screen. And **the freed channel's first occupant is now filed, in two
-halves (dev direction, 2026-08-18):** [#357](https://github.com/Phaazoid/Godoiosis/issues/357)
-puts a `StateIcons` row just above each unit's health bar (riding #350's visibility gate, never
-growing its own), and [#358](https://github.com/Phaazoid/Godoiosis/issues/358) makes the sprite
-itself wear its status — wet drip, frost sheen, Crisis — the channel that keeps states readable
-when [#350](https://github.com/Phaazoid/Godoiosis/issues/350)'s toggle hides the bars.
-`StateIcons.ICONS` still carries art for WET alone; a CHILLED icon is the open art ask. Always-on
-state icons remain the trigger #229 named for the crowding question it deferred — two states
-cannot crowd, a longer vocabulary can.
+someone had patched that one screen. And **the freed channel's first occupant was filed in two
+halves (dev direction, 2026-08-18), of which the first is now BUILT:**
+[#357](https://github.com/Phaazoid/Godoiosis/issues/357) puts a `StateIcons` row just above each
+unit's health bar, and [#358](https://github.com/Phaazoid/Godoiosis/issues/358) — still open —
+makes the sprite itself wear its status (wet drip, frost sheen, Crisis), the channel that keeps
+states readable when [#350](https://github.com/Phaazoid/Godoiosis/issues/350)'s toggle hides the
+bars. Always-on state icons remain the trigger #229 named for the crowding question it deferred —
+two states cannot crowd, a longer vocabulary can.
+
+**#357's structural point is that the row has NO visibility rule of its own.** The icons are
+CHILDREN of `UnitHealthBar`, so a hidden bar hides them by construction — there is no second
+expression to keep in step with the gate, which is what the ticket asked for one level more weakly
+(*"specified to ride it"*). Everything else follows the crown badge #325 put on the same bar: quads
+in the group's local space, so `face()` turns the whole display and nothing gets a billboard basis
+of its own; sizes in texels; a POOL that parks extras rather than freeing them, since the count
+changes every time a state lands or expires. Three Look knobs (icon size, row clearance, spacing),
+preset-excluded like the rest of the Unit HUD group — a mission may not hide what a unit IS.
+
+**CHILLED's art is the FROZEN terrain tile, as a declared placeholder (dev call, 2026-08-19).**
+`StateIcons.ICONS` carried WET alone, and the alternative — falling back to a text label in world
+space — reads as mush at icon size. The stand-in lands in the shared table rather than at one
+surface, so the hover card, the inspect bar and the row all show it, and a real 16px CHILLED icon
+is a one-line swap. Two consequences were paid at the same time, both of them Law #4 arriving on
+schedule: `ActionQueueRow` had kept its **own** one-entry copy of the art table, which would have
+started disagreeing the moment CHILLED existed (it now reads `StateIcons.ICONS`); and the two
+source images disagree in size (32px wet, 16px ice), so `populate` now renders every icon at
+`ICON_SIZE` — the recipe `HoverInfoPanelControl` already uses to draw these same terrain icons.
 
 The doctrine governing everything that enters these channels (dev, 2026-08-18): *"Having access to
 fancy effects doesn't necessitate using them. Using them in the correct places rather than

--- a/tests/presentation/test_unit_health_bar.gd
+++ b/tests/presentation/test_unit_health_bar.gd
@@ -312,3 +312,118 @@ func test_turning_the_setting_off_returns_the_board_to_hover_only() -> void:
 	await _settle()
 
 	assert_array(_shown_bars()).is_empty()
+
+
+# --- The element-state row (#357) --------------------------------------------------------------
+# The first deliberate occupant of the head channel #346 freed: what this unit IS, above the bar
+# that says how hurt it is. Driven through the same wire as everything above — states go on the
+# UNIT, the pointer moves, and the row is read off the meshes. Nothing here calls the bar directly.
+
+func _wet(cell: Vector2i) -> Unit:
+	var unit := _spawn(PLAYER, cell)
+	unit.add_element_state(Elemental.State.WET)
+	return unit
+
+
+func test_a_hovered_units_row_shows_one_icon_per_held_state() -> void:
+	var unit := _wet(Vector2i(2, 2))
+	_point_at(Vector2i(2, 2))
+	await _settle()
+	var bar: UnitHealthBar = _unit_mirror.bar_for(unit)
+	assert_bool(bar.visible).is_true()
+	assert_int(bar.state_icon_count()).is_equal(1)
+
+	# CHILLED reaches the row through StateIcons like any other state — it holds a placeholder
+	# texture rather than its own art, and the row cannot tell the difference.
+	unit.add_element_state(Elemental.State.CHILLED)
+	await _settle()
+	assert_int(bar.state_icon_count()).is_equal(2)
+
+
+func test_a_hovered_unit_with_no_states_wears_no_row() -> void:
+	var unit := _spawn(PLAYER, Vector2i(2, 2))
+	_point_at(Vector2i(2, 2))
+	await _settle()
+	var bar: UnitHealthBar = _unit_mirror.bar_for(unit)
+	assert_bool(bar.visible).is_true()   # the BAR is up; the row is what must be empty
+	assert_int(bar.state_icon_count()).is_equal(0)
+
+
+func test_the_row_sits_clear_above_the_bar_and_flush_with_its_left_edge() -> void:
+	var unit := _wet(Vector2i(2, 2))
+	_point_at(Vector2i(2, 2))
+	await _settle()
+	var bar: UnitHealthBar = _unit_mirror.bar_for(unit)
+
+	# Derived from the knobs, never pinned: the claim is the RELATIONSHIP (clear of the outline's
+	# top, flush with its left), which survives every retune of the values underneath it.
+	var texel := 1.0 / UnitSprite3D.texels_per_unit
+	var icon: float = roundf(_unit_mirror.state_icon_texels)
+	var edge: float = roundf(_unit_mirror.bar_outline_texels)
+	var bar_h: float = roundf(_unit_mirror.bar_height_texels)
+	var track: float = roundf(_unit_mirror.bar_width_texels)
+	var gap: float = roundf(_unit_mirror.state_icon_gap_texels)
+
+	assert_float(bar.state_icon_size().x).is_equal_approx(icon * texel, 0.001)
+	assert_float(bar.state_icon_size().y).is_equal_approx(icon * texel, 0.001)
+
+	var offset := bar.state_icon_offset(0)
+	# Its BOTTOM edge clears the outline's top edge by the gap.
+	assert_float(offset.y - bar.state_icon_size().y * 0.5).is_equal_approx(
+			(bar_h * 0.5 + edge + gap) * texel, 0.001)
+	# Its LEFT edge sits on the outline's left edge — "centered left", the dev's words.
+	assert_float(offset.x - bar.state_icon_size().x * 0.5).is_equal_approx(
+			-(track * 0.5 + edge) * texel, 0.001)
+
+
+func test_the_row_grows_rightward_without_moving_the_first_icon() -> void:
+	var unit := _wet(Vector2i(2, 2))
+	_point_at(Vector2i(2, 2))
+	await _settle()
+	var bar: UnitHealthBar = _unit_mirror.bar_for(unit)
+	var alone := bar.state_icon_offset(0).x
+
+	unit.add_element_state(Elemental.State.CHILLED)
+	await _settle()
+
+	# LEFT-aligned, not centred: a second state must push rightward off a fixed left edge. A row
+	# that re-centred would pass a count test and still slide under the bar every time a state
+	# landed, which is the thing you would notice and a counter would not.
+	assert_float(bar.state_icon_offset(0).x).override_failure_message(
+			"the first icon moved when a second arrived — the row is centring, not left-aligning") \
+			.is_equal_approx(alone, 0.001)
+	assert_float(bar.state_icon_offset(1).x).is_greater(bar.state_icon_offset(0).x)
+
+
+func test_a_state_leaving_takes_its_icon_away() -> void:
+	var unit := _wet(Vector2i(2, 2))
+	unit.add_element_state(Elemental.State.CHILLED)
+	_point_at(Vector2i(2, 2))
+	await _settle()
+	var bar: UnitHealthBar = _unit_mirror.bar_for(unit)
+	assert_int(bar.state_icon_count()).is_equal(2)   # precondition, via the real path
+
+	unit.remove_element_state(Elemental.State.WET)
+	await _settle()
+
+	# The pool only ever GROWS, so the retired slot is still there — parked, not drawn. A row that
+	# forgot to park it would keep claiming a state the unit shed.
+	assert_int(bar.state_icon_count()).is_equal(1)
+
+
+func test_the_row_rides_the_bars_own_visibility_and_not_a_rule_of_its_own() -> void:
+	# The one-gate claim (#350), asserted where it is visible: a wet unit nobody is pointing at
+	# wears nothing, and the SETTING alone is enough to put its states on the board.
+	var unit := _wet(Vector2i(2, 2))
+	_point_at(Vector2i(20, 20))   # empty ground: not hovered, no plan
+	await _settle()
+	var bar: UnitHealthBar = _unit_mirror.bar_for(unit)
+	assert_bool(bar.visible).is_false()
+
+	_set_always_on(true)
+	await _settle()
+
+	assert_bool(bar.visible).is_true()
+	assert_int(bar.state_icon_count()).override_failure_message(
+			"the row did not follow the bar up — it has grown a visibility rule of its own") \
+			.is_equal(1)

--- a/tests/ui/test_state_icons.gd
+++ b/tests/ui/test_state_icons.gd
@@ -35,3 +35,48 @@ func test_populate_clears_prior_contents() -> void:
 	StateIcons.populate(box, [])
 	await get_tree().process_frame
 	assert_int(box.get_child_count()).is_equal(0)
+
+# --- CHILLED's placeholder art, and the 3D row's door (#357) -------------------------------
+
+func test_chilled_resolves_to_art_rather_than_the_text_fallback() -> void:
+	# The dev's call: the frozen-water tile stands in until a real CHILLED icon exists. It lands in
+	# ICONS rather than at any one surface, so this asserts the SHARED table answered — a per-surface
+	# fix would leave the other two showing a text label.
+	var box: HBoxContainer = auto_free(HBoxContainer.new())
+	add_child(box)
+
+	StateIcons.populate(box, [Elemental.State.CHILLED])
+	await get_tree().process_frame
+	assert_int(box.get_child_count()).is_equal(1)
+	assert_object(box.get_child(0)).is_instanceof(TextureRect)
+
+
+func test_every_icon_is_configured_to_render_at_one_size() -> void:
+	# A PROXY for "the row is uniform", asserted at the mechanism because a drawn size is not
+	# observable headless. It has teeth against the revert that matters: the source art disagrees
+	# (32px wet, 16px ice), so with expand/stretch left at KEEP the row shows one at half the other.
+	var box: HBoxContainer = auto_free(HBoxContainer.new())
+	add_child(box)
+
+	StateIcons.populate(box, [Elemental.State.WET, Elemental.State.CHILLED])
+	await get_tree().process_frame
+	assert_int(box.get_child_count()).is_equal(2)
+	for child in box.get_children():
+		var rect := child as TextureRect
+		assert_object(rect).is_not_null()
+		assert_vector(rect.custom_minimum_size).is_equal(Vector2(StateIcons.ICON_SIZE))
+		assert_int(rect.expand_mode).is_equal(TextureRect.EXPAND_IGNORE_SIZE)
+		assert_int(rect.stretch_mode).is_equal(TextureRect.STRETCH_KEEP_ASPECT_CENTERED)
+
+
+func test_textures_for_skips_none_and_keeps_the_callers_order() -> void:
+	# The door the world-space row reads (#357), so UnitMirror never indexes ICONS itself.
+	var textures := StateIcons.textures_for([Elemental.State.CHILLED, Elemental.State.NONE,
+			Elemental.State.WET])
+	assert_int(textures.size()).is_equal(2)
+	assert_object(textures[0]).is_same(StateIcons.ICONS[Elemental.State.CHILLED])
+	assert_object(textures[1]).is_same(StateIcons.ICONS[Elemental.State.WET])
+
+
+func test_textures_for_is_empty_for_a_unit_holding_nothing() -> void:
+	assert_array(StateIcons.textures_for([])).is_empty()


### PR DESCRIPTION
Closes #357.

Your ruling on #346's open half: *"I want an icon for what states a unit has to appear just above their health bar, centered left."* This is that, and it's the crown badge from #325 one step harder — N icons rather than one, so the single quad becomes a pool.

## What it does

A row of `StateIcons` art sits above each unit's health bar, flush with the outline's **left** edge and growing rightward. It's built from the same recipe as the crown: unshaded, fog-proof, nearest-filtered quads laid out in the bar group's local space, so `face()` turns the whole display and nothing gets a billboard basis of its own.

**The row has no visibility rule — structurally, not by discipline.** The icons are *children* of `UnitHealthBar`, so #350's one gate hides them with nothing to keep in step. The ticket asked for this one level more weakly ("specified to ride it"); what shipped can't drift.

## The CHILLED call

You said to use the frozen water tile as the placeholder, and it's a better answer than any of the three I offered — it lands in `StateIcons.ICONS`, so the hover card and inspect bar get CHILLED too, not just the 3D row. Real art is a one-line swap later.

That pulled in two consequences, both Law #4 arriving on schedule. Flagging them because they widen the diff past the ticket:

- **`ActionQueueRow` kept its own one-entry copy of the art table.** Harmless while the table had one entry — but the moment CHILLED existed, a queued chill attack would have shown no state overlay while a wet one did. It now reads `StateIcons.ICONS`.
- **The two source images disagree in size** (32px wet, 16px ice), and `populate` was letting each rect take its texture's native size — so the row would have shown one icon at half the other's. `ICON_SIZE` is now 32 (the larger source, so every existing 2D surface is pixel-identical) and every icon renders at it, using the recipe `HoverInfoPanelControl` already uses for these same terrain icons.

Say the word if you'd rather either of those was its own ticket.

## Knobs (Look tab → Unit HUD)

- **State icon size** — in texels, 16 = one cell. Defaults to 8: both sources are powers of two, so 8 is an exact 4:1 and 2:1 reduction and won't shimmer. First dial to reach for if the icons don't read.
- **State row clearance** — gap between the bar's outline and the icons.
- **State icon spacing** — between neighbouring icons; only visible on a unit holding both states.

All three preset-excluded, like the rest of the Unit HUD group: a mission may not wear a look that hides what a unit IS.

## Verification

`tests/presentation` 284/284 and `tests/ui` 183/183, 467 together. 10 new cases, each confirmed executed in the XML report rather than assumed.

Two mutants, run isolated on the one suite file, each reddening the case it aimed at and nothing earlier:

- **the wire** — severing the `set_state_icons` call reds `shows_one_icon_per_held_state`. Both ends can be perfectly correct and unconnected; that's #103's shape.
- **the pool** — making it never park extras reds `a_state_leaving_takes_its_icon_away`. A count-up-only test is blind to stale slots.

The visibility gate deliberately gets no mutant: a hidden parent hides a child by construction, so there is no second rule to break.

**Not verified, and it's the thing worth your eye:** whether an 8-texel icon actually reads at play distance. Headless can't see it, and that volume already holds the bar, the digits, the crown and the selection icons. Hover a wet unit, chill one, then flip always-show on and see whether the board gets busy.
