### PR TITLE
Commit Dialogic's populated directory cache (main dirties on every editor open)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -22,8 +22,15 @@ Dialogic="*uid://ds2q0uclmolvu"
 
 [dialogic]
 
-directories/dch_directory={}
-directories/dtl_directory={}
+directories/dch_directory={
+"torv": "res://Scenarios/dialog/characters/torv.dch"
+}
+directories/dtl_directory={
+"prolog_intro": "res://Scenarios/dialog/prolog_intro.dtl",
+"prolog_step_complete": "res://Scenarios/dialog/prolog_step_complete.dtl",
+"prolog_step_first_join": "res://Scenarios/dialog/prolog_step_first_join.dtl",
+"prolog_step_selected": "res://Scenarios/dialog/prolog_step_selected.dtl"
+}
 layout/style_directory={}
 
 [display]


### PR DESCRIPTION
The `dch`/`dtl` directories in `project.godot` are Dialogic's derived cache. Main held the **empty** form (a pre-#370 branch's editor session erased the entries, and its PR carried the emptied file over the populated one), so every editor open on main re-derived them and dirtied the tree.

This commits exactly the form the editor writes — verified **byte-identical** to the working-tree version your editor produces — so a scan finds nothing to change. Once merged, your local diff on main disappears on pull.

**Recurrence note:** these entries change only when dialog content changes; the rule is that a PR adding/removing `.dtl`/`.dch` files carries the matching directory entries. An unexpected `[dialogic]` diff = a scan disagreeing with committed content, worth a look rather than a shrug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)