### PR TITLE
Save to source no longer eats a declaration's trailing comment (#378)

### DIFF
--- a/Classes/dev/KnobSource.gd
+++ b/Classes/dev/KnobSource.gd
@@ -26,11 +26,16 @@ enum Kind {
 
 # Both spellings of an authored default are accepted (`:= value` and `: Type = value`) and any
 # `: set = _x` suffix is CARRIED, not dropped -- several knobs own a setter, and losing it would
-# silently un-live the knob rather than fail. `@export` and `static` are one pattern rather than
-# two: which prefix a declaration wears is a fact about the SOURCE, not about the caller's intent,
-# and a name is unique in its script either way. The `^` anchor is what keeps an indented local
-# `var` of the same name out.
-const DECLARATION_LINE := "(?m)^((?:@export|static)[ \\t]+var[ \\t]+%s[ \\t]*(?::[ \\t]*\\w+[ \\t]*=|:=)[ \\t]*)(.+?)([ \\t]*:[ \\t]*set[ \\t]*=[ \\t]*\\w+)?$"
+# silently un-live the knob rather than fail. A trailing # comment is carried the same way (#378:
+# the first real Save deleted billboard_lift's), and the value group excluding # is what makes
+# that sound -- the value can never cross into a comment, so a comment whose TEXT contains
+# ": set = foo" cannot be half-eaten as a setter. No knob value contains # (DevWidgets.literal_for
+# emits numeric Color forms, never hex strings), and the save laws run this against every real
+# declaration, so one arriving later fails there. `@export` and `static` are one pattern rather
+# than two: which prefix a declaration wears is a fact about the SOURCE, not about the caller's
+# intent, and a name is unique in its script either way. The `^` anchor is what keeps an indented
+# local `var` of the same name out.
+const DECLARATION_LINE := "(?m)^((?:@export|static)[ \\t]+var[ \\t]+%s[ \\t]*(?::[ \\t]*\\w+[ \\t]*=|:=)[ \\t]*)([^#\\n]+?)([ \\t]*:[ \\t]*set[ \\t]*=[ \\t]*\\w+)?([ \\t]*#[^\\n]*)?$"
 
 # One entry of a const Layer -> spec dictionary, keyed by the layer's NAME as written. The value is
 # a Color(...) call or a constant reference, and it cannot be matched as "up to the next comma" --
@@ -61,8 +66,9 @@ static func rewrite_layer_color(source: String, layer_name: String, literal: Str
 
 
 # Rebuilt from the match rather than through sub(), so a literal containing $ could never be read
-# as a backreference. `keep_suffix` carries group 3 (a declaration's `: set = _x`); the layer form
-# has no third group and keeps whatever follows the value untouched by ending the match there.
+# as a backreference. `keep_suffix` carries groups 3 and 4 (a declaration's `: set = _x` and its
+# trailing comment, in that order -- #378); the layer form has neither group and keeps whatever
+# follows the value untouched by ending the match there.
 static func _rewrite(source: String, pattern: String, literal: String, keep_suffix: bool) -> String:
 	var re := RegEx.create_from_string(pattern)
 	if re == null:
@@ -72,7 +78,7 @@ static func _rewrite(source: String, pattern: String, literal: String, keep_suff
 		return ""
 	var line := found.get_string(1) + literal
 	if keep_suffix:
-		line += found.get_string(3)
+		line += found.get_string(3) + found.get_string(4)
 	return source.substr(0, found.get_start(0)) + line + source.substr(found.get_end(0))
 
 

--- a/Classes/presentation/BoardOverlays.gd
+++ b/Classes/presentation/BoardOverlays.gd
@@ -105,7 +105,7 @@ const ART_PIXELS_PER_CELL := 16.0
 @export var bracket_scale := 1.02
 @export var fill_lift := 0.02          # quad height above the top face — the z-fight gap
 @export var lift_step := 0.004         # per-sort spacing so stacked layers never coincide
-@export var billboard_lift := 0.85
+@export var billboard_lift := 0.85     # icon height above the cell's top face
 @export var billboard_pixel_size := 1.0 / 32.0
 # What the hover bracket turns when the pointer is over something the 2D calls INVALID (#245).
 # A knob because there is nothing to mirror here: 2D says "invalid" with a negative-icon TEXTURE,

--- a/tests/dev/test_knob_source.gd
+++ b/tests/dev/test_knob_source.gd
@@ -58,6 +58,49 @@ func test_a_typed_export_default_is_rewritten() -> void:
 	assert_str(out).contains("@export var cover_scale: float = 0.62")
 
 
+# The comment is documentation the save was never asked to touch (#378: the first real Save
+# deleted billboard_lift's). Whitespace before the # rides with it, so the comment column holds.
+func test_a_trailing_comment_survives_the_rewrite() -> void:
+	var commented := """extends Node3D
+
+@export var fill_lift := 0.02          # quad height above the top face -- the z-fight gap
+"""
+	var out := KnobSource.rewrite_declaration_default(commented, "fill_lift", "0.04")
+	assert_str(out).is_equal("""extends Node3D
+
+@export var fill_lift := 0.04          # quad height above the top face -- the z-fight gap
+""")
+
+
+# Both suffixes at once, in their original order -- the setter is code and the comment is prose,
+# and a rewrite that reordered them would not parse.
+func test_a_setter_and_a_comment_survive_together() -> void:
+	var both := """extends Node3D
+
+@export var tuft_scale := 1.0: set = _set_tuft_scale   # stands the plants up (#280)
+"""
+	var out := KnobSource.rewrite_declaration_default(both, "tuft_scale", "1.3")
+	assert_str(out).is_equal("""extends Node3D
+
+@export var tuft_scale := 1.3: set = _set_tuft_scale   # stands the plants up (#280)
+""")
+
+
+# A comment may SAY ": set = _x" without BEING a setter. The value group refusing to cross a #
+# is what makes this unambiguous -- without it, backtracking can hand half the comment to the
+# setter group and the rewrite reassembles a line that never existed.
+func test_a_comment_naming_a_setter_is_not_eaten_as_one() -> void:
+	var tricky := """extends Node3D
+
+@export var flame_lift := 0.5   # tuned live; the writer is: set = _set_flame_lift on the mirror
+"""
+	var out := KnobSource.rewrite_declaration_default(tricky, "flame_lift", "0.7")
+	assert_str(out).is_equal("""extends Node3D
+
+@export var flame_lift := 0.7   # tuned live; the writer is: set = _set_flame_lift on the mirror
+""")
+
+
 # A multi-argument literal must not be mistaken for the start of the setter suffix.
 func test_a_vector_literal_is_rewritten_whole() -> void:
 	var out := KnobSource.rewrite_declaration_default(VECTOR, "flame_size", "Vector2(0.4, 0.9)")


### PR DESCRIPTION
Closes #378. Step 0 of the dev-tools reorganization — shipped alone because the defect fires on every Save you make today.

## The bug

Your first real use of #373's Save (`0987c80`) proved the feature and exposed this:

```diff
-@export var billboard_lift := 1.1      # icon height above the cell's top face
+@export var billboard_lift := 0.85
```

Value landed, comment deleted. `DECLARATION_LINE`'s value group ran to end-of-line — it carried a `: set = _x` suffix but swallowed a trailing comment into the value it replaced. 12 declarations across the knob scripts carry one.

## The fix

One regex, one append, in `KnobSource.gd`:

- The value group becomes `[^#\n]+?` and a fourth group captures `[ \t]*#...` — whitespace included, so the comment column holds.
- `_rewrite` re-appends it beside the setter suffix. The layer-colour path is untouched (its pattern ends at the value).
- The `[^#\n]` constraint is load-bearing, not cosmetic: a comment whose *text* contains `: set = foo` can no longer be half-parsed as a setter. Pinned by its own case.
- `billboard_lift`'s comment restored, your 0.85 kept.

No knob value legally contains `#` (`literal_for` emits numeric Color forms, never hex), and the save laws already run this rewriter against every real declaration, so a hash-bearing one arriving later fails there.

## Verification

`tests/dev` 224/224 green. Falsified by re-introducing exactly the shipped bug (dropping the re-append): `test_a_trailing_comment_survives_the_rewrite` red on the aimed case.

Note: the worktree's `--import` pass emptied Dialogic's directory caches in `project.godot`; that artifact is deliberately NOT in this diff.

**You are on `fix/save-eats-comments`** — though there's nothing visual to check; the proof is the test cases and the restored line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
