### PR TITLE
Missions talk now: end the dialog your fixture booted (fixes main CI)

### DIFF
--- a/Classes/flow/ScenarioDirector.gd
+++ b/Classes/flow/ScenarioDirector.gd
@@ -78,6 +78,9 @@ func disarm() -> void:
 	_armed = false
 	_beats = []
 	_steps = []
+	# Pending is CONTENT, not display: a queued beat surviving disarm resurrects the moment the
+	# current timeline ends (timeline_ended pops the queue) -- disarmed means nothing left to say.
+	_pending.clear()
 	game.refresh_mission_status()
 
 

--- a/tests/flow/test_scenario_director.gd
+++ b/tests/flow/test_scenario_director.gd
@@ -290,3 +290,20 @@ func test_prolog_authored_content_resolves() -> void:
 		assert_object(beat.timeline).is_not_null()
 	for step: TutorialStep in scenario.tutorial_steps:
 		assert_str(step.text).is_not_empty()
+
+
+func test_disarm_also_empties_the_pending_queue() -> void:
+	# The resurrection bug: a beat queued behind a running timeline survived disarm, and
+	# timeline_ended popped it back to life on a director that had nothing left to say.
+	_director.set_beats([
+		_beat(DialogBeat.Trigger.MISSION_START, "First voice."),
+		_beat(DialogBeat.Trigger.MISSION_START, "Queued voice."),
+	])
+	_director.mission_started()   # first starts, second queues
+	await _await_starts(1)
+	_director.disarm()
+	Dialogic.end_timeline(true)   # ended pops the queue -- which must now be empty
+	await Dialogic.timeline_ended
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_int(_starts).is_equal(1)

--- a/tests/presentation/test_board_mirror.gd
+++ b/tests/presentation/test_board_mirror.gd
@@ -36,6 +36,7 @@ func before_test() -> void:
 
 
 func after_test() -> void:
+	await DialogFixtures.end_all_dialog(self)   # the mission door arms #182 dialog; end it or it leaks
 	get_tree().root.remove_child(_scene)
 	_scene.free()
 

--- a/tests/presentation/test_camera_follow.gd
+++ b/tests/presentation/test_camera_follow.gd
@@ -36,6 +36,7 @@ func before_test() -> void:
 
 
 func after_test() -> void:
+	await DialogFixtures.end_all_dialog(self)   # the mission door arms #182 dialog; end it or it leaks
 	get_tree().root.remove_child(_scene)
 	_scene.free()
 

--- a/tests/presentation/test_camera_start.gd
+++ b/tests/presentation/test_camera_start.gd
@@ -42,6 +42,7 @@ func before_test() -> void:
 
 
 func after_test() -> void:
+	await DialogFixtures.end_all_dialog(self)   # the mission door arms #182 dialog; end it or it leaks
 	get_tree().root.remove_child(_scene)
 	_scene.free()
 

--- a/tests/presentation/test_input_bridge.gd
+++ b/tests/presentation/test_input_bridge.gd
@@ -38,9 +38,18 @@ func before_test() -> void:
 	_container = _scene.get_node("Main/GameContainer") as SubViewportContainer
 	_scene.load_mission(PROLOG)
 	await await_idle_frame()
+	# The Prolog carries the #182 lesson now, and load_mission routes through begin_mission -- the
+	# fresh-start door that ARMS it. This suite tests the CLICK WIRE, not the tutorial: disarm so
+	# no step or beat can spawn a Dialogic layer mid-click (its CanvasLayer consumes the synthesized
+	# press this suite exists to route), and end the intro the mission start already fired.
+	_game.scenario_director.disarm()
+	await DialogFixtures.end_all_dialog(self)
 
 
 func after_test() -> void:
+	# Cases that re-enter the fresh-start door mid-test (demo boot, board swaps) re-arm the Prolog
+	# lesson and re-fire its intro -- end it before the scene dies.
+	await DialogFixtures.end_all_dialog(self)
 	get_tree().root.remove_child(_scene)
 	_scene.free()
 

--- a/tests/presentation/test_unit_mirror.gd
+++ b/tests/presentation/test_unit_mirror.gd
@@ -25,6 +25,7 @@ func before_test() -> void:
 
 
 func after_test() -> void:
+	await DialogFixtures.end_all_dialog(self)   # the mission door arms #182 dialog; end it or it leaks
 	get_tree().root.remove_child(_scene)
 	_scene.free()
 

--- a/tests/support/dialog_fixtures.gd
+++ b/tests/support/dialog_fixtures.gd
@@ -1,0 +1,15 @@
+# Shared dialog teardown for suites that boot missions through the fresh-start door (#182).
+# Missions can TALK now: begin_mission arms the scenario's beats, a MISSION_START intro spawns
+# Dialogic's layout ON THE TREE ROOT -- outside any suite fixture, so it survives scene removal,
+# eats synthesized clicks, and bleeds into the next case as orphans unless ended explicitly.
+class_name DialogFixtures
+
+
+# End whatever is talking and wait for the layout to actually die. Call from after_test (and
+# from before_test if the suite needs a silent board mid-case -- pair with director.disarm()).
+static func end_all_dialog(suite: GdUnitTestSuite) -> void:
+	if Dialogic.current_timeline != null:
+		Dialogic.end_timeline(true)
+		await Dialogic.timeline_ended   # end_timeline is async; ended fires after its clears
+	await suite.await_idle_frame()
+	await suite.await_idle_frame()      # the layout is queue_freed -- let it die before orphan accounting

--- a/tests/support/dialog_fixtures.gd.uid
+++ b/tests/support/dialog_fixtures.gd.uid
@@ -1,0 +1,1 @@
+uid://bxg43yegc5eeb


### PR DESCRIPTION
Fixes the red main CI from the #370 merge ([failing run](https://github.com/Phaazoid/Godoiosis/actions/runs/32218857835)).

## What broke

The Prolog talks now, and five presentation suites boot it through `begin_mission` -- the fresh-start door that arms the lesson. Torv's intro spawns Dialogic's layout **on the tree root**, outside any suite fixture:

- it consumed the input bridge's synthesized mouse press before it could bubble to the board -- the red case (`the press never armed the drag`). Reproduced locally on main; deterministic, not a CI-only race.
- it survived `_scene.free()` (wrong subtree) and leaked ~72 orphans per booting case, bleeding across suites because Dialogic is a persistent autoload.

## The director bug underneath

`disarm()` left `_pending` populated. A beat queued behind a running timeline could resurrect via `timeline_ended` on a director with nothing left to say -- exactly how the bridge's intro came back *after* the fixture disarmed it (an earlier suite's still-open timeline made the intro queue instead of play). Pending is content; disarm clears it now, with a regression case pinning the resurrection.

## The fixture rule

New `tests/support/dialog_fixtures.gd`: `DialogFixtures.end_all_dialog(suite)` is the one teardown dance (end, await `timeline_ended`, two frames for the `queue_free`). All five mission-booting presentation suites call it in `after_test`; the input bridge also disarms in `before_test` -- it tests the click wire, not the tutorial.

`presentation` + `flow`: 480/480, **0 orphans**.

## Flagged, not fixed here

Demo / watch-only mode boots missions through the same arming door -- a watch-only Prolog opens Torv's intro with no player to advance it. Design question, filing separately.
