### PR TITLE
Dialog & Tutorial dev page + dialog lints; capture stops wiping lessons (#397)

### DIFF
--- a/Classes/dev/BoardLint.gd
+++ b/Classes/dev/BoardLint.gd
@@ -39,6 +39,7 @@ static func check(game) -> Array[Dictionary]:
 	_check_placement(game, board, found)
 	_check_cohesion(game, found)
 	_check_look_preset(game, found)
+	_check_dialog(game, board, found)
 
 	# Ordered by severity here, not at the panel: a second reader would otherwise have to re-derive
 	# the running order, and the order IS part of what the report says. Grouping by a pass over the
@@ -145,3 +146,31 @@ static func _check_look_preset(game, found: Array[Dictionary]) -> void:
 	_add(found, Severity.DEGRADES,
 		"This board names look preset '%s', which no longer exists -- it opens with the default look."
 			% preset)
+
+
+# #397, the two checks deferred from #390. Both read the SAME stores the director reads
+# (ScenarioManager's current_dialog_beats/current_tutorial_steps), so every fault here is
+# reachable from the surface that misbehaves -- a check against a saved file would miss the
+# unsaved edits the dev-tools page makes.
+static func _check_dialog(game, board: BoardContext, found: Array[Dictionary]) -> void:
+	for beat: DialogBeat in game.scenario_manager.current_dialog_beats:
+		if beat.timeline == null:
+			_add(found, Severity.DEGRADES,
+				"A dialog beat (%s) has no timeline -- it fires into nothing."
+					% DialogBeat.Trigger.keys()[beat.trigger])
+
+	# The name check is authored-time advice: mid-battle, a named unit may legitimately be gone
+	# (dead, extracted), so past the opening turn of an ARMED battle it stays quiet (dev call,
+	# #397). An un-armed board is an authoring session and always gets checked -- the dev-tools
+	# Load path never arms.
+	if game.scenario_director.past_opening_turn():
+		return
+	var names: Dictionary = {}
+	for unit: Unit in board.units:
+		if is_instance_valid(unit) and unit.unit_data != null:
+			names[unit.unit_data.display_name] = true
+	for step: TutorialStep in game.scenario_manager.current_tutorial_steps:
+		if step.unit_name != "" and not names.has(step.unit_name):
+			_add(found, Severity.BLOCKS,
+				("A tutorial step names '%s', but no unit on this board carries that name -- "
+					+ "the step can never complete and the lesson stalls there.") % step.unit_name)

--- a/Classes/dev/DevOverlay.gd
+++ b/Classes/dev/DevOverlay.gd
@@ -25,6 +25,7 @@ class_name DevOverlay
 @onready var scenario_tool: ScenarioTool = get_node("%Scenario")
 @onready var scenario_header: ScenarioHeader = get_node("%ScenarioHeader")
 @onready var squads_ai: SquadsAiTool = get_node("%SquadsAI")
+@onready var dialog_tool: DialogTool = get_node("%Dialog")
 @onready var moods_tool: MoodsTool = get_node("%Moods")
 @onready var object_tool: ObjectTool = get_node("%Objects")
 @onready var game_tool: GameTool = get_node("%Game")
@@ -49,6 +50,8 @@ const LEAVES: Array[Dictionary] = [
 		"tip": "Click a unit in dev mode to edit it here — the unit standing on THIS board, not its character file."},
 	{"scope": "Scenario", "label": "Squads & AI", "page": "%SquadsAI",
 		"tip": "Who is standing on this board and how it behaves — per-faction AI control, and each squad's archetype and zone."},
+	{"scope": "Scenario", "label": "Dialog & Tutorial", "page": "%Dialog",
+		"tip": "The mission's script — dialog beats (who says what, and when) and the sequential tutorial steps the HUD instructs through. Check board lints both."},
 	{"scope": "Project", "label": "Characters", "page": "%Character",
 		"tip": "Author cast characters — the Resources/Units/ files authored saves reference. Update rewrites the character everywhere; Save As or Capture creates."},
 	{"scope": "Project", "label": "Items", "page": "%Item Editor",
@@ -105,6 +108,7 @@ func _ready() -> void:
 	scenario_header.init(scenario_manager, game)
 	scenario_tool.init(scenario_manager, game, scenario_header)
 	squads_ai.init(game, scenario_header)
+	dialog_tool.init(game, scenario_header)
 	spawn.init(game)
 	unit_editor.init(game)
 	tile_brush.init(game)
@@ -234,6 +238,8 @@ func _on_tab_changed(_tab: int):
 		scenario_tool.refresh_on_show()
 	if current == squads_ai:
 		squads_ai.refresh_on_show()
+	if current == dialog_tool:
+		dialog_tool.refresh_on_show()
 	if current != tile_brush:
 		tile_brush.deactivate()
 	_update_zone_visibility()
@@ -244,6 +250,7 @@ func _on_tab_changed(_tab: int):
 func _on_scenario_file_changed() -> void:
 	scenario_tool.refresh_on_show()
 	squads_ai.refresh_on_show()
+	dialog_tool.refresh_on_show()
 
 # The Spawn form's dropdowns go stale whenever authoring happens elsewhere, so they refresh at
 # BOTH doors into it: outer tab entry above, and the sub-tab switch here -- "save a character,

--- a/Classes/dev/DialogTool.gd
+++ b/Classes/dev/DialogTool.gd
@@ -1,0 +1,267 @@
+extends VBoxContainer
+class_name DialogTool
+
+# The Dialog & Tutorial page (#397): authoring for a scenario's #182 arrays -- dialog beats and
+# tutorial steps -- which were the last mission content still edited in the Godot inspector.
+# Edits write ScenarioManager's live stores DIRECTLY (the same arrays the armed director reads
+# and capture_scenario saves), so a change is playable immediately and Update carries it.
+# Rows rebuild whole on every structural edit: content is tiny, and rebuild-on-write cannot
+# drift from the store. Timeline choices come from Dialogic's own dtl registry -- the one
+# directory the editor plugin maintains -- never a second file scan.
+
+var game   # the Game coordinator; set by init()
+var _header: ScenarioHeader
+var _beat_list: VBoxContainer
+var _step_list: VBoxContainer
+
+# done_when choices: the triggers a step can WAIT on. MISSION_START is the arming moment itself
+# and STEP_COMPLETED is derived FROM steps -- neither is a thing a step can watch for.
+const STEP_TRIGGERS: Array[DialogBeat.Trigger] = [
+	DialogBeat.Trigger.TURN_START,
+	DialogBeat.Trigger.SQUAD_FORMED,
+	DialogBeat.Trigger.UNIT_SELECTED,
+	DialogBeat.Trigger.SQUAD_MEMBER_ADDED,
+]
+
+
+func init(p_game, header: ScenarioHeader) -> void:
+	game = p_game
+	_header = header
+	_build_skeleton()
+	refresh()
+
+
+func refresh_on_show() -> void:
+	refresh()
+
+
+func _mark() -> void:
+	if _header != null:
+		_header.mark_modified()
+
+
+func _beats() -> Array[DialogBeat]:
+	return game.scenario_manager.current_dialog_beats
+
+
+func _steps() -> Array[TutorialStep]:
+	return game.scenario_manager.current_tutorial_steps
+
+
+func _build_skeleton() -> void:
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_child(scroll)
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(vbox)
+
+	DevWidgets.add_label(vbox, "DIALOG BEATS")
+	_beat_list = VBoxContainer.new()
+	vbox.add_child(_beat_list)
+	var add_beat := Button.new()
+	add_beat.text = "Add beat"
+	DevWidgets.apply_tooltip(add_beat, "A beat fires ONCE per battle when its trigger happens: "
+		+ "a Dialogic timeline plays over the board. Beats are independent of each other.")
+	add_beat.pressed.connect(_on_add_beat)
+	vbox.add_child(add_beat)
+
+	DevWidgets.add_label(vbox, "TUTORIAL STEPS")
+	_step_list = VBoxContainer.new()
+	vbox.add_child(_step_list)
+	var add_step := Button.new()
+	add_step.text = "Add step"
+	DevWidgets.apply_tooltip(add_step, "Steps are a SEQUENTIAL lesson: the active step's text "
+		+ "shows on the mission-status HUD until its done-when fires, then the next activates. "
+		+ "Order matters -- use the arrows.")
+	add_step.pressed.connect(_on_add_step)
+	vbox.add_child(add_step)
+
+
+func refresh() -> void:
+	for child in _beat_list.get_children():
+		child.queue_free()
+	for child in _step_list.get_children():
+		child.queue_free()
+	var beats := _beats()
+	for i in beats.size():
+		_beat_list.add_child(_beat_row(beats[i], i))
+	if beats.is_empty():
+		DevWidgets.add_label(_beat_list, "  (no beats -- this mission plays silent)")
+	var steps := _steps()
+	for i in steps.size():
+		_step_list.add_child(_step_row(steps[i], i))
+	if steps.is_empty():
+		DevWidgets.add_label(_step_list, "  (no steps -- no lesson on this mission)")
+
+
+func _on_add_beat() -> void:
+	_beats().append(DialogBeat.new())
+	_mark()
+	refresh()
+
+
+func _on_add_step() -> void:
+	_steps().append(TutorialStep.new())
+	_mark()
+	refresh()
+
+
+# --- beat rows ---
+
+func _beat_row(beat: DialogBeat, index: int) -> HBoxContainer:
+	var row := HBoxContainer.new()
+
+	var trigger := OptionButton.new()
+	for value: int in DialogBeat.Trigger.values():
+		trigger.add_item(String(DialogBeat.Trigger.keys()[value]).capitalize(), value)
+	trigger.select(trigger.get_item_index(beat.trigger))
+	DevWidgets.apply_tooltip(trigger, "When this beat fires. Step completed = when the lesson "
+		+ "advances past step N (the payoff voice).")
+	trigger.item_selected.connect(func(item_index: int) -> void:
+		beat.trigger = trigger.get_item_id(item_index) as DialogBeat.Trigger
+		_mark()
+		refresh())   # the conditional param below follows the trigger
+	row.add_child(trigger)
+
+	if beat.trigger == DialogBeat.Trigger.TURN_START:
+		row.add_child(_int_field("turn", beat.turn, 1, func(value: int) -> void:
+			beat.turn = value
+			_mark()))
+	if beat.trigger == DialogBeat.Trigger.STEP_COMPLETED:
+		row.add_child(_int_field("step", beat.step, 1, func(value: int) -> void:
+			beat.step = value
+			_mark()))
+
+	var timeline := OptionButton.new()
+	timeline.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	timeline.add_item("(no timeline)", 0)
+	var directory := _timeline_directory()
+	var names: Array = directory.keys()
+	names.sort()
+	var selected := 0
+	for i in names.size():
+		timeline.add_item(names[i], i + 1)
+		if beat.timeline != null and beat.timeline.resource_path == String(directory[names[i]]):
+			selected = i + 1
+	timeline.select(selected)
+	DevWidgets.apply_tooltip(timeline, "The Dialogic timeline this beat plays -- Dialogic's own "
+		+ "registry (every .dtl the project knows). A beat with no timeline fires into nothing; "
+		+ "Check board flags it.")
+	timeline.item_selected.connect(func(item_index: int) -> void:
+		if item_index == 0:
+			beat.timeline = null
+		else:
+			beat.timeline = load(String(directory[timeline.get_item_text(item_index)])) as DialogicTimeline
+		_mark())
+	row.add_child(timeline)
+
+	row.add_child(_remove_button(func() -> void:
+		_beats().remove_at(index)
+		_mark()
+		refresh()))
+	return row
+
+
+# --- step rows ---
+
+func _step_row(step: TutorialStep, index: int) -> HBoxContainer:
+	var row := HBoxContainer.new()
+
+	var text := LineEdit.new()
+	text.text = step.text
+	text.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	DevWidgets.apply_tooltip(text, "The instruction shown on the mission-status HUD while this "
+		+ "step is active.")
+	text.text_changed.connect(func(value: String) -> void:
+		step.text = value
+		_mark())
+	row.add_child(text)
+
+	var done := OptionButton.new()
+	for trigger in STEP_TRIGGERS:
+		done.add_item(String(DialogBeat.Trigger.keys()[trigger]).capitalize(), trigger)
+	done.select(done.get_item_index(step.done_when))
+	DevWidgets.apply_tooltip(done, "What completes this step and activates the next.")
+	done.item_selected.connect(func(item_index: int) -> void:
+		step.done_when = done.get_item_id(item_index) as DialogBeat.Trigger
+		_mark()
+		refresh())   # which params show follows the choice
+	row.add_child(done)
+
+	if step.done_when != DialogBeat.Trigger.TURN_START:
+		var unit_name := LineEdit.new()
+		unit_name.text = step.unit_name
+		unit_name.placeholder_text = "any unit"
+		unit_name.custom_minimum_size.x = 90
+		DevWidgets.apply_tooltip(unit_name, "Match against a unit's display name (the squad "
+			+ "LEADER for squad triggers). Empty = any. A name no board unit carries stalls the "
+			+ "lesson -- Check board flags it.")
+		unit_name.text_changed.connect(func(value: String) -> void:
+			step.unit_name = value
+			_mark())
+		row.add_child(unit_name)
+	if step.done_when == DialogBeat.Trigger.SQUAD_MEMBER_ADDED:
+		row.add_child(_int_field("size", step.squad_size, 0, func(value: int) -> void:
+			step.squad_size = value
+			_mark()))
+	if step.done_when == DialogBeat.Trigger.TURN_START:
+		row.add_child(_int_field("turn", step.turn, 1, func(value: int) -> void:
+			step.turn = value
+			_mark()))
+
+	var up := Button.new()
+	up.text = "^"
+	up.disabled = index == 0
+	up.pressed.connect(func() -> void: _move_step(index, -1))
+	row.add_child(up)
+	var down := Button.new()
+	down.text = "v"
+	down.disabled = index == _steps().size() - 1
+	down.pressed.connect(func() -> void: _move_step(index, 1))
+	row.add_child(down)
+
+	row.add_child(_remove_button(func() -> void:
+		_steps().remove_at(index)
+		_mark()
+		refresh()))
+	return row
+
+
+func _move_step(index: int, delta: int) -> void:
+	var steps := _steps()
+	var step: TutorialStep = steps[index]
+	steps.remove_at(index)
+	steps.insert(index + delta, step)
+	_mark()
+	refresh()
+
+
+# --- small shared pieces ---
+
+func _int_field(label_text: String, initial: int, minimum: int, on_change: Callable) -> HBoxContainer:
+	var box := HBoxContainer.new()
+	var label := Label.new()
+	label.text = label_text
+	box.add_child(label)
+	var spin := SpinBox.new()
+	spin.min_value = minimum
+	spin.max_value = 99
+	spin.value = initial
+	spin.value_changed.connect(func(value: float) -> void: on_change.call(int(value)))
+	box.add_child(spin)
+	return box
+
+
+func _remove_button(on_pressed: Callable) -> Button:
+	var button := Button.new()
+	button.text = "x"
+	DevWidgets.apply_tooltip(button, "Remove this row. No confirm -- Update is where the file is "
+		+ "at stake, and it asks.")
+	button.pressed.connect(on_pressed)
+	return button
+
+
+func _timeline_directory() -> Dictionary:
+	return ProjectSettings.get_setting("dialogic/directories/dtl_directory", {})

--- a/Classes/dev/DialogTool.gd.uid
+++ b/Classes/dev/DialogTool.gd.uid
@@ -1,0 +1,1 @@
+uid://dfxwnho3ggjrr

--- a/Classes/flow/ScenarioDirector.gd
+++ b/Classes/flow/ScenarioDirector.gd
@@ -1,36 +1,35 @@
 class_name ScenarioDirector
 extends Node
 
-# Runs a scenario's authored script (#182): DialogBeats (independent "when X, say Y" moments)
-# and TutorialSteps (a sequential lesson whose active step shows on the mission-status HUD).
-# Built in game._build_collaborators with a back-ref (the DevController pattern).
+# Runs a scenario's authored script (#182): DialogBeats (independent "when X, say Y" moments over
+# Dialogic timelines) and TutorialSteps (a sequential lesson whose active step renders as the
+# mission HUD's instruction row). Built in game._build_collaborators with a back-ref (the
+# DevController pattern).
 #
 # Seam rules: the board is the only authority on game state -- nothing here mirrors board facts
 # into Dialogic's variable store. Triggers arrive as the board's own signals plus
-# MissionController's fresh-start call. Both beats and steps are fresh-start content: a resume
-# disarms them -- missing a nudge beats replaying a seen intro, and the objectives half of the
-# HUD (#134) restores either way.
+# MissionController's fresh-start call. CONTENT lives on ScenarioManager
+# (current_dialog_beats/current_tutorial_steps, the current_look_preset seam) and is read LIVE
+# here, never copied (#397) -- so capture_scenario always sees the lesson, and disarming silences
+# EXECUTION without destroying what Update needs to save. This node owns only execution state:
+# armed, fired, pending, the step cursor, the turn count.
 #
-# One node runs both ON PURPOSE: a step and a beat can answer the same event (forming the squad
-# completes the step AND fires the payoff line), so the order is pinned here -- step advances
-# first (the HUD shows what's next), then beats fire (the voice reacts) -- instead of racing
+# One node runs both beats and steps ON PURPOSE: a step and a beat can answer the same event, so
+# the order is pinned here -- step advances (HUD refreshes) then beats fire -- instead of racing
 # between two listeners.
 
 var game   # the Game coordinator; set by game._build_collaborators()
 
-var _beats: Array[DialogBeat] = []
 var _fired: Dictionary = {}   # DialogBeat -> true; battle-scoped, cleared with the board
 var _pending: Array[DialogicTimeline] = []   # triggered while another timeline was playing
 var _dialog_active := false   # OUR in-flight latch: Dialogic.current_timeline is set a frame late
                               # (start() defers to the layout's ready), so same-frame beats need this
 var _player_turn := 0   # counts turn_started(PLAYER); no other system owns this count
-
-var _steps: Array[TutorialStep] = []
-var _step_idx := 0   # index of the ACTIVE step; past the end = lesson done
+var _step_idx := 0      # index of the ACTIVE step; past the end = lesson done
 
 # Content loads INERT and mission_started() arms it: apply_scenario's own spawn loop fires
 # squad_created once per unit (spawn_unit's solo-squad invariant), and a loading board must
-# never trip a lesson or a beat. A resume loads content and simply never arms.
+# never trip a lesson or a beat. A resume or watch-only boot simply never arms (#375).
 var _armed := false
 
 
@@ -42,25 +41,19 @@ func _ready() -> void:
 	Dialogic.timeline_ended.connect(_on_timeline_ended)
 
 
-# The scenario's script arrives with the board (apply_scenario). REPLACED, not merged (#150).
-func set_beats(beats: Array[DialogBeat]) -> void:
-	_beats = beats
-	_fired.clear()
-	_pending.clear()
-	_player_turn = 0
-
-
-func set_steps(steps: Array[TutorialStep]) -> void:
-	_steps = steps
-	_step_idx = 0
-
-
 # What the HUD's instruction row shows; empty = no row. game.refresh_mission_status() reads
 # this on every refresh -- the panel never reads the director directly (#134's contract).
 func active_instruction() -> String:
-	if not _armed or _step_idx >= _steps.size():
+	if not _armed or _step_idx >= _steps().size():
 		return ""
-	return _steps[_step_idx].text
+	return _steps()[_step_idx].text
+
+
+# BoardLint's gate for the authored-time checks (#397): true only once an ARMED battle has moved
+# past its opening turn. Deliberately false on un-armed boards -- the dev-tools Load path never
+# arms, and that is exactly the authoring session the lint exists for.
+func past_opening_turn() -> bool:
+	return _armed and _player_turn > 1
 
 
 # Fresh mission start (begin_mission / restart_mission -- the #220 door). Not board_loaded:
@@ -68,18 +61,17 @@ func active_instruction() -> String:
 func mission_started() -> void:
 	_armed = true
 	game.refresh_mission_status()   # the lesson's first instruction is up before anyone talks
-	for beat: DialogBeat in _beats:
+	for beat: DialogBeat in _beats():
 		if beat.trigger == DialogBeat.Trigger.MISSION_START:
 			_fire(beat)
 
 
-# A resume is not a fresh start; beats and steps are fresh-start content.
+# A resume (or watch-only boot) is not a fresh start. Silences EXECUTION only: the content stays
+# on ScenarioManager, so a later capture_scenario still saves the lesson (#397).
 func disarm() -> void:
 	_armed = false
-	_beats = []
-	_steps = []
-	# Pending is CONTENT, not display: a queued beat surviving disarm resurrects the moment the
-	# current timeline ends (timeline_ended pops the queue) -- disarmed means nothing left to say.
+	# Pending is queued EXECUTION: a beat surviving here resurrects the moment the current
+	# timeline ends (timeline_ended pops the queue) -- disarmed means nothing left to say.
 	_pending.clear()
 	game.refresh_mission_status()
 
@@ -87,12 +79,10 @@ func disarm() -> void:
 # Board teardown (clear_board). Ends any running timeline so no dialog outlives its board.
 func reset() -> void:
 	_armed = false
-	_beats = []
-	_steps = []
-	_step_idx = 0
 	_fired.clear()
 	_pending.clear()
 	_player_turn = 0
+	_step_idx = 0
 	_dialog_active = false
 	if Dialogic.current_timeline != null:
 		Dialogic.end_timeline(true)   # un-awaited: nothing downstream depends on completion
@@ -108,7 +98,7 @@ func _on_turn_started(faction: Team.Faction) -> void:
 	if step != null and step.done_when == DialogBeat.Trigger.TURN_START \
 			and step.turn == _player_turn:
 		_advance_step()
-	for beat: DialogBeat in _beats:
+	for beat: DialogBeat in _beats():
 		if beat.trigger == DialogBeat.Trigger.TURN_START and beat.turn == _player_turn:
 			_fire(beat)
 
@@ -120,7 +110,7 @@ func _on_unit_selected(unit: Unit) -> void:
 	if step != null and step.done_when == DialogBeat.Trigger.UNIT_SELECTED \
 			and _name_matches(step.unit_name, unit):
 		_advance_step()
-	for beat: DialogBeat in _beats:
+	for beat: DialogBeat in _beats():
 		if beat.trigger == DialogBeat.Trigger.UNIT_SELECTED:
 			_fire(beat)
 
@@ -135,7 +125,7 @@ func _on_squad_created(squad: Squad) -> void:
 	if step != null and step.done_when == DialogBeat.Trigger.SQUAD_FORMED \
 			and _name_matches(step.unit_name, leader):
 		_advance_step()
-	for beat: DialogBeat in _beats:
+	for beat: DialogBeat in _beats():
 		if beat.trigger == DialogBeat.Trigger.SQUAD_FORMED:
 			_fire(beat)
 
@@ -151,17 +141,27 @@ func _on_squad_member_joined(squad: Squad, _unit: Unit) -> void:
 			and _name_matches(step.unit_name, leader) \
 			and squad.get_members().size() >= step.squad_size:
 		_advance_step()
-	for beat: DialogBeat in _beats:
+	for beat: DialogBeat in _beats():
 		if beat.trigger == DialogBeat.Trigger.SQUAD_MEMBER_ADDED:
 			_fire(beat)
+
+
+# --- content: ScenarioManager's stores, read live (#397) ---
+
+func _beats() -> Array[DialogBeat]:
+	return game.scenario_manager.current_dialog_beats
+
+
+func _steps() -> Array[TutorialStep]:
+	return game.scenario_manager.current_tutorial_steps
 
 
 # --- steps ---
 
 func _active_step() -> TutorialStep:
-	if _step_idx >= _steps.size():
+	if _step_idx >= _steps().size():
 		return null
-	return _steps[_step_idx]
+	return _steps()[_step_idx]
 
 
 func _advance_step() -> void:
@@ -169,7 +169,7 @@ func _advance_step() -> void:
 	game.refresh_mission_status()   # the write-point pattern (#134), not a signal
 	# THEN the payoff voice (the pinned order: HUD first). _step_idx is also how many steps
 	# are complete, which is exactly the 1-based index STEP_COMPLETED beats author against.
-	for beat: DialogBeat in _beats:
+	for beat: DialogBeat in _beats():
 		if beat.trigger == DialogBeat.Trigger.STEP_COMPLETED and beat.step == _step_idx:
 			_fire(beat)
 

--- a/Classes/flow/ScenarioManager.gd
+++ b/Classes/flow/ScenarioManager.gd
@@ -66,6 +66,11 @@ var current_look_preset := ""
 # store/writer shape as the look right above -- apply_scenario sets it, clear_board zeroes it, the
 # dev Scenario tab captures into it, capture_scenario reads it back out.
 var current_camera_start: CameraPose = null
+# The #182 lesson content, same seam: authored scenario content that is not board state. THE store
+# — ScenarioDirector reads these LIVE (never copies), capture_scenario writes them back out, and
+# clear_board empties them so a sandbox spawn cannot inherit the last mission's lesson.
+var current_dialog_beats: Array[DialogBeat] = []
+var current_tutorial_steps: Array[TutorialStep] = []
 
 # Entries whose unit_data failed to resolve (resource deleted/moved since saving) come back
 # null. Drop them with a push_error instead of letting load_scenario null-deref (#13). Pure +
@@ -161,6 +166,8 @@ func capture_scenario(scenario_name: String, authored := false) -> ScenarioData:
 	scenario.ai_factions = game.ai_controller.ai_factions()   # #150: who the computer plays here
 	scenario.look_preset = current_look_preset               # #253 part 2: the look it wears
 	scenario.camera_start = current_camera_start             # #234: where it opens, if authored
+	scenario.dialog_beats = current_dialog_beats.duplicate()       # #182/#397: Update must not wipe
+	scenario.tutorial_steps = current_tutorial_steps.duplicate()   # the lesson it cannot see on the board
 	scenario.captured_zones = game.mission_controller.captured_zone_names()
 	scenario.contested = game.mission_controller.is_contested()
 
@@ -211,8 +218,10 @@ func apply_scenario(scenario: ScenarioData) -> void:
 	# Before any turn starts: MissionController._begin_turn runs after load_scenario returns, and
 	# start_faction_turn is what reads these. The set is REPLACED, not merged (#150).
 	game.ai_controller.set_ai_factions(scenario.ai_factions)
-	game.scenario_director.set_beats(scenario.dialog_beats)   # same REPLACED-not-merged seam (#182)
-	game.scenario_director.set_steps(scenario.tutorial_steps)
+	# #182 lesson content: REPLACED, not merged (#150's shape). The director reads these stores
+	# live; clear_board (first line of this function) already reset its execution state.
+	current_dialog_beats = scenario.dialog_beats
+	current_tutorial_steps = scenario.tutorial_steps
 	# Set BEFORE board_loaded fires (it is this function's last line), because battle3d reads this
 	# from that signal. The 3D view is the only reader; a flat Main.tscn launch has no host and
 	# correctly applies nothing.
@@ -316,6 +325,9 @@ func clear_board():
 	current_look_preset = ""
 	# And the camera start (#234): a sandbox spawn must not open on the last mission's authored shot.
 	current_camera_start = null
+	# And the lesson (#182/#397): content follows its board out.
+	current_dialog_beats = []
+	current_tutorial_steps = []
 	# Same seam for AI control (#150): spawn_sandbox() lands here with no ScenarioData, so without
 	# this it would inherit the last mission's flags. A typed local, not a bare [] -- `game` is
 	# untyped, and a literal passed through it is not coerced to the typed parameter.

--- a/Scenes/DevOverlay.tscn
+++ b/Scenes/DevOverlay.tscn
@@ -14,6 +14,7 @@
 [ext_resource type="Script" path="res://Classes/dev/GameTool.gd" id="9_game1"]
 [ext_resource type="Script" path="res://Classes/dev/ScenarioHeader.gd" id="10_schdr"]
 [ext_resource type="Script" path="res://Classes/dev/SquadsAiTool.gd" id="11_sqai"]
+[ext_resource type="Script" path="res://Classes/dev/DialogTool.gd" id="11_dlgt"]
 [ext_resource type="Script" path="res://Classes/dev/ExperimentsTool.gd" id="12_exps"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1dnd3"]
@@ -86,6 +87,12 @@ unique_name_in_owner = true
 visible = false
 layout_mode = 2
 script = ExtResource("11_sqai")
+
+[node name="Dialog" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/Body/DevTabs" unique_id=990000300]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+script = ExtResource("11_dlgt")
 
 [node name="SquadsScroll" type="ScrollContainer" parent="Panel/MarginContainer/VBoxContainer/Body/DevTabs/SquadsAI" unique_id=990000075]
 layout_mode = 2

--- a/tests/dev/test_board_lint.gd
+++ b/tests/dev/test_board_lint.gd
@@ -297,3 +297,47 @@ func test_no_shipped_mission_loses_a_unit_on_load() -> void:
 			problems.append("%s: %d of %d entries reached the board — the rest were dropped as blocked or off-map"
 				% [path.get_file(), actual, expected])
 	assert_array(problems).is_empty()
+
+
+# --- the dialog checks (#397, deferred from #390) --------------------------------------------------
+
+func test_a_beat_with_no_timeline_degrades() -> void:
+	var beat := DialogBeat.new()   # timeline left null
+	game.scenario_manager.current_dialog_beats.append(beat)
+	assert_bool(_mentions(BoardLint.Severity.DEGRADES, "no timeline")).is_true()
+	# Non-vacuous twin: give it a timeline and the finding goes.
+	beat.timeline = DialogicTimeline.new()
+	assert_bool(_mentions(BoardLint.Severity.DEGRADES, "no timeline")).is_false()
+
+
+func test_a_step_naming_an_absent_unit_blocks() -> void:
+	var step := TutorialStep.new()
+	step.unit_name = "Torv"
+	step.text = "Select Torv."
+	game.scenario_manager.current_tutorial_steps.append(step)
+	assert_bool(_mentions(BoardLint.Severity.BLOCKS, "Torv")).is_true()
+	# Non-vacuous twin: put a Torv on the board and the finding goes.
+	var torv_data := H.make_unit_data({}, Team.Faction.PLAYER)
+	torv_data.display_name = "Torv"
+	assert_object(game.spawn_unit(torv_data, Vector2i(0, 0))).is_not_null()
+	assert_bool(_mentions(BoardLint.Severity.BLOCKS, "Torv")).is_false()
+
+
+func test_an_empty_unit_name_is_never_a_finding() -> void:
+	var step := TutorialStep.new()
+	step.unit_name = ""   # "any unit" is always satisfiable
+	game.scenario_manager.current_tutorial_steps.append(step)
+	assert_bool(_texts_at(BoardLint.Severity.BLOCKS).is_empty()).is_true()
+
+
+func test_the_name_check_stays_quiet_past_the_opening_turn() -> void:
+	# Dev call (#397): mid-battle, a named unit may legitimately be gone (dead, extracted), so an
+	# ARMED battle past turn 1 stops asking. The un-armed authoring board above always asks.
+	var step := TutorialStep.new()
+	step.unit_name = "Torv"
+	game.scenario_manager.current_tutorial_steps.append(step)
+	game.scenario_director.mission_started()   # arms
+	game.turn_manager.turn_started.emit(Team.Faction.PLAYER)   # turn 1: still authored-time
+	assert_bool(_mentions(BoardLint.Severity.BLOCKS, "Torv")).is_true()
+	game.turn_manager.turn_started.emit(Team.Faction.PLAYER)   # turn 2: battle underway
+	assert_bool(_mentions(BoardLint.Severity.BLOCKS, "Torv")).is_false()

--- a/tests/dev/test_dialog_tool.gd
+++ b/tests/dev/test_dialog_tool.gd
@@ -1,0 +1,68 @@
+# The Dialog & Tutorial page (#397). The tree-law suite already pins its LEAF (resolves, unique,
+# tooltipped); what this suite pins is the page's contract with the stores: rows project
+# ScenarioManager's lesson content, edits write it back, and every edit marks the header.
+extends GdUnitTestSuite
+
+const MAIN_SCENE := "res://Scenes/Main.tscn"
+
+var _main: Node
+var game: Node2D
+var tool_page: DialogTool
+
+
+func before_test() -> void:
+	_main = (load(MAIN_SCENE) as PackedScene).instantiate()
+	_main.name = "Main"
+	get_tree().root.add_child(_main)
+	await await_idle_frame()
+	game = _main.get_node("GameContainer/GameView/Game")
+	game.scenario_manager.clear_board()
+	tool_page = game.dev_overlay.dialog_tool
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	get_tree().root.remove_child(_main)
+	_main.free()
+
+
+func _beat_rows() -> int:
+	var count := 0
+	for child in tool_page._beat_list.get_children():
+		if child is HBoxContainer and not child.is_queued_for_deletion():
+			count += 1
+	return count
+
+
+func test_rows_project_the_stores() -> void:
+	game.scenario_manager.current_dialog_beats.append(DialogBeat.new())
+	var step := TutorialStep.new()
+	step.text = "Do the thing."
+	game.scenario_manager.current_tutorial_steps.append(step)
+	tool_page.refresh()
+	assert_int(_beat_rows()).is_equal(1)
+	var texts: Array[String] = []
+	for child in tool_page._step_list.get_children():
+		for control in child.find_children("*", "LineEdit", true, false):
+			texts.append((control as LineEdit).text)
+	assert_array(texts).contains(["Do the thing."])
+
+
+func test_add_beat_writes_the_store_and_marks_the_header() -> void:
+	var header: ScenarioHeader = tool_page._header
+	assert_object(header).is_not_null()
+	tool_page._on_add_beat()
+	assert_int(game.scenario_manager.current_dialog_beats.size()).is_equal(1)
+	assert_int(_beat_rows()).is_equal(1)
+
+
+func test_reorder_moves_the_authored_sequence() -> void:
+	var first := TutorialStep.new()
+	first.text = "first"
+	var second := TutorialStep.new()
+	second.text = "second"
+	game.scenario_manager.current_tutorial_steps.append(first)
+	game.scenario_manager.current_tutorial_steps.append(second)
+	tool_page.refresh()
+	tool_page._move_step(1, -1)
+	assert_str(game.scenario_manager.current_tutorial_steps[0].text).is_equal("second")

--- a/tests/dev/test_dialog_tool.gd.uid
+++ b/tests/dev/test_dialog_tool.gd.uid
@@ -1,0 +1,1 @@
+uid://wpi3xnb0dvdc

--- a/tests/flow/test_dialog_capture.gd
+++ b/tests/flow/test_dialog_capture.gd
@@ -1,0 +1,63 @@
+# The #397 store move: lesson content lives on ScenarioManager and SURVIVES capture.
+#
+# The bug this pins: capture_scenario carried every authored field except dialog_beats and
+# tutorial_steps, so the Scenario tool's Update button silently erased a mission's lesson.
+# Real Main scene, real capture/apply -- the wire, not the two ends.
+extends GdUnitTestSuite
+
+const MAIN_SCENE := "res://Scenes/Main.tscn"
+
+var _main: Node
+var game: Node2D
+
+
+func before_test() -> void:
+	_main = (load(MAIN_SCENE) as PackedScene).instantiate()
+	_main.name = "Main"
+	get_tree().root.add_child(_main)
+	await await_idle_frame()
+	game = _main.get_node("GameContainer/GameView/Game")
+	game.scenario_manager.clear_board()
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	get_tree().root.remove_child(_main)
+	_main.free()
+
+
+func test_capture_carries_the_lesson_and_apply_round_trips_it() -> void:
+	var beat := DialogBeat.new()
+	beat.trigger = DialogBeat.Trigger.STEP_COMPLETED
+	beat.step = 2
+	beat.timeline = DialogicTimeline.new()
+	var step := TutorialStep.new()
+	step.text = "Select Torv."
+	step.unit_name = "Torv"
+	game.scenario_manager.current_dialog_beats.append(beat)
+	game.scenario_manager.current_tutorial_steps.append(step)
+
+	var captured: ScenarioData = game.scenario_manager.capture_scenario("roundtrip")
+	assert_int(captured.dialog_beats.size()).is_equal(1)
+	assert_int(captured.tutorial_steps.size()).is_equal(1)
+	assert_str(captured.tutorial_steps[0].text).is_equal("Select Torv.")
+
+	game.scenario_manager.apply_scenario(captured)   # routes through clear_board -> empty stores
+	assert_int(game.scenario_manager.current_dialog_beats.size()).is_equal(1)
+	assert_int(game.scenario_manager.current_tutorial_steps.size()).is_equal(1)
+
+
+func test_clear_board_empties_the_lesson_stores() -> void:
+	game.scenario_manager.current_dialog_beats.append(DialogBeat.new())
+	game.scenario_manager.current_tutorial_steps.append(TutorialStep.new())
+	game.scenario_manager.clear_board()
+	assert_bool(game.scenario_manager.current_dialog_beats.is_empty()).is_true()
+	assert_bool(game.scenario_manager.current_tutorial_steps.is_empty()).is_true()
+
+
+func test_a_disarmed_director_does_not_lose_the_content_a_capture_needs() -> void:
+	# The old shape's failure: disarm() destroyed the director's COPY of the content, so a
+	# resume-then-Update wiped the lesson. Content and execution are separate now.
+	game.scenario_manager.current_tutorial_steps.append(TutorialStep.new())
+	game.scenario_director.disarm()
+	assert_int(game.scenario_manager.capture_scenario("after-disarm").tutorial_steps.size()).is_equal(1)

--- a/tests/flow/test_dialog_capture.gd.uid
+++ b/tests/flow/test_dialog_capture.gd.uid
@@ -1,0 +1,1 @@
+uid://cgvacx5mrfwhm

--- a/tests/flow/test_scenario_director.gd
+++ b/tests/flow/test_scenario_director.gd
@@ -11,10 +11,17 @@ const PLAYER := Team.Faction.PLAYER
 const ENEMY := Team.Faction.ENEMY
 
 
+class ManagerStub extends RefCounted:
+	# Just the two #397 content stores the director reads live; the real ScenarioManager needs a board.
+	var current_dialog_beats: Array[DialogBeat] = []
+	var current_tutorial_steps: Array[TutorialStep] = []
+
+
 class GameStub extends Node:
 	signal unit_selected(unit: Unit)   # mirrors game.gd's signal; tests emit it directly
 	var turn_manager: TurnManager
 	var squad_manager: SquadManager
+	var scenario_manager: ManagerStub
 	var refreshes := 0   # counts refresh_mission_status calls -- the #134 write-point wire
 
 	func refresh_mission_status() -> void:
@@ -30,6 +37,7 @@ func before_test() -> void:
 	_stub = auto_free(GameStub.new())
 	_stub.turn_manager = auto_free(TurnManager.new())
 	_stub.squad_manager = auto_free(SquadManager.new())
+	_stub.scenario_manager = ManagerStub.new()   # #397: the content stores the director reads live
 	add_child(_stub)
 	_director = ScenarioDirector.new()
 	_director.game = _stub
@@ -86,13 +94,13 @@ func _await_starts(expected: int) -> void:
 # --- MISSION_START ---
 
 func test_mission_start_beat_plays_on_mission_started() -> void:
-	_director.set_beats([_beat(DialogBeat.Trigger.MISSION_START, "Welcome to the academy.")])
+	_set_beats([_beat(DialogBeat.Trigger.MISSION_START, "Welcome to the academy.")])
 	_director.mission_started()
 	await _await_starts(1)
 
 
 func test_mission_start_beat_fires_once_per_battle() -> void:
-	_director.set_beats([_beat(DialogBeat.Trigger.MISSION_START, "Once only.")])
+	_set_beats([_beat(DialogBeat.Trigger.MISSION_START, "Once only.")])
 	_director.mission_started()
 	_director.mission_started()
 	await _await_starts(1)
@@ -103,7 +111,7 @@ func test_mission_start_beat_fires_once_per_battle() -> void:
 # --- TURN_START ---
 
 func test_turn_start_beat_waits_for_its_player_turn() -> void:
-	_director.set_beats([_beat(DialogBeat.Trigger.TURN_START, "Turn two tip.", 2)])
+	_set_beats([_beat(DialogBeat.Trigger.TURN_START, "Turn two tip.", 2)])
 	_director.mission_started()   # content is inert until armed
 	_stub.turn_manager.turn_started.emit(ENEMY)    # enemy turns never advance the player count
 	_stub.turn_manager.turn_started.emit(PLAYER)   # player turn 1: not yet
@@ -116,7 +124,7 @@ func test_turn_start_beat_waits_for_its_player_turn() -> void:
 # --- SQUAD_FORMED ---
 
 func test_squad_formed_beat_fires_for_player_squad_only() -> void:
-	_director.set_beats([_beat(DialogBeat.Trigger.SQUAD_FORMED, "Squads share a plan.")])
+	_set_beats([_beat(DialogBeat.Trigger.SQUAD_FORMED, "Squads share a plan.")])
 	_director.mission_started()
 	_stub.squad_manager.squad_created.emit(_squad(ENEMY))
 	await get_tree().process_frame
@@ -128,7 +136,7 @@ func test_squad_formed_beat_fires_for_player_squad_only() -> void:
 # --- one timeline at a time ---
 
 func test_beat_landing_mid_dialog_queues_until_the_timeline_ends() -> void:
-	_director.set_beats([
+	_set_beats([
 		_beat(DialogBeat.Trigger.MISSION_START, "Intro talking."),
 		_beat(DialogBeat.Trigger.SQUAD_FORMED, "Payoff line."),
 	])
@@ -142,13 +150,14 @@ func test_beat_landing_mid_dialog_queues_until_the_timeline_ends() -> void:
 # --- resume / teardown ---
 
 func test_disarm_silences_every_trigger() -> void:
-	_director.set_beats([
+	_set_beats([
 		_beat(DialogBeat.Trigger.MISSION_START, "Never."),
 		_beat(DialogBeat.Trigger.TURN_START, "Never.", 1),
 		_beat(DialogBeat.Trigger.SQUAD_FORMED, "Never."),
 	])
 	_director.disarm()
-	_director.mission_started()
+	# No re-arm: mission_started IS the fresh-start door, so calling it here would legitimately
+	# fire (#397 -- disarm silences execution, it no longer destroys content).
 	_stub.turn_manager.turn_started.emit(PLAYER)
 	_stub.squad_manager.squad_created.emit(_player_squad())
 	await get_tree().process_frame
@@ -157,7 +166,7 @@ func test_disarm_silences_every_trigger() -> void:
 
 
 func test_reset_ends_a_running_timeline() -> void:
-	_director.set_beats([_beat(DialogBeat.Trigger.MISSION_START, "Doomed dialog.")])
+	_set_beats([_beat(DialogBeat.Trigger.MISSION_START, "Doomed dialog.")])
 	_director.mission_started()
 	await _await_starts(1)
 	_director.reset()
@@ -183,7 +192,7 @@ func _named_unit(unit_name: String, fac: Team.Faction) -> Unit:
 
 
 func test_selection_step_requires_the_named_unit() -> void:
-	_director.set_steps([
+	_set_steps([
 		_step(DialogBeat.Trigger.UNIT_SELECTED, "Select Torv.", "Torv"),
 		_step(DialogBeat.Trigger.SQUAD_FORMED, "Squad up."),
 	])
@@ -195,7 +204,7 @@ func test_selection_step_requires_the_named_unit() -> void:
 
 
 func test_member_step_waits_for_the_squad_size() -> void:
-	_director.set_steps([_step(DialogBeat.Trigger.SQUAD_MEMBER_ADDED, "Bring everyone.", "", 3)])
+	_set_steps([_step(DialogBeat.Trigger.SQUAD_MEMBER_ADDED, "Bring everyone.", "", 3)])
 	_director.mission_started()
 	var squad := _player_squad()
 	squad._add_member(_named_unit("Second", PLAYER))   # 2 members: leader + one
@@ -207,8 +216,8 @@ func test_member_step_waits_for_the_squad_size() -> void:
 
 
 func test_step_and_payoff_beat_share_one_event_step_first() -> void:
-	_director.set_steps([_step(DialogBeat.Trigger.SQUAD_FORMED, "Form a squad.")])
-	_director.set_beats([_beat(DialogBeat.Trigger.SQUAD_FORMED, "Good -- now you move as one.")])
+	_set_steps([_step(DialogBeat.Trigger.SQUAD_FORMED, "Form a squad.")])
+	_set_beats([_beat(DialogBeat.Trigger.SQUAD_FORMED, "Good -- now you move as one.")])
 	_director.mission_started()
 	_stub.squad_manager.squad_created.emit(_player_squad())
 	assert_str(_director.active_instruction()).is_equal("")   # the step advanced...
@@ -216,7 +225,7 @@ func test_step_and_payoff_beat_share_one_event_step_first() -> void:
 
 
 func test_the_lesson_walks_in_authored_order() -> void:
-	_director.set_steps([
+	_set_steps([
 		_step(DialogBeat.Trigger.UNIT_SELECTED, "Select Torv.", "Torv"),
 		_step(DialogBeat.Trigger.SQUAD_FORMED, "Squad up with someone.", "Torv"),
 		_step(DialogBeat.Trigger.SQUAD_MEMBER_ADDED, "Bring the other two.", "", 4),
@@ -241,7 +250,7 @@ func test_the_lesson_walks_in_authored_order() -> void:
 
 
 func test_disarm_clears_the_instruction() -> void:
-	_director.set_steps([_step(DialogBeat.Trigger.SQUAD_FORMED, "Never seen on resume.")])
+	_set_steps([_step(DialogBeat.Trigger.SQUAD_FORMED, "Never seen on resume.")])
 	_director.mission_started()
 	assert_str(_director.active_instruction()).is_equal("Never seen on resume.")
 	_director.disarm()
@@ -249,13 +258,13 @@ func test_disarm_clears_the_instruction() -> void:
 
 
 func test_payoff_beat_fires_when_its_step_completes() -> void:
-	_director.set_steps([
+	_set_steps([
 		_step(DialogBeat.Trigger.UNIT_SELECTED, "Select Torv.", "Torv"),
 		_step(DialogBeat.Trigger.SQUAD_FORMED, "Squad up."),
 	])
 	var payoff := _beat(DialogBeat.Trigger.STEP_COMPLETED, "Both steps done.")
 	payoff.step = 2
-	_director.set_beats([payoff])
+	_set_beats([payoff])
 	_director.mission_started()
 	_stub.unit_selected.emit(_named_unit("Torv", PLAYER))   # completes step 1 -- not the payoff's step
 	await get_tree().process_frame
@@ -265,7 +274,7 @@ func test_payoff_beat_fires_when_its_step_completes() -> void:
 
 
 func test_member_step_ignores_the_wrong_leaders_squad() -> void:
-	_director.set_steps([_step(DialogBeat.Trigger.SQUAD_MEMBER_ADDED, "Grow Torv's squad.", "Torv", 2)])
+	_set_steps([_step(DialogBeat.Trigger.SQUAD_MEMBER_ADDED, "Grow Torv's squad.", "Torv", 2)])
 	_director.mission_started()
 	var isaac_squad := auto_free(Squad.new()) as Squad
 	isaac_squad.set_leader(_named_unit("Isaac", PLAYER))
@@ -295,7 +304,7 @@ func test_prolog_authored_content_resolves() -> void:
 func test_disarm_also_empties_the_pending_queue() -> void:
 	# The resurrection bug: a beat queued behind a running timeline survived disarm, and
 	# timeline_ended popped it back to life on a director that had nothing left to say.
-	_director.set_beats([
+	_set_beats([
 		_beat(DialogBeat.Trigger.MISSION_START, "First voice."),
 		_beat(DialogBeat.Trigger.MISSION_START, "Queued voice."),
 	])
@@ -307,3 +316,12 @@ func test_disarm_also_empties_the_pending_queue() -> void:
 	await get_tree().process_frame
 	await get_tree().process_frame
 	assert_int(_starts).is_equal(1)
+
+
+# #397: content lives on the manager; the director reads it live. These write the stub store.
+func _set_beats(beats: Array[DialogBeat]) -> void:
+	_stub.scenario_manager.current_dialog_beats = beats
+
+
+func _set_steps(steps: Array[TutorialStep]) -> void:
+	_stub.scenario_manager.current_tutorial_steps = steps

--- a/tests/ui/test_mission_status_panel.gd
+++ b/tests/ui/test_mission_status_panel.gd
@@ -206,7 +206,7 @@ func test_the_panel_stays_inside_the_viewport() -> void:
 # ==============================================================================
 
 func _steps(list: Array[TutorialStep]) -> void:
-	game.scenario_director.set_steps(list)
+	game.scenario_manager.current_tutorial_steps = list   # #397: the manager owns content
 	game.scenario_director.mission_started()   # content is inert until armed (the solo-squad spawn guard)
 
 


### PR DESCRIPTION
Closes #397. And fixes a live data-loss bug recon surfaced on the way.

## The bug first: Update was wiping lessons

`capture_scenario` carried every authored field *except* `dialog_beats` and `tutorial_steps` -- so the Scenario tool's **Update button silently erased the Prolog lesson** (the confirm you asked for in #197 would even ask politely first). Fixed with the `current_look_preset` pattern: **`ScenarioManager` owns `current_dialog_beats` / `current_tutorial_steps`** (set by apply, cleared by `clear_board`, written out by capture), and **`ScenarioDirector` reads them live instead of copying**. Consequence: `disarm()` now silences *execution* without destroying *content*, so resume-then-Update can't lose anything either. Pinned by `tests/flow/test_dialog_capture.gd`.

## The page: Scenario ▸ Dialog & Tutorial

- **Beats**: trigger dropdown, the conditional param (`turn`/`step`) appearing only for its trigger, and a **timeline dropdown fed from Dialogic's own dtl registry** -- the directory the editor plugin maintains, no second file scan. 
- **Steps**: instruction text, done-when, unit name, size/turn, **up/down reorder** (order is part of the edit), remove.
- Edits write the manager's stores directly -- immediately playable on an armed board, captured by Update, every edit marks the header `(modified)`. Children are all code-built, so the `.tscn` change is one node. The tree-law suite covers the leaf (resolves / unique / tooltipped) for free.

## The two deferred lints (`BoardLint._check_dialog`)

- **Beat with no timeline** → DEGRADES (fires into nothing).
- **Step naming a unit absent from the board** → BLOCKS (the lesson stalls there forever, silently -- your #390 class exactly).

Your un-started-board ruling shipped with one polarity adjustment, flagged in the plan: the gate is `past_opening_turn()` -- **false on un-armed boards** -- because the dev-tools Load path never arms the director, and that's precisely the authoring session the check exists for. So: authoring boards always check, resumed/armed battles past turn 1 go quiet. (`Check board` + CI both run in always-check contexts.)

## Tests

41 cases across four suites: capture round-trip (the wipe regression), the reads-live disarm semantics, lint teeth with non-vacuous twins (fault flagged, fault fixed, finding gone), the opening-turn gate through real signals, and page-contract cases (rows project stores, edits write back, reorder moves the authored sequence). The lint wire was mutant-checked: severing the `_check_dialog` call reds the aimed case. `flow`+`dev`+`ui` green.

## For your hands

Load the Prolog in dev tools → Scenario ▸ Dialog & Tutorial: the four beats and three steps render as rows. The row layout/density is untuned first-draft -- tell me what feels cramped. #400 (the player dialog-off setting) is filed and rides next.
