### PR TITLE
#325 follow-up: the crown sinks under the rings, and the readout's axis disagrees

### DIFF
--- a/Classes/presentation/BoardOverlays.gd
+++ b/Classes/presentation/BoardOverlays.gd
@@ -87,7 +87,12 @@ const LAYERS: Dictionary[Layer, Dictionary] = {
 	# was the top of the table, so freeze icons drew over path arrows and planning ghosts.
 	Layer.TERRAIN: {"color": Color.WHITE, "sort": 2, "kind": Kind.SPRITE},
 	Layer.TERRAIN_PREVIEW: {"color": Color.WHITE, "sort": 2, "kind": Kind.SPRITE},
-	Layer.ICONS: {"color": Color.WHITE, "sort": 0, "kind": Kind.BILLBOARD},
+	# The ONE layer that hangs in the AIR rather than lying on the floor, so it sorts above
+	# every floor layer. It sat at 0 while nothing could overlap it; #325 then put a ring
+	# decal (3) directly under every crown, which drew straight over it. 15 is the top of
+	# the lawful band -- a law pins every layer under FLAME_RENDER_PRIORITY. A BILLBOARD
+	# ignores _lift_of and rides billboard_lift, so this moves PRIORITY only, not geometry.
+	Layer.ICONS: {"color": Color.WHITE, "sort": 15, "kind": Kind.BILLBOARD},
 }
 
 const FILL_TEXTURE_PATH := "res://Art/LookDev/cell_fill.png"

--- a/Classes/presentation/UnitHealthBar.gd
+++ b/Classes/presentation/UnitHealthBar.gd
@@ -247,13 +247,17 @@ func _stop_alarm() -> void:
 # every element (Label3D moves its glyphs and its outline by different amounts). Rotating the
 # parent makes every child's ordinary local position correct by construction, at any angle.
 #
-# Yaw only, matching the BILLBOARD_FIXED_Y the icons beside it use: atan2(x, z) points local +Z,
-# which is the face QuadMesh and Label3D present, at the camera.
-func face(camera_position: Vector3) -> void:
-	var to_camera := camera_position - global_position
-	if absf(to_camera.x) < 0.0001 and absf(to_camera.z) < 0.0001:
-		return   # camera directly overhead: any yaw is as good as another, so keep the last one
-	global_rotation = Vector3(0.0, atan2(to_camera.x, to_camera.z), 0.0)
+# Yaw only, and it must MATCH BILLBOARD_FIXED_Y rather than merely resemble it (#325 follow-up).
+# FIXED_Y aligns a sprite to the VIEW PLANE, one yaw board-wide; pointing each readout at the
+# camera POSITION instead gives a slightly different angle per unit, agreeing only at screen
+# centre -- which read as the crown and the bar sitting on visibly different axes. Every sprite
+# in this stack is FIXED_Y, UnitSprite3D included, so the READOUT is what moves: the unit art is
+# the anchor anything hung on it must agree with. Camera basis +Z is the direction FIXED_Y faces.
+func face(camera_basis: Basis) -> void:
+	var facing := camera_basis.z
+	if absf(facing.x) < 0.0001 and absf(facing.z) < 0.0001:
+		return   # camera straight overhead: any yaw is as good as another, so keep the last one
+	global_rotation = Vector3(0.0, atan2(facing.x, facing.z), 0.0)
 
 
 # What fraction of the bar the fill actually covers — the RENDERED fact, read off the mesh rather

--- a/Classes/presentation/UnitMirror.gd
+++ b/Classes/presentation/UnitMirror.gd
@@ -373,7 +373,7 @@ func _sync_bar(unit: Unit, sprite: UnitSprite3D, bar: UnitHealthBar, hovered: bo
 	if is_inside_tree():
 		var camera := get_viewport().get_camera_3d()
 		if camera != null:
-			bar.face(camera.global_position)
+			bar.face(camera.global_transform.basis)
 
 
 # The readout rides whatever is ON SCREEN. That is the same fork _sync makes when it hides a

--- a/tests/presentation/test_board_overlays.gd
+++ b/tests/presentation/test_board_overlays.gd
@@ -437,6 +437,28 @@ func test_no_overlay_layer_can_sort_over_the_flame() -> void:
 			.is_less(BoardOverlays.UNIT_RENDER_PRIORITY)
 
 
+func test_markup_that_hangs_in_the_air_sorts_above_markup_that_lies_on_the_floor() -> void:
+	# A RELATIONSHIP, not a value (#325 follow-up, found in play: the crown drew under the
+	# squad rings). Every FILL/SPRITE layer is markup lying on the board face; a BILLBOARD
+	# stands in the volume above it, so it can never sort behind one -- the dev put it as
+	# rings are on the floor and should not draw above anything. Pinning the relation rather
+	# than the numbers leaves both free to be retuned.
+	var floor_top := -9999
+	var air_low := 9999
+	for layer: BoardOverlays.Layer in BoardOverlays.LAYERS:
+		var spec: Dictionary = BoardOverlays.LAYERS[layer]
+		if spec["kind"] == BoardOverlays.Kind.BILLBOARD:
+			air_low = mini(air_low, spec["sort"])
+		else:
+			floor_top = maxi(floor_top, spec["sort"])
+	# Non-vacuity: with no billboard layer declared, the compare below is trivially true.
+	assert_int(air_low).override_failure_message(
+			"no BILLBOARD layer is declared, so this case proves nothing").is_not_equal(9999)
+	assert_int(air_low).override_failure_message(
+			"a layer hanging in the air sorts at %d, at or below floor markup at %d" \
+			% [air_low, floor_top]).is_greater(floor_top)
+
+
 func test_a_unit_sprite_actually_carries_that_priority() -> void:
 	# Test the wire: the constant is worth nothing if no sprite reads it, and ghosts are built
 	# by UnitMirror through the same plain constructor rather than for_unit_data.

--- a/tests/presentation/test_unit_health_bar.gd
+++ b/tests/presentation/test_unit_health_bar.gd
@@ -191,13 +191,16 @@ func test_the_readout_is_one_display_and_not_parts_that_drift() -> void:
 			"nothing was displaced, so laying it out in the parent's space proves nothing"
 			).is_greater_equal(2)
 
-	# And the other half: something has to turn it now that its parts do not turn themselves.
+	# And the other half: something has to turn it now that its parts do not turn themselves --
+	# to the camera VIEW PLANE, which is what BILLBOARD_FIXED_Y does to every sprite around it
+	# (#325 follow-up). Pointing at the camera POSITION instead is the same angle only at screen
+	# centre, which is why the crown and the bar read as sitting on different axes.
 	var camera := bar.get_viewport().get_camera_3d()
 	assert_object(camera).is_not_null()
-	var to_camera: Vector3 = camera.global_position - bar.global_position
+	var facing: Vector3 = camera.global_transform.basis.z
 	assert_float(bar.global_rotation.y).override_failure_message(
-			"the readout does not face the camera").is_equal_approx(
-			atan2(to_camera.x, to_camera.z), 0.001)
+			"the readout is not aligned to the camera view plane").is_equal_approx(
+			atan2(facing.x, facing.z), 0.001)
 
 
 func test_the_readout_sorts_above_every_unit_and_every_overlay() -> void:


### PR DESCRIPTION
Both of your feel-check findings on the rings, and neither was where it looked.

## The crown drew under the rings

`Layer.ICONS` — the crown, and the **only BILLBOARD layer, i.e. the only markup that hangs in the air** — sorted at **0**, inside the floor band, while `GROUND_ICONS` (the rings) sorts at **3**. `render_priority` is the alpha-queue key, so the rings won by two bands. It sat at 0 harmlessly for as long as nothing could overlap it; #325 then put a decal directly under every crown for the first time.

Now **15**, the top of the lawful band, declared as *the air sorts above the floor* — your rule, that rings lie on the floor and should never draw above anything. Free of side effects: a `BILLBOARD` ignores `_lift_of` and rides `billboard_lift`, so this moves priority only, never geometry.

## The crown and the bar sat on different axes

The house convention is **`BILLBOARD_FIXED_Y`** — view-plane alignment, one yaw board-wide. It is what `UnitSprite3D` uses (the unit art itself) and what every `BoardOverlays` billboard uses, the crown included.

`UnitHealthBar.face()` did something else: it pointed each bar **at the camera's position**, which matches the view plane only at screen centre and drifts with off-centre angle — exactly "a little bit different." Its own comment claimed it matched `BILLBOARD_FIXED_Y`; **that claim was false**, which is how it survived #229, #313, #350 and #357.

The unit art is the anchor everything hung on it must agree with, so the **readout moves, not the sprites**: `face()` now takes the camera basis and yaws to its `+Z`. #357's state icons are children of the bar, so they are corrected by the same edit — no second fix.

## Verification

`test_board_overlays` + `test_unit_health_bar` + `test_overlay_mirror` — **66/66**.

**Both new claims falsified**, since each is in a blind-spot category:
- ICONS back to 0 reds the new sort law with `a layer hanging in the air sorts at 0, at or below floor markup at 6`.
- Restoring the genuine point-at-camera math reds the facing case — which also **proves the two conventions really do differ** at the fixture's camera angle, rather than my having reasoned it.

The new sort law pins a **relationship** (air above floor), not the numbers, so both stay free to retune.

**Not checkable headless, stated plainly:** `BILLBOARD_FIXED_Y` is applied in the vertex shader, so a sprite's rendered yaw never reaches its node transform — no test can compare the bar against the crown directly. Whether they now agree on screen is your feel-check. If they still disagree, the fallback is to give the crown the bar's treatment (billboard off, rotated as part of a group) rather than the reverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
