### PR TITLE
#325 verdict: the crown goes back over the head, the rings stay

### DIFF
--- a/Classes/board/OverlayManager.gd
+++ b/Classes/board/OverlayManager.gd
@@ -91,19 +91,21 @@ enum OverlayType {
 	INVALIDMOVE
 }
 
+# The ONE answer to what each marker type looks like, applied once by create_unit_icon's setup --
+# so _style_icon below never touches a texture, and there is no second place a marker's art can come
+# from. Membership is a per-squad ring underfoot, leadership the crown over the head (#325, settled
+# 2026-08-19); the legacy green square lost, and SquadHighlightIcon.png is now unreferenced.
 const ICON_TEXTURES = {
 	OverlayIcon.IconType.CROWN: preload("res://Art/Icons/BoardIcons/CrownIcon.png"),
-	OverlayIcon.IconType.SQUADMEMBER: preload("res://Art/Icons/BoardIcons/SquadHighlightIcon.png")
+	OverlayIcon.IconType.SQUADMEMBER: preload("res://Art/Icons/BoardIcons/SquadRingIcon.png")
 }
 
-# --- Squad marker style (#325 experiment) --------------------------------------------------
-# Rings underfoot vs the legacy over-the-head squares. static, the ATTACK_MODULATE pattern, so
-# the Look tab's toggle reaches it without a node ref; read by _style_icon here and by
-# OverlayMirror._icons, so flipping it moves BOTH stacks. Style only -- icon LIFECYCLE (when a
-# marker exists) is untouched either way. The losing style gets deleted when the experiment ends.
-static var SQUAD_MARKER_RINGS := true
+# --- Squad markers (#325, settled 2026-08-19) ----------------------------------------------
+# The dev played both styles and took a MIX: membership is a per-squad coloured RING underfoot,
+# leadership is the ORIGINAL crown over the head. The legacy green squares lost and are deleted --
+# no toggle, no second style. SQUAD_RING_ALPHA stays a live Look-tab value; it tunes a shipped
+# feature rather than picking between two.
 static var SQUAD_RING_ALPHA := 0.9
-const SQUAD_RING_TEXTURE := preload("res://Art/Icons/BoardIcons/SquadRingIcon.png")
 # Per-squad hues, dealt lazily by SquadManager when a squad first gains a squadmate: cool for
 # friendly squads, warm for enemy ones, so "which squad" and "whose side" read from one glance.
 # Plain consts, one per line -- edit freely; WHITE is reserved as the not-yet-dealt sentinel.
@@ -451,26 +453,21 @@ func create_unit_icon(unit: Unit, type: OverlayIcon.IconType) -> OverlayIcon:
 	icons_by_unit[unit][type] = icon
 	return icon
 
-# Presentation only (#325): which texture/tint/z an icon wears under the current marker style.
-# Rings lie under the unit in the squad's dealt hue; the crown decal keeps its authored gold so
-# it never fights the palette. Square mode is byte-for-byte the legacy look.
+# Presentation only: the TINT and Z a marker wears. Never the texture -- ICON_TEXTURES above is that
+# one answer and setup applies it, so this cannot become a second place a marker's art comes from.
+# What genuinely varies per UNIT is the squad hue, and only membership rings carry one; the crown
+# keeps its authored gold over the head so it never fights the palette.
 func _style_icon(icon: OverlayIcon, unit: Unit) -> void:
-	if SQUAD_MARKER_RINGS and icon.icon_type == OverlayIcon.IconType.SQUADMEMBER:
+	if icon.icon_type == OverlayIcon.IconType.SQUADMEMBER:
 		icon.sprite.z_index = RING_Z_INDEX
-		icon.sprite.texture = SQUAD_RING_TEXTURE
 		var hue: Color = unit.squad.ring_hue if unit.squad != null else Color.WHITE
 		icon.sprite.modulate = Color(hue.r, hue.g, hue.b, SQUAD_RING_ALPHA)
 	else:
-		# CROWN keeps the legacy over-sprite form in BOTH styles: in ring mode the 3D never
-		# mirrors it (the leader reads off the health bar's badge -- UnitMirror), but the flat
-		# view has no bar to badge, so its head crown stays. The readout family's #292
-		# asymmetry, one member wider.
-		icon.sprite.texture = ICON_TEXTURES[icon.icon_type]
 		icon.sprite.z_index = HEAD_ICON_Z_INDEX
 		icon.sprite.modulate = Color.WHITE
 
-# The Look-tab toggle restyles markers already on screen; walking the store here keeps the
-# panel ignorant of icon lifecycle.
+# The Look tab's ring-opacity slider restyles markers already on screen; walking the store here
+# keeps the panel ignorant of icon lifecycle.
 func restyle_squad_markers() -> void:
 	for unit in icons_by_unit.keys().duplicate():
 		if not is_instance_valid(unit):

--- a/Classes/dev/LookTool.gd
+++ b/Classes/dev/LookTool.gd
@@ -292,26 +292,17 @@ func _rebuild() -> void:
 
 # --- #325 experiment: squares vs rings ---------------------------------------------------
 
-# Bespoke rows rather than table entries: the style flag is a bool STATIC on OverlayManager
-# (both stacks read it), which neither KNOBS (property paths on scene nodes) nor LAYER_KNOBS
-# (Color-only) can address. They die with the experiment, whichever style wins.
+# A bespoke row rather than a table entry: ring alpha is a float STATIC on OverlayManager (both
+# stacks read it), which neither KNOBS (property paths on scene nodes) nor LAYER_KNOBS (Color-only)
+# can address. The Rings-underfoot checkbox beside it died with #325's verdict -- rings won for
+# membership, the head crown won for leadership, and there is no second style left to pick.
 func _build_squad_marker_rows(rows: VBoxContainer) -> void:
-	_add_heading(rows, "Squad markers (#325 experiment)")
+	_add_heading(rows, "Squad markers")
 	var first := rows.get_child_count()
-	DevWidgets.add_checkbox(rows, "Rings underfoot", OverlayManager.SQUAD_MARKER_RINGS,
-		_on_ring_toggle)
-	_apply_tip(rows, first, DevWidgets.wrap_tooltip(
-		"ON: squad membership reads as a per-squad coloured ring under each member, with the crown decal inside the leader's. OFF: the legacy green squares over heads. MOVES BOTH STACKS -- and takes effect on markers already up. The losing style gets deleted when the experiment resolves."))
-	first = rows.get_child_count()
 	DevWidgets.add_slider(rows, "Ring opacity", OverlayManager.SQUAD_RING_ALPHA, 0.1, 1.0, 0.01,
 		_on_ring_alpha)
 	_apply_tip(rows, first, DevWidgets.wrap_tooltip(
-		"Alpha of the membership rings (the crown decal stays opaque). MOVES BOTH STACKS."))
-
-
-func _on_ring_toggle(on: bool) -> void:
-	OverlayManager.SQUAD_MARKER_RINGS = on
-	_restyle_squad_markers()
+		"Alpha of the per-squad membership rings under each member (the leader's crown, over the head, stays opaque). MOVES BOTH STACKS -- and takes effect on markers already up."))
 
 
 func _on_ring_alpha(moved: float) -> void:

--- a/Classes/presentation/LookKnobs.gd
+++ b/Classes/presentation/LookKnobs.gd
@@ -217,8 +217,6 @@ const KNOBS: Array[Dictionary] = [
 		"tip": "What the predicted-loss span pulses TO when the plan predicts a named rung -- a down, a kill, or Crisis. It pulses back to the ordinary loss colour, so this is only the bright half of the cue; make it too close to that colour and the pulse stops registering."},
 	{"group": "Unit HUD", "node": "UnitMirror", "prop": "unhovered_shows_number", "label": "Unhovered bars show number",
 		"tip": "Whether a readout that is up for any reason OTHER than hover -- a queued plan, or the always-show setting -- also carries the HP digits. Off by default: either one can put a bar over half the board or all of it, and pointing at any of them reveals its number anyway."},
-	{"group": "Unit HUD", "node": "UnitMirror", "prop": "crown_badge_scale", "label": "Crown badge scale", "min": 0.5, "max": 4.0, "step": 0.1,
-		"tip": "Size of the leader's crown beside the health bar, as a multiple of the bar's height (#325 -- ring mode only; the squares style keeps its floating crown). At 1.0 the crown matches the bar line; push it up if the glyph turns to mush at distance."},
 ]
 
 # A preset is SCENE MOOD, not game settings (dev, 2026-08-15). Everything in KNOBS is captured
@@ -280,7 +278,6 @@ const PRESET_EXCLUDED: Array[String] = [
 	"UnitMirror|notch_texels",
 	"UnitMirror|alarm_peak_color",
 	"UnitMirror|unhovered_shows_number",
-	"UnitMirror|crown_badge_scale",
 ]
 
 # --- Identity ---------------------------------------------------------------------------

--- a/Classes/presentation/OverlayMirror.gd
+++ b/Classes/presentation/OverlayMirror.gd
@@ -229,12 +229,16 @@ func _split_knockback(om: OverlayManager, trails: Array[Dictionary], ghosts: Arr
 			ghosts.append(entry)
 
 
-# Selection icons (crown / squadmember): anchored to the icon's own authored target_cell, and
-# forked on the 2D's own style flag (#325 experiment). Squares ride ICONS as head billboards
-# with a per-type y-stagger against z-fighting (the 2D stacks them by tree order); rings ride
-# GROUND_ICONS as surface decals, texture and tint arriving BY COPY from the 2D sprite -- the
-# squad hue is authored there, never re-derived here. CROWN is skipped in ring mode: the leader
-# reads off the health bar's badge (UnitMirror), and the flat view keeps its own head crown.
+# Selection icons, routed by TYPE rather than by a style mode (#325 verdict, dev call after playing
+# both, 2026-08-19). CROWN rides ICONS as a head billboard -- leadership is what a unit IS, and
+# nothing has read better over a head than the original crown. Everything else (today, SQUADMEMBER)
+# rides GROUND_ICONS as a surface decal in the squad's own hue, texture and tint arriving BY COPY
+# from the 2D sprite, so the hue is authored in one place and never re-derived here.
+#
+# The leader wears BOTH: a ring because they are a member, the crown because they lead.
+#
+# No per-type y-stagger any more. It existed to keep several head-icon types off each other's
+# plane; CROWN is the channel's only tenant now, so there is nothing to stagger against.
 func _icons(om: OverlayManager) -> void:
 	var heads: Array[Dictionary] = []
 	var ground: Array[Dictionary] = []
@@ -245,13 +249,10 @@ func _icons(om: OverlayManager) -> void:
 			if icon == null or not is_instance_valid(icon):
 				continue
 			var surface := _anchor(icon.target_cell)
-			if OverlayManager.SQUAD_MARKER_RINGS:
-				if type == OverlayIcon.IconType.CROWN:
-					continue
-				ground.append(_marker(surface, icon.sprite.texture, icon.sprite.modulate))
-			else:
-				surface.origin.y += float(type) * 0.02
+			if type == OverlayIcon.IconType.CROWN:
 				heads.append(_marker(surface, icon.sprite.texture, icon.sprite.modulate))
+			else:
+				ground.append(_marker(surface, icon.sprite.texture, icon.sprite.modulate))
 	_markers(BoardOverlays.Layer.ICONS, heads)
 	_markers(BoardOverlays.Layer.GROUND_ICONS, ground)
 

--- a/Classes/presentation/UnitHealthBar.gd
+++ b/Classes/presentation/UnitHealthBar.gd
@@ -39,16 +39,12 @@ const OUTLINE_COLOR := Color.BLACK
 # text by font_size would have meant a 4px font to hit the size the dev asked for, which renders to
 # mush; sizing by pixel_size keeps the atlas crisp and shrinks the quad.
 const FONT_RESOLUTION := 32
-# Gap between the leader badge and the bar's outline, in texels. Not a knob: spacing inside one
-# display, not a feel value anyone tunes per board.
-const BADGE_GAP_TEXELS := 2.0
 
 var _outline: MeshInstance3D
 var _missing: MeshInstance3D
 var _fill: MeshInstance3D
 var _doomed: MeshInstance3D    # #313: the span between current HP and what the plan predicts
 var _notch: MeshInstance3D     # #313: the marker AT the predicted level
-var _badge: MeshInstance3D     # #325: the leader's crown at bar height, left of the bar
 var _label: Label3D
 
 var _width := 32.0
@@ -72,8 +68,6 @@ var _alarm_peak_color := Color(1.0, 1.0, 1.0, 1.0)
 var _predicted := 0
 var _has_prediction := false
 var _number_shown := true
-var _badge_texture: Texture2D = null
-var _badge_scale := 1.0
 
 var _alarm: Tween
 var _alarm_peak_live := Color(1.0, 1.0, 1.0, 1.0)   # the peak the RUNNING tween was started with
@@ -106,10 +100,6 @@ func _init() -> void:
 	_fill = _make_quad(BoardOverlays.UNIT_HUD_RENDER_PRIORITY + 2)
 	_doomed = _make_quad(BoardOverlays.UNIT_HUD_RENDER_PRIORITY + 3)
 	_notch = _make_quad(BoardOverlays.UNIT_HUD_RENDER_PRIORITY + 4)
-	_badge = _make_quad(BoardOverlays.UNIT_HUD_RENDER_PRIORITY)
-	# The one textured quad in the group: pixel art, so nearest like every sprite in the stack.
-	var badge_material := _badge.material_override as StandardMaterial3D
-	badge_material.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST
 	_label = Label3D.new()
 	# NOT billboarded, like everything else here — face() turns the whole group instead. Label3D
 	# draws its glyphs and its outline as two surfaces, and displacing it with Label3D.offset (the
@@ -129,7 +119,6 @@ func _init() -> void:
 	add_child(_fill)
 	add_child(_doomed)
 	add_child(_notch)
-	add_child(_badge)
 	add_child(_label)
 	visible = false
 	_rebuild()
@@ -191,15 +180,6 @@ func clear_prediction() -> void:
 # number. Two reasons to be up (#313), so the number follows the reason rather than the bar.
 func set_number_shown(shown: bool) -> void:
 	_number_shown = shown
-	_rebuild()
-
-
-# The leader's crown riding the bar (#325 -- dev call: leadership reads beside health, on the
-# bar's own visibility). null = no badge. The texture is passed in, like every other input --
-# this node never reads game state.
-func set_leader_badge(texture: Texture2D, scale: float) -> void:
-	_badge_texture = texture
-	_badge_scale = scale
 	_rebuild()
 
 
@@ -277,15 +257,6 @@ func alarm_running() -> bool:
 	return _alarm != null
 
 
-# Rendered facts for tests, same reason as fill_fraction: read off the mesh, never recomputed.
-func badge_shown() -> bool:
-	return _badge.visible
-
-
-func badge_size() -> Vector2:
-	return (_badge.mesh as QuadMesh).size
-
-
 func track_texels() -> float:
 	return roundf(_width)
 
@@ -304,7 +275,7 @@ func _rebuild() -> void:
 	var signature: Array = [_width, _height, _outline_texels, _fill_color, _missing_color,
 			_number_height, _number_outline, _number_color, _gap, _shows_max, _number_shown,
 			_doomed_color, _heal_color, _notch_color, _notch_texels,
-			_current, _maximum, _predicted, _has_prediction, _badge_texture, _badge_scale]
+			_current, _maximum, _predicted, _has_prediction]
 	if signature == _drawn:
 		return
 	_drawn = signature
@@ -354,17 +325,6 @@ func _draw() -> void:
 	# direction precisely because the group has one orientation.
 	var half_text: float = _label.get_aabb().size.x * 0.5
 	_label.position = Vector3(-track_w * 0.5 * texel + _gap + half_text, 0.0, texel)
-
-	# The leader badge (#325): bar-height, square, off the outline's left edge. Vertically
-	# centred with the bar, so "same height, sitting to the left" is true by construction.
-	_badge.visible = _badge_texture != null
-	if _badge.visible:
-		var badge_h: float = bar_h * maxf(_badge_scale, 0.01)
-		var badge_x: float = -(track_w * 0.5 + edge + BADGE_GAP_TEXELS + badge_h * 0.5)
-		_size_quad(_badge, badge_h * texel, badge_h * texel, badge_x * texel)
-		var badge_material := _badge.material_override as StandardMaterial3D
-		badge_material.albedo_texture = _badge_texture
-		badge_material.albedo_color = Color.WHITE
 
 
 # The prediction (#313). The SPAN runs between where the bar is now and where the plan leaves it,

--- a/Classes/presentation/UnitMirror.gd
+++ b/Classes/presentation/UnitMirror.gd
@@ -63,10 +63,11 @@ const PIXELS_PER_CELL := float(GridUtils.TILE_SIZE)  # 16 — grid.map_to_local'
 # for two rounds and read as floating both times, because a map sprite's visible head is wherever
 # its transparent padding ends and no single number is right for every piece of art.
 #
-# The selection icons (crown, squad member, target) hang at BoardOverlays.billboard_lift, measured
-# from the CELL, and the dev's stacking is icons on top with the readout tucked under them. Nothing
-# enforces that: a test would be pinning one tuning value against another, which the tuning razor
-# forbids, so if the icons move this moves by hand.
+# The CROWN hangs at BoardOverlays.billboard_lift, measured from the CELL, and the dev's stacking is
+# it on top with the readout tucked under. Nothing enforces that: a test would be pinning one tuning
+# value against another, which the tuning razor forbids, so if the crown moves this moves by hand.
+# (It is the head channel's only tenant since #325's verdict -- TARGET went to the ground with #346,
+# squad membership followed it as a ring.)
 @export var hud_lift := 0.06
 @export var bar_width_texels := 26.0
 @export var bar_height_texels := 5.0
@@ -115,8 +116,6 @@ const PIXELS_PER_CELL := float(GridUtils.TILE_SIZE)  # 16 — grid.map_to_local'
 # either way. ONE knob rather than one per reason -- the question is how crowded this volume may
 # get, and that question does not change with why a bar happens to be up.
 @export var unhovered_shows_number := false
-# #325: the leader's crown badge beside the bar, as a multiple of the bar's own height.
-@export var crown_badge_scale := 1.0
 
 # Which unit the pointer resolves to, injected by battle3d — the same idiom as pointer_source and
 # board_source. A Callable rather than a game back-ref keeps this node testable and keeps the
@@ -346,11 +345,6 @@ func _sync_bar(unit: Unit, sprite: UnitSprite3D, bar: UnitHealthBar, hovered: bo
 			alarm_peak_color)
 	bar.set_hp(unit.get_current_hp(), unit.get_max_hp())
 	bar.set_number_shown(hovered or unhovered_shows_number)
-	# #325: in ring mode leadership reads beside health; the squares arm keeps its billboard.
-	var leads: bool = OverlayManager.SQUAD_MARKER_RINGS and unit.squad != null \
-			and unit.squad.get_leader() == unit and unit.has_squad()
-	var crown: Texture2D = OverlayManager.ICON_TEXTURES[OverlayIcon.IconType.CROWN] if leads else null
-	bar.set_leader_badge(crown, crown_badge_scale)
 	if foretold:
 		bar.set_prediction(_predicted_hp(unit, plan), PlanResolver.plan_fells(unit, plan.hypo))
 	else:

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -7,7 +7,7 @@ its child [#49 Action Queue UX](https://github.com/Phaazoid/Godoiosis/issues/49)
 This is a *guidelines* doc, not a spec — it captures the principles we're holding the work to,
 plus the running order of the queue-UX checklist. Update it as items land.
 
-**Canon checked through #365 (2026-08-19).**
+**Canon checked through #367 (2026-08-19).**
 
 ## Principles
 
@@ -376,11 +376,32 @@ over its head. Seeing both at once, the dev's call was that **the ground one rea
 **Retired by this rule:** `IconType.TARGET`, whose only producer was `draw_create_squad` — the
 target-pick ground marker is now the single answer to *which unit may I pick*. `CURSOR` and
 `INVALID` went with it as never-produced leftovers. **`CROWN` and `SQUADMEMBER` were answered by
-[#325](https://github.com/Phaazoid/Godoiosis/issues/325), shipped 2026-08-19:** membership is a
-per-squad coloured RING under each member, and the leader's crown is a badge ON THE HEALTH BAR,
-bar-height and to its left — so leadership rides #229's readout rather than floating on its own.
-The legacy squares survive behind a Look-tab toggle until the dev rules; **the loser then gets
-deleted, not kept as a second opinion.**
+[#325](https://github.com/Phaazoid/Godoiosis/issues/325), and the dev's verdict after playing both
+styles (2026-08-19) was a MIX rather than a winner:** membership is a per-squad coloured RING under
+each member; leadership is the **original crown over the head**, unchanged from before the ticket,
+including its timing — hover *any* squad member and that squad's leader wears it. The legacy green
+squares lost outright and are **deleted**: no toggle, no second style, `SQUAD_MARKER_RINGS` gone.
+
+The leader wears **both** — a ring because they are a member, the crown because they lead — and
+that is the two-channel rule of this section working rather than an exception to it: the ring says
+what this INTERACTION is about, the crown says what this UNIT is.
+
+**The interim design — the crown as a badge on the health bar — is deleted, and why it lost is
+worth keeping.** It read fine in isolation; what killed it is that it made leadership conditional
+on a *different* marker's visibility. [#350](https://github.com/Phaazoid/Godoiosis/issues/350)
+landed a day later and made the health bar a player preference that is **off by default**, so a
+squad leader silently had no persistent 3D marker at all. Neither ticket was wrong on its own and
+neither could see it; it appeared only in composition. **The rule that falls out: a marker answering
+"what is this unit" must not ride another marker's visibility gate** — which is also the standing
+caution for [#357](https://github.com/Phaazoid/Godoiosis/issues/357), whose state-icon row is
+specified to ride exactly that gate. Riding it is a choice about defaults, not a free consolidation.
+
+**Two things are now single-sourced by the deletion**, both Law #4 in miniature: `ICON_TEXTURES` is
+the one answer to what a marker type LOOKS like (applied once at `setup`, so `_style_icon` only ever
+decides tint and z — it used to assign textures too, a second place a marker's art came from), and
+`OverlayMirror._icons` routes by TYPE rather than by mode (CROWN to the head channel, everything
+else to the ground). The per-type y-stagger went with the squares: CROWN is the head channel's only
+tenant, so there is nothing left to stagger against.
 
 **The premise this ticket was filed on was wrong, and the correction generalises.** #325's body
 said `Layer.SQUAD` "already draws the squad's footprint" — measured false while planning: that
@@ -389,9 +410,9 @@ the head-icon channel (`OverlayManager.icons_by_unit`) was the **only** membersh
 game. So the build RELOCATED that one channel rather than restyling a fill, and the icon
 lifecycle never moved. Third instance of [#228](https://github.com/Phaazoid/Godoiosis/issues/228)'s
 law — *an issue's own premises are stale-able; re-derive from the code before building.*
-The 2D keeps a head crown, since the flat view has no bar to badge — a declared
-[#292](https://github.com/Phaazoid/Godoiosis/issues/292) asymmetry, the readout family's, one
-member wider.
+**The 2D/3D asymmetry the badge introduced is gone with it** — both views now draw the same head
+crown, so there is nothing here for [#292](https://github.com/Phaazoid/Godoiosis/issues/292) to
+carry.
 
 Two things the retirement exposed, both worth keeping in mind. **The head icon was never the
 general answer**: TARGET was created in exactly one flow, so rescue, intimidate and join-squad had

--- a/tests/presentation/test_overlay_mirror.gd
+++ b/tests/presentation/test_overlay_mirror.gd
@@ -23,14 +23,12 @@ var _unit_mirror: UnitMirror
 var _mirror: OverlayMirror
 
 
-var _rings_were: bool
 var _ring_alpha_was: float
 
 
 func before_test() -> void:
 	get_tree().root.size = Vector2i(1280, 720)
 	# Statics outlive a test; cache rather than restore-to-a-literal, per the tuning razor.
-	_rings_were = OverlayManager.SQUAD_MARKER_RINGS
 	_ring_alpha_was = OverlayManager.SQUAD_RING_ALPHA
 	var packed := load(SCENE_PATH) as PackedScene
 	_scene = packed.instantiate() as Node3D
@@ -47,7 +45,6 @@ func before_test() -> void:
 
 
 func after_test() -> void:
-	OverlayManager.SQUAD_MARKER_RINGS = _rings_were
 	OverlayManager.SQUAD_RING_ALPHA = _ring_alpha_was
 	get_tree().root.remove_child(_scene)
 	_scene.free()
@@ -413,41 +410,32 @@ func test_squad_fills_and_icons_mirror() -> void:
 		assert_bool(textures.has(marker["texture"])).is_true()
 		assert_bool(tints.has(marker["modulate"])).override_failure_message(
 				"a ground decal's tint is not the 2D sprite's -- the hue stopped arriving by copy").is_true()
-	# Two styles never draw at once: ring mode leaves the head channel empty.
-	assert_int(_overlays.markers_of(BoardOverlays.Layer.ICONS).size()).is_equal(0)
+	# The two channels split by TYPE, not by mode (#325 verdict): rings on the ground, the leader's
+	# crown over the head. One squad, one leader, so exactly one head marker.
+	assert_int(_overlays.markers_of(BoardOverlays.Layer.ICONS).size()).is_equal(1)
 
 
-func test_ring_mode_keeps_the_crown_off_the_ground() -> void:
+func test_the_leader_wears_the_crown_over_the_head_and_a_ring_underfoot() -> void:
 	var pair := _squad_pair()
 	_om().redraw_squad_unit_icons(pair[0].squad)
 	await _settle()
-	# The leader's CROWN icon still exists in 2D (the flat view's legacy head mark) but never
-	# lands in the ground channel -- in ring mode the leader reads off the health bar's badge
-	# instead (test_unit_health_bar pins that half).
+	# #325's verdict, and the half that was DEAD between 2026-08-18 and the verdict: the crown is
+	# produced in 2D (it always was) and the 3D mirror has to carry it to the head channel. Ring
+	# mode used to drop it on the floor of _icons and badge the health bar instead.
 	assert_bool(_om().icons_by_unit[pair[0]].has(OverlayIcon.IconType.CROWN)).is_true()
 	var crown: Texture2D = OverlayManager.ICON_TEXTURES[OverlayIcon.IconType.CROWN]
+	var heads := _overlays.markers_of(BoardOverlays.Layer.ICONS)
+	assert_int(heads.size()).override_failure_message(
+			"the crown never reached the head channel -- the 3D mirror dropped it").is_equal(1)
+	assert_bool(heads[0]["texture"] == crown).is_true()
+
+	# ...and it is NOT also on the ground. The leader still gets a ring there, because they are a
+	# member too, so the ground channel holds rings only -- never the crown.
 	for marker in _overlays.markers_of(BoardOverlays.Layer.GROUND_ICONS):
 		assert_bool(marker["texture"] == crown).override_failure_message(
-				"the crown landed on the ground channel -- ring mode should badge the bar instead").is_false()
-
-
-func test_square_mode_restores_the_head_billboards_on_markers_already_up() -> void:
-	var pair := _squad_pair()
-	_om().redraw_squad_unit_icons(pair[0].squad)
-	await _settle()
-	# The Look-tab toggle's path: flip the static, restyle in place -- no lifecycle event fires.
-	OverlayManager.SQUAD_MARKER_RINGS = false
-	_om().restyle_squad_markers()
-	await _settle()
-	var icon_count := 0
-	for unit in _om().icons_by_unit:
-		for type in _om().icons_by_unit[unit]:
-			icon_count += 1
-			var sprite: Sprite2D = (_om().icons_by_unit[unit][type] as OverlayIcon).sprite
-			assert_that(sprite.texture).is_same(OverlayManager.ICON_TEXTURES[type])
-	var heads := _overlays.markers_of(BoardOverlays.Layer.ICONS)
-	assert_int(heads.size()).is_equal(icon_count)
-	assert_int(_overlays.markers_of(BoardOverlays.Layer.GROUND_ICONS).size()).is_equal(0)
+				"the crown landed on the ground channel as well as the head").is_false()
+	assert_int(_overlays.markers_of(BoardOverlays.Layer.GROUND_ICONS).size()).override_failure_message(
+			"the leader lost its own membership ring").is_equal(2)
 
 
 func test_a_ring_on_a_ramp_lies_tilted_with_the_slope() -> void:
@@ -620,3 +608,47 @@ func test_a_reload_of_an_unchanged_board_leaves_the_zone_fills_drawn() -> void:
 			"the 2D lost the zones on reload, which is a different bug").is_equal(drawn)
 	assert_that(_sorted_3d(BoardOverlays.Layer.ZONE_CAPTURE)).override_failure_message(
 			"the board reloaded and its zones never came back in 3D").is_equal(drawn)
+
+
+# Move the pointer the way the picker does, so everything past this line is the real hover wire:
+# battle3d hands the cell to HoverPresenter, which resolves the unit and creates the icons.
+func _point_at(cell: Vector2i) -> void:
+	var heights: BoardHeights = game.board_heights
+	_scene._pointer_cell = BoardSpace.of_cell(cell, heights.elevation_at(cell))
+
+
+func test_hovering_any_squadmate_crowns_the_leader_and_clears_on_the_way_out() -> void:
+	# The TIMING half of #325's verdict, in the dev's own words: the crown "stays over the squad
+	# leader whenever you are hovering over any squad member, like it did before". Nothing asserted
+	# that end to end before -- get_squad_icons was never the thing that broke, the 3D mirror was,
+	# and a case that draws the icons by hand cannot tell the two apart.
+	var pair := _squad_pair()
+	_point_at(pair[1].movement.cell)   # the MEMBER, not the leader
+	await _settle()
+
+	var crown: Texture2D = OverlayManager.ICON_TEXTURES[OverlayIcon.IconType.CROWN]
+	var heads := _overlays.markers_of(BoardOverlays.Layer.ICONS)
+	assert_int(heads.size()).override_failure_message(
+			"hovering a squadmate did not put a crown over the leader").is_equal(1)
+	assert_bool(heads[0]["texture"] == crown).is_true()
+
+	# It is over the LEADER, not the unit under the cursor.
+	var leader_anchor := BoardSpace.surface_point(pair[0].movement.cell, game.board_heights)
+	assert_float(heads[0]["pos"].x).is_equal_approx(leader_anchor.x, 0.01)
+	assert_float(heads[0]["pos"].z).override_failure_message(
+			"the crown is over the hovered member, not the leader").is_equal_approx(leader_anchor.z, 0.01)
+
+	# Somewhere on the board with nobody on it. DERIVED, never a literal: hover draws nothing OFF
+	# the painted board (update_hover_visuals returns early on a tileless cell), so "look away" has
+	# to land on a real tile -- and which tiles exist is authored content this suite must not pin.
+	var empty := GridUtils.NO_CELL
+	for cell: Vector2i in game.grid.get_used_cells():
+		if game.unit_at_pointer(cell) == null:
+			empty = cell
+			break
+	assert_bool(empty != GridUtils.NO_CELL).override_failure_message(
+			"the fixture board has no empty tile to look away at").is_true()
+	_point_at(empty)
+	await _settle()
+	assert_int(_overlays.markers_of(BoardOverlays.Layer.ICONS).size()).override_failure_message(
+			"the crown outlived the hover that raised it").is_equal(0)

--- a/tests/presentation/test_unit_health_bar.gd
+++ b/tests/presentation/test_unit_health_bar.gd
@@ -22,7 +22,6 @@ const PLAYER := Team.Faction.PLAYER
 var _scene: Node3D
 var game: Node2D
 var _unit_mirror: UnitMirror
-var _rings_were: bool
 
 
 func before_test() -> void:
@@ -30,8 +29,6 @@ func before_test() -> void:
 	# this a suite asserting which units wear a bar reads the developer's own saved preference.
 	PlayerSettings.reset_for_test()
 	get_tree().root.size = Vector2i(1280, 720)
-	# A static outlives a test; cache rather than restore-to-a-literal, per the tuning razor.
-	_rings_were = OverlayManager.SQUAD_MARKER_RINGS
 	var packed := load(SCENE_PATH) as PackedScene
 	_scene = packed.instantiate() as Node3D
 	_scene.auto_play = false
@@ -45,7 +42,6 @@ func before_test() -> void:
 
 
 func after_test() -> void:
-	OverlayManager.SQUAD_MARKER_RINGS = _rings_were
 	get_tree().root.remove_child(_scene)
 	_scene.free()
 
@@ -213,50 +209,6 @@ func test_the_readout_sorts_above_every_unit_and_every_overlay() -> void:
 	for layer: BoardOverlays.Layer in BoardOverlays.LAYERS:
 		var spec: Dictionary = BoardOverlays.LAYERS[layer]
 		assert_int(BoardOverlays.UNIT_HUD_RENDER_PRIORITY).is_greater(spec["sort"])
-
-
-# --- The leader badge (#325): the crown rides the bar in ring mode -------------------------
-
-func _squad_pair() -> Array[Unit]:
-	var leader := _spawn(PLAYER, Vector2i(2, 2))
-	var member := _spawn(PLAYER, Vector2i(3, 2))
-	game.squad_manager.join_squad(member, leader.squad)
-	return [leader, member]
-
-
-func test_a_hovered_leaders_bar_wears_the_crown_badge_at_bar_height() -> void:
-	var pair := _squad_pair()
-	_point_at(Vector2i(2, 2))
-	await _settle()
-	var bar: UnitHealthBar = _unit_mirror.bar_for(pair[0])
-	assert_bool(bar.visible).is_true()
-	assert_bool(bar.badge_shown()).is_true()
-	# "Same height as the health bar" (dev call), square -- derived from the knobs, never pinned.
-	var texel := 1.0 / UnitSprite3D.texels_per_unit
-	var expected: float = roundf(_unit_mirror.bar_height_texels) * _unit_mirror.crown_badge_scale * texel
-	assert_float(bar.badge_size().y).is_equal_approx(expected, 0.001)
-	assert_float(bar.badge_size().x).is_equal_approx(bar.badge_size().y, 0.001)
-
-
-func test_a_hovered_members_bar_carries_no_badge() -> void:
-	var pair := _squad_pair()
-	_point_at(Vector2i(3, 2))
-	await _settle()
-	var bar: UnitHealthBar = _unit_mirror.bar_for(pair[1])
-	assert_bool(bar.visible).is_true()
-	assert_bool(bar.badge_shown()).is_false()
-
-
-func test_square_mode_keeps_the_badge_off_the_bar() -> void:
-	# The toggle compares two complete systems: in squares mode the crown billboard is the
-	# leader's mark, so the bar must not double-crown it.
-	OverlayManager.SQUAD_MARKER_RINGS = false
-	var pair := _squad_pair()
-	_point_at(Vector2i(2, 2))
-	await _settle()
-	var bar: UnitHealthBar = _unit_mirror.bar_for(pair[0])
-	assert_bool(bar.visible).is_true()
-	assert_bool(bar.badge_shown()).is_false()
 
 
 # --- The always-show setting (#350) -----------------------------------------------------------


### PR DESCRIPTION
Closes #325. Your verdict, built: the rings stay for membership, the **original crown goes back over the head** for leadership (hover any squad member, the leader wears it — unchanged from before the ticket), the bar badge is gone, and the legacy green squares are deleted outright.

## Mostly deletion, and the crown's production path was never the problem

`game.get_squad_icons` has produced `[SQUADMEMBER, CROWN]` for the leader the whole time, in 2D, untouched by #325. What the experiment did was stop the **3D mirror** from carrying the crown — one `continue` in `OverlayMirror._icons` — and badge the health bar instead. So this is that `continue` removed, the badge removed, and the mode fork removed.

Net **-55 lines**.

## Things worth ruling on

1. **`OverlayMirror._icons` routes by TYPE, not by mode.** CROWN → head channel, everything else → ground. The per-type y-stagger went with the squares: it existed to keep several head-icon types off each other's plane, and CROWN is that channel's only tenant now.

2. **`ICON_TEXTURES` became the ONE answer to what a marker type looks like** — applied once at `setup`, so `_style_icon` now only decides tint and z. This is a **fix I found by breaking it**, not a tidy-up: my first pass retired the `SQUADMEMBER` entry from that table on the grounds that `_style_icon` overrode the texture anyway. It has a second reader — `create_unit_icon`'s `icon.setup(ICON_TEXTURES[type], …)` — and the suite went red immediately. Law #4's "count all callers" catching me in the act; the corrected shape is strictly better than what I planned, because the texture now comes from exactly one place instead of two.

3. **The leader wears both a ring and a crown.** A ring because they are a member, a crown because they lead. That is this section's two-channel rule working, not an exception to it — the ground says what the interaction is about, the head says what the unit is.

4. **`SQUAD_MARKER_RINGS` is gone**, with `_style_icon`'s fork and the Look tab's checkbox. **Ring opacity stays** — it tunes a shipped feature rather than picking between two designs. `SquadHighlightIcon.png` is now unreferenced; I left the file on disk rather than deleting art with its `.import` sidecar in this diff.

## Why the badge lost, recorded in canon

It read fine in isolation. What killed it is that it made **leadership conditional on a different marker's visibility** — and #350 landed a day later making the health bar a player preference that is *off by default*, so a squad leader silently had no persistent 3D marker at all. Neither ticket was wrong alone; it existed only in composition, which is why I filed it on #44 rather than as a bug against either.

**The rule that falls out, now in `visual-clarity.md`: a marker answering "what is this unit" must not ride another marker's visibility gate.** That is also the standing caution for #357, whose state-icon row is specified to ride exactly that gate — riding it is a choice about defaults, not a free consolidation.

## Verification

- `tests/presentation` + `tests/dev` **473 cases**, `tests/ui` + `tests/squad` **332 cases** — all green, 0 failures, 0 orphans. Full tree is CI's.
- **New case pinning what you actually asked for**: hover a **non-leader** member → the crown appears over the **leader** (asserted by position, not just by count) → look away → it clears. Nothing asserted that end to end before, because every existing case drew the icons by hand and so could not tell "produced in 2D" from "mirrored into 3D" apart.
- **Falsified**, and it needed isolating: restoring the `continue` reds an *earlier* case first, which truncates the file — so I disabled the earlier cases one at a time and confirmed **both** new cases red on their own, with the right messages. That wire (2D icon → 3D mirror) is the #103 shape and the only place a green suite could go blind here.
- The three #350 always-on cases are untouched and still green — the regression guard that this deletion did not disturb that gate.
- **Yours**: crown height over the head, the ring-plus-crown stack on a leader, and whether the crown reads at low camera pitch.

## Canon

`docs/design/visual-clarity.md`'s #346 section rewritten to the settled rule. I kept the genuinely good part of the earlier #325 sweep — the #228 correction that `Layer.SQUAD` was never a membership marker — since that is true regardless of which style won. The `#292` asymmetry that sweep declared is **gone**, not moved: both views draw the same head crown now.
