### PR TITLE
Player setting: Show mission dialog (#400)

### DIFF
--- a/Classes/core/PlayerSettings.gd
+++ b/Classes/core/PlayerSettings.gd
@@ -21,6 +21,7 @@ class_name PlayerSettings
 
 enum Setting {
 	ALWAYS_SHOW_HEALTH,
+	SHOW_DIALOG,
 }
 
 # Per-setting metadata. Literal-only, so it can be a compile-time const (the Experiments.DEFS shape).
@@ -32,6 +33,11 @@ const DEFS := {
 		"title": "Always show health bars",
 		"desc": "Keep every unit's health bar up, not just the one under your cursor. The numbers still appear on hover.",
 		"default": false,
+	},
+	Setting.SHOW_DIALOG: {
+		"title": "Show mission dialog",
+		"desc": "Characters speak during missions. Turn off to skip all dialog -- replays, restarts, or preference. Tutorial instructions stay on either way.",
+		"default": true,
 	},
 }
 

--- a/Classes/flow/ScenarioDirector.gd
+++ b/Classes/flow/ScenarioDirector.gd
@@ -190,6 +190,11 @@ func _fire(beat: DialogBeat) -> void:
 	if _fired.has(beat) or beat.timeline == null:
 		return
 	_fired[beat] = true
+	# The #400 player switch: dialog off CONSUMES the beat without playing it -- a moment that
+	# passed silently must not replay if the setting comes back mid-battle. Tutorial INSTRUCTIONS
+	# are not dialog and never gate here; the #134 row carries the lesson alone then.
+	if not PlayerSettings.is_on(PlayerSettings.Setting.SHOW_DIALOG):
+		return
 	if _dialog_active or Dialogic.current_timeline != null:
 		_pending.append(beat.timeline)
 	else:

--- a/tests/flow/test_scenario_director.gd
+++ b/tests/flow/test_scenario_director.gd
@@ -43,6 +43,7 @@ func before_test() -> void:
 	_director.game = _stub
 	_stub.add_child(_director)   # _ready connects the two manager signals + Dialogic
 	_starts = 0
+	PlayerSettings.reset_for_test()   # is_on falls through to DISK otherwise (the #350 gotcha)
 	Dialogic.timeline_started.connect(_count_start)
 
 
@@ -325,3 +326,26 @@ func _set_beats(beats: Array[DialogBeat]) -> void:
 
 func _set_steps(steps: Array[TutorialStep]) -> void:
 	_stub.scenario_manager.current_tutorial_steps = steps
+
+
+# --- the #400 player switch ---
+
+func test_dialog_off_consumes_beats_silently_and_never_replays_them() -> void:
+	PlayerSettings.set_on(PlayerSettings.Setting.SHOW_DIALOG, false)
+	_set_beats([_beat(DialogBeat.Trigger.MISSION_START, "Skipped entirely.")])
+	_director.mission_started()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_int(_starts).is_equal(0)
+	# The moment passed: re-enabling mid-battle must not replay it...
+	PlayerSettings.set_on(PlayerSettings.Setting.SHOW_DIALOG, true)
+	_director.mission_started()   # same battle, fired-set intact
+	await get_tree().process_frame
+	assert_int(_starts).is_equal(0)
+
+
+func test_dialog_off_leaves_the_instruction_row_alone() -> void:
+	PlayerSettings.set_on(PlayerSettings.Setting.SHOW_DIALOG, false)
+	_set_steps([_step(DialogBeat.Trigger.SQUAD_FORMED, "Form a squad.")])
+	_director.mission_started()
+	assert_str(_director.active_instruction()).is_equal("Form a squad.")


### PR DESCRIPTION
Closes #400. **Stacked on `feat/397-dialog-page` (#401)** -- merge bottom-up: #401 first, delete its head, this retargets to main. (Also: your `"a"` commit on that branch carries the same project.godot fix as #402, so #402 can close unmerged once #401 lands.)

## What it is

Exactly the shape #350 promised: **one row in `PlayerSettings.DEFS`** ("Show mission dialog", default on -- `SettingsScreen` renders it with zero UI work, pause menu and title screen both) and **one gate in `ScenarioDirector._fire`**, read live at each fire so toggling mid-battle works without wiring.

## The one semantic decision

Dialog off **consumes** the beat rather than deferring it: the moment passed silently, so re-enabling mid-battle never replays an intro for a board state that has moved on. Future beats fire normally once the setting is back. Tutorial **instructions never gate** -- they are reference, not voice, and with dialog off the mission-status row carries the lesson alone (the #404 interaction note).

## Tests

Off consumes silently and never replays (same battle, fired-set intact); the instruction row is untouched by the setting. The director suite gained `PlayerSettings.reset_for_test()` in `before_test` -- the #350 disk-fallthrough gotcha, without which these cases would read the developer's own settings.cfg. `flow` 204/204, settings suites green.
