### PR TITLE
Re-land #400: Show mission dialog setting (stranded by the stacked merge)

### DIFF
--- a/Classes/core/PlayerSettings.gd
+++ b/Classes/core/PlayerSettings.gd
@@ -21,6 +21,7 @@ class_name PlayerSettings
 
 enum Setting {
 	ALWAYS_SHOW_HEALTH,
+	SHOW_DIALOG,
 }
 
 # Per-setting metadata. Literal-only, so it can be a compile-time const (the Experiments.DEFS shape).
@@ -32,6 +33,11 @@ const DEFS := {
 		"title": "Always show health bars",
 		"desc": "Keep every unit's health bar up, not just the one under your cursor. The numbers still appear on hover.",
 		"default": false,
+	},
+	Setting.SHOW_DIALOG: {
+		"title": "Show mission dialog",
+		"desc": "Characters speak during missions. Turn off to skip all dialog -- replays, restarts, or preference. Tutorial instructions stay on either way.",
+		"default": true,
 	},
 }
 

--- a/Classes/flow/ScenarioDirector.gd
+++ b/Classes/flow/ScenarioDirector.gd
@@ -190,6 +190,11 @@ func _fire(beat: DialogBeat) -> void:
 	if _fired.has(beat) or beat.timeline == null:
 		return
 	_fired[beat] = true
+	# The #400 player switch: dialog off CONSUMES the beat without playing it -- a moment that
+	# passed silently must not replay if the setting comes back mid-battle. Tutorial INSTRUCTIONS
+	# are not dialog and never gate here; the #134 row carries the lesson alone then.
+	if not PlayerSettings.is_on(PlayerSettings.Setting.SHOW_DIALOG):
+		return
 	if _dialog_active or Dialogic.current_timeline != null:
 		_pending.append(beat.timeline)
 	else:

--- a/project.godot
+++ b/project.godot
@@ -22,8 +22,15 @@ Dialogic="*uid://ds2q0uclmolvu"
 
 [dialogic]
 
-directories/dch_directory={}
-directories/dtl_directory={}
+directories/dch_directory={
+"torv": "res://Scenarios/dialog/characters/torv.dch"
+}
+directories/dtl_directory={
+"prolog_intro": "res://Scenarios/dialog/prolog_intro.dtl",
+"prolog_step_complete": "res://Scenarios/dialog/prolog_step_complete.dtl",
+"prolog_step_first_join": "res://Scenarios/dialog/prolog_step_first_join.dtl",
+"prolog_step_selected": "res://Scenarios/dialog/prolog_step_selected.dtl"
+}
 layout/style_directory={}
 
 [display]

--- a/tests/flow/test_scenario_director.gd
+++ b/tests/flow/test_scenario_director.gd
@@ -43,6 +43,7 @@ func before_test() -> void:
 	_director.game = _stub
 	_stub.add_child(_director)   # _ready connects the two manager signals + Dialogic
 	_starts = 0
+	PlayerSettings.reset_for_test()   # is_on falls through to DISK otherwise (the #350 gotcha)
 	Dialogic.timeline_started.connect(_count_start)
 
 
@@ -325,3 +326,26 @@ func _set_beats(beats: Array[DialogBeat]) -> void:
 
 func _set_steps(steps: Array[TutorialStep]) -> void:
 	_stub.scenario_manager.current_tutorial_steps = steps
+
+
+# --- the #400 player switch ---
+
+func test_dialog_off_consumes_beats_silently_and_never_replays_them() -> void:
+	PlayerSettings.set_on(PlayerSettings.Setting.SHOW_DIALOG, false)
+	_set_beats([_beat(DialogBeat.Trigger.MISSION_START, "Skipped entirely.")])
+	_director.mission_started()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_int(_starts).is_equal(0)
+	# The moment passed: re-enabling mid-battle must not replay it...
+	PlayerSettings.set_on(PlayerSettings.Setting.SHOW_DIALOG, true)
+	_director.mission_started()   # same battle, fired-set intact
+	await get_tree().process_frame
+	assert_int(_starts).is_equal(0)
+
+
+func test_dialog_off_leaves_the_instruction_row_alone() -> void:
+	PlayerSettings.set_on(PlayerSettings.Setting.SHOW_DIALOG, false)
+	_set_steps([_step(DialogBeat.Trigger.SQUAD_FORMED, "Form a squad.")])
+	_director.mission_started()
+	assert_str(_director.active_instruction()).is_equal("Form a squad.")


### PR DESCRIPTION
Re-lands #400 -- **the stacked-merge trap fired on #406**: it merged into its base branch (`feat/397-dialog-page`) *after* #401 had already carried that branch to main, so the dialog-off setting never actually reached main (verified by tip-to-tip diff: `PlayerSettings`, the director gate, and the tests are all absent from `main`). Same commit, retargeted straight at main; the diff is identical to what you reviewed in #406.

Original description: one `PlayerSettings.DEFS` row ("Show mission dialog", default on), one live-read gate in `ScenarioDirector._fire` -- off CONSUMES a beat (never replays after re-enable), instructions never gate. Tests pin both, plus the `reset_for_test()` disk-fallthrough guard.

Merge-order lesson for the memory files, already recorded: a stacked PR is only safe merged bottom-up **before** the base's own PR -- once the base merges to main, the stack must be retargeted, not merged into the now-dead base.
