### PR TITLE
Standing squad rings behind a player setting (#435)

### DIFF
--- a/Classes/actions/OrderExecutor.gd
+++ b/Classes/actions/OrderExecutor.gd
@@ -125,6 +125,12 @@ func _end_squad_turn(squad: Squad) -> void:
 	game.refresh_end_turn_button()
 	for member in squad.members:
 		game.overlay_manager.clear_planned_path(member)
+	# LAST, not beside the ejection sweeps above: the clear at the top of this method would wipe an
+	# earlier restore. Standing rings deliberately stand down for the WHOLE pass -- a marker sits on
+	# its unit's projected destination, which during a pass is the cell the unit has not reached
+	# yet, so a ring left up would jump ahead of the unit instead of travelling with it. Riding the
+	# animated position is a separate build; the settled board is where they come back.
+	game.refresh_squad_rings()
 
 # Why a concede happened, for the console: an AI cannot see a red flash, so this is the only place
 # the refusal is visible at all.

--- a/Classes/board/OverlayIcon.gd
+++ b/Classes/board/OverlayIcon.gd
@@ -1,14 +1,17 @@
 extends Node2D
 class_name OverlayIcon
 
-# One marker hung on a UNIT rather than a cell: a Sprite2D plus the cell it was anchored to.
+# One marker hung on a UNIT rather than a cell: a Sprite2D that follows the unit it was built for.
 # Built and pooled by OverlayManager (icons_by_unit), styled by its _style_icon (#325: a ring
-# underfoot or the legacy head square), and mirrored by OverlayMirror._icons into
-# BoardOverlays.Layer.GROUND_ICONS (rings, surface decals) or Layer.ICONS (squares, billboards).
+# underfoot, the crown over the head), and mirrored by OverlayMirror._icons into
+# BoardOverlays.Layer.GROUND_ICONS (rings, surface decals) or Layer.ICONS (crowns, billboards).
 
 @onready var sprite = $Sprite2D
 var icon_type
-var target_cell: Vector2i
+# The unit this marker hangs on, and the grid its cells are measured in. The CELL is deliberately
+# not stored -- see current_cell.
+var unit: Unit
+var grid: TileMapLayer
 
 # The above-the-head channel: what a unit IS, never what the current interaction is about
 # (#346 -- ground markup carries the interaction). CURSOR/TARGET/INVALID lived here and are
@@ -19,7 +22,27 @@ enum IconType {
 	SQUADMEMBER
 }
 
-func setup(texture: Texture2D, cell: Vector2i, type: IconType):
+func setup(texture: Texture2D, marker_unit: Unit, board_grid: TileMapLayer, type: IconType):
 	sprite.texture = texture
-	target_cell = cell
+	unit = marker_unit
+	grid = board_grid
 	icon_type = type
+
+# THE answer to where this marker sits -- read by the 2D position below and by OverlayMirror alike,
+# so the two views cannot drift into two answers. Derived, never copied: a stored cell goes stale
+# silently the moment a marker outlives one repaint (#308), which was invisible while markers lived
+# only as long as a selection and got rebuilt constantly. get_projected_destination already returns
+# the projected cell while a move is queued and movement.cell otherwise, so planning and settled
+# state both read correctly from the one expression.
+func current_cell() -> Vector2i:
+	return unit.get_projected_destination()
+
+func has_unit() -> bool:
+	return is_instance_valid(unit)
+
+# Following the unit is the icon's own job rather than something each redraw path must remember;
+# forgetting is what left a persistent ring behind on the cell its unit walked off.
+func _process(_delta: float) -> void:
+	if not has_unit() or grid == null:
+		return
+	position = grid.map_to_local(current_cell())

--- a/Classes/board/OverlayManager.gd
+++ b/Classes/board/OverlayManager.gd
@@ -139,6 +139,12 @@ const HEAD_ICON_Z_INDEX := 8  # the legacy squares' z; code re-asserts it so the
 
 var overlay_map = {}
 var icons_by_unit := {} # { Unit : { IconType : OverlayIcon } }
+
+# WHICH squads wear a STANDING ring right now, injected by game (the squad_manager.board_source
+# idiom). redraw_squad_unit_icons clears the WHOLE channel and then draws one squad, so without
+# this it strips every OTHER squad's standing rings the moment the player hovers one. Returns
+# empty while ALWAYS_SHOW_SQUAD_RINGS is off, which is what keeps the selection paths untouched.
+var standing_squads_source: Callable = func() -> Array[Squad]: return []
 var planned_move_by_unit := {} #{Unit : MoveAction}
 var terrain_live_sprites: Array[Sprite2D] = []       # live terrain icons (persist across selection)
 var terrain_preview_sprites: Array[Sprite2D] = []    # ephemeral plan-time ghosts (Part B)
@@ -563,8 +569,13 @@ func clear_unit_icon_types(types: Array[OverlayIcon.IconType]):
 		for type in types:
 			clear_unit_icon(unit, type)
 
+# The channel is cleared whole, so everything that should be on it after this call has to be drawn
+# by it: the STANDING set first, then the squad the caller is actually about (which may already be
+# in that set -- create_unit_icon is idempotent, so the overlap costs nothing).
 func redraw_squad_unit_icons(squad: Squad):
 	clear_unit_icon_types([OverlayIcon.IconType.CROWN, OverlayIcon.IconType.SQUADMEMBER])
+	for standing: Squad in standing_squads_source.call():
+		draw_squad_unit_icons(standing)
 	draw_squad_unit_icons(squad)
 
 # What ONE squad's markers ARE: a ring on every member, the crown on its leader. Split out of the

--- a/Classes/board/OverlayManager.gd
+++ b/Classes/board/OverlayManager.gd
@@ -501,9 +501,8 @@ func create_unit_icon(unit: Unit, type: OverlayIcon.IconType) -> OverlayIcon:
 		
 	var icon := ICON_SCENE.instantiate()
 	icon_overlay.add_child(icon)
-	var cell := unit.get_projected_destination()
-	icon.setup(ICON_TEXTURES[type], cell, type)
-	icon.position = board_tilemap.map_to_local(cell)
+	icon.setup(ICON_TEXTURES[type], unit, board_tilemap, type)
+	icon.position = board_tilemap.map_to_local(icon.current_cell())
 	_style_icon(icon, unit)
 
 	icons_by_unit[unit][type] = icon
@@ -566,6 +565,13 @@ func clear_unit_icon_types(types: Array[OverlayIcon.IconType]):
 
 func redraw_squad_unit_icons(squad: Squad):
 	clear_unit_icon_types([OverlayIcon.IconType.CROWN, OverlayIcon.IconType.SQUADMEMBER])
+	draw_squad_unit_icons(squad)
+
+# What ONE squad's markers ARE: a ring on every member, the crown on its leader. Split out of the
+# redraw above so the standing-ring sweep (game.refresh_squad_rings) can draw many squads without
+# each one wiping the last -- the alternative was a second copy of this pair, which is how the two
+# would have drifted.
+func draw_squad_unit_icons(squad: Squad) -> void:
 	for member in squad.get_members():
 		create_unit_icon(member, OverlayIcon.IconType.SQUADMEMBER)
 		if member == squad.get_leader():

--- a/Classes/board/OverlayManager.gd
+++ b/Classes/board/OverlayManager.gd
@@ -140,11 +140,11 @@ const HEAD_ICON_Z_INDEX := 8  # the legacy squares' z; code re-asserts it so the
 var overlay_map = {}
 var icons_by_unit := {} # { Unit : { IconType : OverlayIcon } }
 
-# WHICH squads wear a STANDING ring right now, injected by game (the squad_manager.board_source
-# idiom). redraw_squad_unit_icons clears the WHOLE channel and then draws one squad, so without
-# this it strips every OTHER squad's standing rings the moment the player hovers one. Returns
-# empty while ALWAYS_SHOW_SQUAD_RINGS is off, which is what keeps the selection paths untouched.
-var standing_squads_source: Callable = func() -> Array[Squad]: return []
+# Puts the STANDING markers back after this manager clears the channel whole, injected by game (the
+# squad_manager.board_source idiom). A Callable that DRAWS rather than one that returns a squad
+# list, so "what does the standing set look like" has exactly one implementation instead of one
+# here and one in game. Does nothing while ALWAYS_SHOW_SQUAD_RINGS is off.
+var standing_rings_drawer: Callable = func() -> void: pass
 var planned_move_by_unit := {} #{Unit : MoveAction}
 var terrain_live_sprites: Array[Sprite2D] = []       # live terrain icons (persist across selection)
 var terrain_preview_sprites: Array[Sprite2D] = []    # ephemeral plan-time ghosts (Part B)
@@ -574,8 +574,7 @@ func clear_unit_icon_types(types: Array[OverlayIcon.IconType]):
 # in that set -- create_unit_icon is idempotent, so the overlap costs nothing).
 func redraw_squad_unit_icons(squad: Squad):
 	clear_unit_icon_types([OverlayIcon.IconType.CROWN, OverlayIcon.IconType.SQUADMEMBER])
-	for standing: Squad in standing_squads_source.call():
-		draw_squad_unit_icons(standing)
+	standing_rings_drawer.call()
 	draw_squad_unit_icons(squad)
 
 # What ONE squad's markers ARE: a ring on every member, the crown on its leader. Split out of the

--- a/Classes/core/PlayerSettings.gd
+++ b/Classes/core/PlayerSettings.gd
@@ -20,6 +20,7 @@ class_name PlayerSettings
 
 enum Setting {
 	ALWAYS_SHOW_HEALTH,
+	ALWAYS_SHOW_SQUAD_RINGS,
 	SHOW_DIALOG,
 	PHOTOSENSITIVITY,
 }
@@ -32,6 +33,11 @@ const DEFS := {
 	Setting.ALWAYS_SHOW_HEALTH: {
 		"title": "Always show health bars",
 		"desc": "Keep every unit's health bar up, not just the one under your cursor. The numbers still appear on hover.",
+		"default": false,
+	},
+	Setting.ALWAYS_SHOW_SQUAD_RINGS: {
+		"title": "Always show squad rings",
+		"desc": "Keep every squad's coloured rings under its members at all times, not just the squad you're looking at.",
 		"default": false,
 	},
 	Setting.SHOW_DIALOG: {

--- a/Classes/presentation/OverlayMirror.gd
+++ b/Classes/presentation/OverlayMirror.gd
@@ -414,11 +414,15 @@ func _air_anchor(px: Vector2, from_cell: Vector2i) -> Transform3D:
 	return Transform3D(Basis.IDENTITY, BoardSpace.of_pixels(px, flight_y))
 
 
-# Selection icons, routed by TYPE rather than by a style mode (#325 verdict, dev call after playing
+# Unit markers, routed by TYPE rather than by a style mode (#325 verdict, dev call after playing
 # both, 2026-08-19). CROWN rides ICONS as a head billboard -- leadership is what a unit IS, and
 # nothing has read better over a head than the original crown. Everything else (today, SQUADMEMBER)
 # rides GROUND_ICONS as a surface decal in the squad's own hue, texture and tint arriving BY COPY
 # from the 2D sprite, so the hue is authored in one place and never re-derived here.
+#
+# They were SELECTION icons until #423 slice 1; ALWAYS_SHOW_SQUAD_RINGS can now keep membership
+# rings standing, which is why the anchor below asks the ICON where its unit is instead of reading
+# a cell stamped when the marker was built.
 #
 # The leader wears BOTH: a ring because they are a member, the crown because they lead.
 #
@@ -431,9 +435,9 @@ func _icons(om: OverlayManager) -> void:
 		var by_type: Dictionary = om.icons_by_unit[unit]
 		for type in by_type:
 			var icon := by_type[type] as OverlayIcon
-			if icon == null or not is_instance_valid(icon):
+			if icon == null or not is_instance_valid(icon) or not icon.has_unit():
 				continue
-			var surface := _anchor(icon.target_cell)
+			var surface := _anchor(icon.current_cell())
 			if type == OverlayIcon.IconType.CROWN:
 				heads.append(_marker(surface, icon.sprite.texture, icon.sprite.modulate))
 			else:

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -453,6 +453,23 @@ without `OverlayManager` learning what a player setting is. The general form: **
 tenant to a channel means auditing every writer that clears the channel, not just the ones that
 draw the new thing.**
 
+**It bit a SECOND time, at a different clear, and that one reached the dev.** `clear_selection_icons`
+is called by `HoverPresenter._hover_idle` on **every hover change while nothing is selected** — bare
+ground included — so the rings drew at load and the first mouse movement wiped them: *"I toggle them
+on, go back into the level, and they are not on. I still have to hover to show them."* Every headless
+case passed because none of them ever **moved the cursor**, which is the one thing a player does
+constantly. The fix is the method's own name taken literally — it drops the SELECTION's markers, and
+standing rings are not the selection's, so they go straight back up. `game.draw_standing_rings` is
+now the single implementation of *what is on this channel with nothing selected*, called by that
+clear and, through `OverlayManager.standing_rings_drawer`, by the per-squad redraw; the injected
+Callable DRAWS rather than returning a squad list precisely so there is not one answer here and
+another in `game`.
+
+**The sharpened form: find the clears by grepping for them, not by imagining which ones matter.**
+Both misses were writers that clear the channel for a reason unrelated to the new feature, and the
+second was reachable by a mouse movement on a board with nothing selected — the most ordinary state
+the game has.
+
 **Two findings worth keeping.** First, **persistence is what made a stale copy visible**:
 `OverlayIcon` stored the cell it was built on and `OverlayMirror` anchored on that copy, which was
 invisible only because markers were rebuilt constantly — the instant one outlived a move it sat on

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -441,6 +441,18 @@ rings. It is gated on having squadmates (`Unit.has_squad`'s question) and delibe
 `ring_hue`, which is dealt once at the first squadmate and never reset — that gate would leave a
 lone leftover wearing a colour forever.
 
+**A CHANNEL THAT IS CLEARED WHOLE HAS TO BE REDRAWN WHOLE, and the per-squad redraw is where that
+bit.** `OverlayManager.redraw_squad_unit_icons` clears every `CROWN`/`SQUADMEMBER` marker and then
+draws the ONE squad it was handed — fine for a decade of selection-scoped markers, since the only
+markers that should exist belong to the thing being selected. Standing rings are the first tenant of
+that channel that has to survive somebody *else's* redraw, and `HoverPresenter` calls it on every
+hover-move preview: so hovering one squad stripped every other squad's rings, which is the state the
+board would have sat in for most of a feel-test. `standing_squads_source` (a Callable injected by
+game, the `SquadManager.board_source` idiom) is what lets the redraw put the standing set back
+without `OverlayManager` learning what a player setting is. The general form: **adding a persistent
+tenant to a channel means auditing every writer that clears the channel, not just the ones that
+draw the new thing.**
+
 **Two findings worth keeping.** First, **persistence is what made a stale copy visible**:
 `OverlayIcon` stored the cell it was built on and `OverlayMirror` anchored on that copy, which was
 invisible only because markers were rebuilt constantly — the instant one outlived a move it sat on

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -7,7 +7,7 @@ its child [#49 Action Queue UX](https://github.com/Phaazoid/Godoiosis/issues/49)
 This is a *guidelines* doc, not a spec — it captures the principles we're holding the work to,
 plus the running order of the queue-UX checklist. Update it as items land.
 
-**Canon checked through #427 (2026-08-20).**
+**Canon checked through #432 (2026-08-21).**
 
 ## Principles
 
@@ -415,6 +415,46 @@ law — *an issue's own premises are stale-able; re-derive from the code before 
 crown, so there is nothing here for [#292](https://github.com/Phaazoid/Godoiosis/issues/292) to
 carry.
 
+**The ring became a STANDING marker behind a player setting (#423 slice 1, dev call 2026-08-21).**
+Planning [#423](https://github.com/Phaazoid/Godoiosis/issues/423)'s form/dissolve/shatter animation
+found that the thing it proposed to animate does not persist: `SQUADMEMBER` icons are produced only
+by selection and hover paths and destroyed by `clear_selection_icons`, exactly as the sentence above
+says — *the icon lifecycle never moved*. #325 relocated the ring from head to ground and left it a
+**selection** marker wearing a membership meaning.
+
+**That killed the half #423 called most valuable, and the reason generalises.** The ticket's best
+argument was that the two *un-previewed* ejections are where feedback earns most. But
+`OrderExecutor.execute_orders` clears the icon channel BEFORE the pass and both ejection sweeps run
+after it, and the turn-start sweep fires when nothing is selected — so **at both settle points there
+was no ring on screen to shatter.** A marker's visibility schedule is part of what it can express:
+an interaction-scoped marker cannot carry an event that happens when no interaction is open, however
+right the marker looks the rest of the time. Fifth instance of
+[#228](https://github.com/Phaazoid/Godoiosis/issues/228)'s law.
+
+So the animation waits, and what shipped first is the lifecycle it needs:
+`PlayerSettings.ALWAYS_SHOW_SQUAD_RINGS`, **off by default**, which keeps every multi-member squad's
+rings up instead of only the squad being looked at. It is a toggle rather than a switchover on
+purpose — the same play-both-then-decide shape #325 itself used, and the loser gets deleted.
+`game.refresh_squad_rings` is the one sweep; it REBUILDS the channel rather than adding to it,
+because `create_unit_icon` only ever adds and a squad shrinking back to one member has to lose its
+rings. It is gated on having squadmates (`Unit.has_squad`'s question) and deliberately **not** on
+`ring_hue`, which is dealt once at the first squadmate and never reset — that gate would leave a
+lone leftover wearing a colour forever.
+
+**Two findings worth keeping.** First, **persistence is what made a stale copy visible**:
+`OverlayIcon` stored the cell it was built on and `OverlayMirror` anchored on that copy, which was
+invisible only because markers were rebuilt constantly — the instant one outlived a move it sat on
+the cell its unit had walked off, in both views. The marker now asks its UNIT where it is
+(`OverlayIcon.current_cell`), one answer read by the 2D position and the mirror alike, which is
+[#308](https://github.com/Phaazoid/Godoiosis/issues/308)'s law arriving on a second shelf. Second,
+**standing rings deliberately stand down for a whole resolution pass**: a marker sits on its unit's
+*projected destination*, which mid-pass is a cell the unit has not reached, so a ring left up would
+jump ahead of the unit rather than travel with it. Riding the animated position is a separate build.
+The restore is the LAST line of `_end_squad_turn`, because that method opens by clearing the channel.
+
+Both views move together, so there is nothing here for
+[#292](https://github.com/Phaazoid/Godoiosis/issues/292) to carry.
+
 Two things the retirement exposed, both worth keeping in mind. **The head icon was never the
 general answer**: TARGET was created in exactly one flow, so rescue, intimidate and join-squad had
 their candidates marked *nowhere in either view* until #316, and Squad Up only looked right because
@@ -482,14 +522,19 @@ hard here, since "every damaged unit" is close to "everywhere". Must reach both 
 on [#292](https://github.com/Phaazoid/Godoiosis/issues/292).
 
 **Squad join / leave feedback on the ring channel.** Animate the per-squad ring under a unit's feet
-**forming** on join and **dissolving** on leave; a forceful removal **shatters** it. The ring is
-#325's, which survived that ticket's verdict (the mix: rings for membership, crown for leadership —
-the green squares were deleted), so this decorates a marker that is now **settled** rather than one
-awaiting a verdict. The genuinely useful half is *which events to hook*, and it is wider than the
-menu: **cohesion ejection** (`SquadManager.enforce_contact`) and **downed ejection** both drop
-membership at settle points and are noted in the codebase as **un-previewed** — a squad silently
-losing a member is exactly the moment feedback earns most, and it is not a click the player made.
-Sprite-FX-shaped, so it queues behind #358.
+**forming** on join and **dissolving** on leave; a forceful removal **shatters** it. The genuinely
+useful half is *which events to hook*, and it is wider than the menu: **cohesion ejection**
+(`SquadManager.enforce_contact`) and **downed ejection** both drop membership at settle points and
+are noted in the codebase as **un-previewed** — a squad silently losing a member is exactly the
+moment feedback earns most, and it is not a click the player made.
+
+**Two of this capture's premises were measured FALSE while planning it (2026-08-21) — see the #423
+slice 1 section above.** The ring was a *selection* marker, so at both settle points there was no
+ring on screen to shatter; and the dependency on #358 was wrong, since `OverlayIcon` is its own
+overlay node while #358's stack rides the unit's `MapSprite`. The persistence this needs shipped
+first as `ALWAYS_SHOW_SQUAD_RINGS`. What remains open is the animation itself, and one design
+question the restraint doctrine sharpens: squads re-form often, and three of these firing at once
+during a settle is worth designing for rather than discovering.
 
 **Warn when a move ends on — or crosses — an element-afflicted tile.** *(Merged capture: the
 action-menu warning recorded 2026-08-18 and the queue-row warning recorded 2026-08-19 are the same

--- a/game.gd
+++ b/game.gd
@@ -185,6 +185,13 @@ func _wire_signals() -> void:
 	squad_manager.squad_became_active.connect(_on_squad_became_active)
 	squad_manager.squad_became_empty.connect(_on_squad_has_no_actions)
 
+	# Standing squad rings follow membership (#423 slice 1). squad_created covers every LEAVE as
+	# well as every birth -- leave_squad ends in create_squad -- so the two ejection sweeps that
+	# nobody authored need no signal of their own.
+	squad_manager.squad_created.connect(func(_s: Squad): refresh_squad_rings())
+	squad_manager.squad_deleted.connect(func(_s: Squad): refresh_squad_rings())
+	squad_manager.squad_member_joined.connect(func(_s: Squad, _u: Unit): refresh_squad_rings())
+
 	squad_action_queue_control.execute_requested.connect(_on_queue_execute_requested)
 	squad_action_queue_control.cancel_requested.connect(_on_queue_cancel_requested)
 	squad_action_queue_control.reorder_attacks_requested.connect(_on_queue_reorder_attacks)
@@ -294,6 +301,9 @@ func _open_pause_menu() -> void:
 			_open_pause_menu()
 		PauseMenu.Choice.SETTINGS:
 			await SettingsScreen.show_screen(self)
+			# PlayerSettings has no changed signal by design, so the ring setting is applied
+			# where the player hands the board back rather than by polling for it.
+			refresh_squad_rings()
 			# GLOSSARY's shape exactly, restore included -- a settings page is another read-only
 			# detour that must hand the player back to the menu they opened it from.
 			game_state = prior
@@ -437,6 +447,8 @@ func _on_turn_started(faction: Team.Faction):
 	# AFTER the ticks: melting ice can strand a squadmate across water it walked over while frozen
 	# (#151) -- the other way a squad splits without any move having authored it.
 	squad_manager.enforce_contact()
+	# An ejection here changed membership without any signal a redraw path listens to.
+	refresh_squad_rings()
 	# AFTER the ticks: an expiring downed countdown kills, and that is the one death that
 	# happens outside a resolution pass (#96).
 	mission_controller.check()
@@ -1005,8 +1017,28 @@ func clear_icons(icons: Array[OverlayIcon.IconType]):
 func clear_selection_icons() -> void:
 	clear_icons([OverlayIcon.IconType.CROWN, OverlayIcon.IconType.SQUADMEMBER])
 
-# ==============================================================================
-#  Board queries
+# --- Standing squad rings (ALWAYS_SHOW_SQUAD_RINGS) ----------------------------------------
+# THE answer to which units wear a membership marker when nothing is selected. Off by default, and
+# while it is off this does NOTHING: the selection paths own the channel exactly as they did, so
+# the setting cannot regress the old behaviour by existing.
+#
+# When it is on the channel is rebuilt from membership rather than added to, which is what makes a
+# marker DISAPPEAR again -- create_unit_icon only ever adds, so a squad dropping back to one member
+# would otherwise leave its rings on the board. A selected squad is already in the standing set,
+# and target-pick markers are redrawn by their own mode, so the clear costs nothing visible.
+#
+# Gated on the squad having squadmates -- Unit.has_squad's question, the one _repaint_squad_plan
+# also asks -- and NOT on ring_hue: a hue is dealt once at the first squadmate and never reset, so
+# a squad that shrank back to one would keep wearing its colour.
+func refresh_squad_rings() -> void:
+	if not PlayerSettings.is_on(PlayerSettings.Setting.ALWAYS_SHOW_SQUAD_RINGS):
+		return
+	clear_selection_icons()
+	for squad: Squad in squad_manager.squads:
+		if not is_instance_valid(squad) or squad.get_members().size() <= 1:
+			continue
+		overlay_manager.draw_squad_unit_icons(squad)
+
 # ==============================================================================
 
 func _board() -> BoardContext:

--- a/game.gd
+++ b/game.gd
@@ -192,7 +192,7 @@ func _wire_signals() -> void:
 	squad_manager.squad_deleted.connect(func(_s: Squad): refresh_squad_rings())
 	squad_manager.squad_member_joined.connect(func(_s: Squad, _u: Unit): refresh_squad_rings())
 	# The per-squad redraw clears the whole channel, so it has to know the standing set too.
-	overlay_manager.standing_squads_source = standing_ring_squads
+	overlay_manager.standing_rings_drawer = draw_standing_rings
 
 	squad_action_queue_control.execute_requested.connect(_on_queue_execute_requested)
 	squad_action_queue_control.cancel_requested.connect(_on_queue_cancel_requested)
@@ -635,7 +635,7 @@ func clear_selection():
 	if squad_manager.active_squad == null:
 		overlay_manager.clear_squad_range()
 	if squad_manager.active_squad == null:
-		clear_icons([OverlayIcon.IconType.CROWN, OverlayIcon.IconType.SQUADMEMBER])
+		clear_selection_icons()
 
 # ==============================================================================
 #  Queueing orders
@@ -1016,13 +1016,19 @@ func clear_icons(icons: Array[OverlayIcon.IconType]):
 # HoverPresenter/OrderExecutor reach this through an UNTYPED `game` ref, and a bare array
 # literal sent that way never gets coerced to clear_icons' typed parameter (it fails at
 # runtime, not at parse time). Keeping the literal on this side of the boundary avoids it.
+#
+# It drops the SELECTION's markers and no others, which is why the standing rings go straight back
+# up: they are not the selection's. That is the whole of the 2026-08-21 bug the dev found by
+# playing -- _hover_idle calls this on EVERY hover change while nothing is selected, bare ground
+# included, so the first mouse movement after a board came up wiped the standing set and only a
+# hover brought it back.
 func clear_selection_icons() -> void:
 	clear_icons([OverlayIcon.IconType.CROWN, OverlayIcon.IconType.SQUADMEMBER])
+	draw_standing_rings()
 
 # --- Standing squad rings (ALWAYS_SHOW_SQUAD_RINGS) ----------------------------------------
-# WHICH squads wear a standing ring: THE one answer, read by the sweep below and -- through
-# OverlayManager.standing_squads_source -- by the per-squad redraw the hover and plan paths call.
-# Empty while the setting is off, so those paths behave exactly as they did.
+# WHICH squads wear a standing ring: THE one answer. Empty while the setting is off, which is what
+# keeps every path above behaving exactly as it did.
 #
 # Gated on the squad having squadmates -- Unit.has_squad's question, the one _repaint_squad_plan
 # also asks -- and NOT on ring_hue: a hue is dealt once at the first squadmate and never reset, so
@@ -1036,20 +1042,25 @@ func standing_ring_squads() -> Array[Squad]:
 			standing.append(squad)
 	return standing
 
-# Rebuild the marker channel from membership. The setting guard is NOT redundant with the empty
-# list above: while the setting is off this must not touch the channel at all, where clearing it
-# and drawing nothing would wipe whatever the selection had up.
+# Put the standing set onto a channel that has just been cleared -- THE one implementation, called
+# by clear_selection_icons above and, through OverlayManager.standing_rings_drawer, by the
+# per-squad redraw the hover and plan paths use. A marker channel that is cleared whole has to be
+# redrawn whole, and this is the one thing that knows what "whole" means when nothing is selected.
+func draw_standing_rings() -> void:
+	for squad: Squad in standing_ring_squads():
+		overlay_manager.draw_squad_unit_icons(squad)
+
+# Membership changed, so the standing set may have gained or lost a squad. Rebuilds rather than
+# adds, which is what makes a marker DISAPPEAR again -- create_unit_icon only ever adds, so a squad
+# dropping back to one member would otherwise leave its rings behind.
 #
-# It REBUILDS rather than adds, which is what makes a marker DISAPPEAR again -- create_unit_icon
-# only ever adds, so a squad dropping back to one member would otherwise leave its rings behind.
-# A selected squad is already in the standing set and target-pick markers are redrawn by their own
-# mode, so the clear costs nothing visible.
+# The setting guard is NOT redundant with standing_ring_squads' empty list: while the setting is
+# off this must not touch the channel at all, where clearing it would wipe the selection's markers
+# and put nothing back.
 func refresh_squad_rings() -> void:
 	if not PlayerSettings.is_on(PlayerSettings.Setting.ALWAYS_SHOW_SQUAD_RINGS):
 		return
 	clear_selection_icons()
-	for squad: Squad in standing_ring_squads():
-		overlay_manager.draw_squad_unit_icons(squad)
 
 # ==============================================================================
 

--- a/game.gd
+++ b/game.gd
@@ -191,6 +191,8 @@ func _wire_signals() -> void:
 	squad_manager.squad_created.connect(func(_s: Squad): refresh_squad_rings())
 	squad_manager.squad_deleted.connect(func(_s: Squad): refresh_squad_rings())
 	squad_manager.squad_member_joined.connect(func(_s: Squad, _u: Unit): refresh_squad_rings())
+	# The per-squad redraw clears the whole channel, so it has to know the standing set too.
+	overlay_manager.standing_squads_source = standing_ring_squads
 
 	squad_action_queue_control.execute_requested.connect(_on_queue_execute_requested)
 	squad_action_queue_control.cancel_requested.connect(_on_queue_cancel_requested)
@@ -1018,25 +1020,35 @@ func clear_selection_icons() -> void:
 	clear_icons([OverlayIcon.IconType.CROWN, OverlayIcon.IconType.SQUADMEMBER])
 
 # --- Standing squad rings (ALWAYS_SHOW_SQUAD_RINGS) ----------------------------------------
-# THE answer to which units wear a membership marker when nothing is selected. Off by default, and
-# while it is off this does NOTHING: the selection paths own the channel exactly as they did, so
-# the setting cannot regress the old behaviour by existing.
-#
-# When it is on the channel is rebuilt from membership rather than added to, which is what makes a
-# marker DISAPPEAR again -- create_unit_icon only ever adds, so a squad dropping back to one member
-# would otherwise leave its rings on the board. A selected squad is already in the standing set,
-# and target-pick markers are redrawn by their own mode, so the clear costs nothing visible.
+# WHICH squads wear a standing ring: THE one answer, read by the sweep below and -- through
+# OverlayManager.standing_squads_source -- by the per-squad redraw the hover and plan paths call.
+# Empty while the setting is off, so those paths behave exactly as they did.
 #
 # Gated on the squad having squadmates -- Unit.has_squad's question, the one _repaint_squad_plan
 # also asks -- and NOT on ring_hue: a hue is dealt once at the first squadmate and never reset, so
 # a squad that shrank back to one would keep wearing its colour.
+func standing_ring_squads() -> Array[Squad]:
+	var standing: Array[Squad] = []
+	if not PlayerSettings.is_on(PlayerSettings.Setting.ALWAYS_SHOW_SQUAD_RINGS):
+		return standing
+	for squad: Squad in squad_manager.squads:
+		if is_instance_valid(squad) and squad.get_members().size() > 1:
+			standing.append(squad)
+	return standing
+
+# Rebuild the marker channel from membership. The setting guard is NOT redundant with the empty
+# list above: while the setting is off this must not touch the channel at all, where clearing it
+# and drawing nothing would wipe whatever the selection had up.
+#
+# It REBUILDS rather than adds, which is what makes a marker DISAPPEAR again -- create_unit_icon
+# only ever adds, so a squad dropping back to one member would otherwise leave its rings behind.
+# A selected squad is already in the standing set and target-pick markers are redrawn by their own
+# mode, so the clear costs nothing visible.
 func refresh_squad_rings() -> void:
 	if not PlayerSettings.is_on(PlayerSettings.Setting.ALWAYS_SHOW_SQUAD_RINGS):
 		return
 	clear_selection_icons()
-	for squad: Squad in squad_manager.squads:
-		if not is_instance_valid(squad) or squad.get_members().size() <= 1:
-			continue
+	for squad: Squad in standing_ring_squads():
 		overlay_manager.draw_squad_unit_icons(squad)
 
 # ==============================================================================

--- a/tests/presentation/test_standing_squad_rings.gd
+++ b/tests/presentation/test_standing_squad_rings.gd
@@ -1,0 +1,168 @@
+# Standing squad rings (#423 slice 1). ALWAYS_SHOW_SQUAD_RINGS turns the membership ring from a
+# SELECTION marker into a persistent one, and a persistent marker has to follow the unit it belongs
+# to -- which is the bug this setting exposed.
+#
+# Driven through the real seams (spawn, join_squad, leave_squad, a resolution pass) rather than by
+# calling the sweep directly, because the claim is that MEMBERSHIP CHANGES reach the channel at all.
+# Asserted on OverlayManager's marker store and on the 3D mirror's anchors, never on pixels.
+#
+# Fixture is test_overlay_mirror's: the Battle3D scene with the boot board cleared.
+extends GdUnitTestSuite
+
+const SCENE_PATH := "res://Scenes/Battle3D/Battle3D.tscn"
+const H := preload("res://tests/support/squad_fixtures.gd")
+
+const PLAYER := Team.Faction.PLAYER
+
+var _scene: Node3D
+var game: Node2D
+var _overlays: BoardOverlays
+
+
+func before_test() -> void:
+	get_tree().root.size = Vector2i(1280, 720)
+	# The setting persists to disk for real players, so a suite that skipped this would read the
+	# DEV'S OWN settings.cfg and pass or fail by what he last clicked.
+	PlayerSettings.reset_for_test()
+	var packed := load(SCENE_PATH) as PackedScene
+	_scene = packed.instantiate() as Node3D
+	_scene.auto_play = false
+	get_tree().root.add_child(_scene)
+	await await_idle_frame()
+	game = _scene.game
+	_overlays = _scene.get_node("BoardOverlays") as BoardOverlays
+	game.scenario_manager.clear_board()
+	game.game_state = game.GameState.IDLE
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	PlayerSettings.reset_for_test()
+	get_tree().root.remove_child(_scene)
+	_scene.free()
+
+
+# process_frame resumes coroutines BEFORE node _process, so one frame is stale.
+func _settle() -> void:
+	await await_idle_frame()
+	await await_idle_frame()
+
+
+func _om() -> OverlayManager:
+	return game.overlay_manager
+
+
+func _spawn(cell: Vector2i) -> Unit:
+	var unit: Unit = game.spawn_unit(H.make_unit_data({}, PLAYER), cell)
+	assert_object(unit).is_not_null()   # fixture setup, not the claim under test
+	return unit
+
+
+func _rings_on() -> void:
+	PlayerSettings.set_on(PlayerSettings.Setting.ALWAYS_SHOW_SQUAD_RINGS, true)
+
+
+func _pair() -> Array[Unit]:
+	var leader := _spawn(Vector2i(2, 2))
+	var member := _spawn(Vector2i(5, 2))
+	game.squad_manager.join_squad(member, leader.squad)
+	return [leader, member]
+
+
+func _ringed_units() -> Array[Unit]:
+	var ringed: Array[Unit] = []
+	for key in _om().icons_by_unit:
+		var unit := key as Unit
+		if unit != null and _om().icons_by_unit[key].has(OverlayIcon.IconType.SQUADMEMBER):
+			ringed.append(unit)
+	return ringed
+
+
+# --- The setting -------------------------------------------------------------------
+
+# Off is a promise that nothing changed: the channel still belongs to the selection paths, so the
+# setting cannot regress the old board simply by existing.
+func test_off_by_default_a_join_leaves_no_standing_ring() -> void:
+	assert_bool(PlayerSettings.is_on(PlayerSettings.Setting.ALWAYS_SHOW_SQUAD_RINGS)).is_false()
+	_pair()
+	await _settle()
+	assert_array(_ringed_units()).override_failure_message(
+			"a ring stood on the board with the setting OFF -- the selection paths no longer own the channel"
+			).is_empty()
+
+
+func test_on_a_two_member_squad_wears_rings_with_nothing_selected() -> void:
+	_rings_on()
+	var pair := _pair()
+	await _settle()
+	var ringed := _ringed_units()
+	assert_int(ringed.size()).is_equal(2)
+	assert_bool(ringed.has(pair[0]) and ringed.has(pair[1])).is_true()
+	# Parity (#292): the 3D view carries the same two, so this is not a 2D-only feature.
+	assert_int(_overlays.markers_of(BoardOverlays.Layer.GROUND_ICONS).size()).override_failure_message(
+			"the standing rings never reached the 3D ground channel").is_equal(2)
+
+
+func test_on_solo_squads_wear_none() -> void:
+	_rings_on()
+	_spawn(Vector2i(2, 2))
+	_spawn(Vector2i(5, 2))
+	await _settle()
+	assert_array(_ringed_units()).override_failure_message(
+			"a unit with no squadmates wore a membership ring").is_empty()
+
+
+# The ring_hue trap. A hue is dealt once at the first squadmate and NEVER reset, so gating the sweep
+# on "does this squad have a colour" would leave the leftover member wearing one forever.
+func test_on_a_squad_that_shrank_back_to_one_wears_none() -> void:
+	_rings_on()
+	var pair := _pair()
+	await _settle()
+	assert_int(_ringed_units().size()).is_equal(2)   # precondition, not the claim
+	game.squad_manager.leave_squad(pair[1])
+	await _settle()
+	assert_bool(pair[0].squad.ring_hue != Color.WHITE).override_failure_message(
+			"the shrunken squad lost its dealt hue -- this case no longer covers the trap it was written for"
+			).is_true()
+	assert_array(_ringed_units()).override_failure_message(
+			"a lone unit kept its squad ring -- the sweep is gated on the dealt hue, not on membership"
+			).is_empty()
+
+
+# --- The wire ----------------------------------------------------------------------
+
+# THE bug persistence exposed. A marker used to STORE the cell it was built on and the mirror
+# anchored on that copy; markers rebuilt every repaint hid it, but a standing ring outlives the
+# move, so the copy went stale and the ring stayed on the cell its unit walked off (#308).
+func test_a_standing_ring_follows_the_unit_that_moved() -> void:
+	_rings_on()
+	var pair := _pair()
+	await _settle()
+	var moved_to := Vector2i(5, 5)
+	pair[1].movement.set_cell(moved_to)
+	await _settle()
+	var heights: BoardHeights = game.board_heights
+	var expected := BoardSpace.surface_transform(moved_to, heights).origin
+	var found := false
+	for marker: Dictionary in _overlays.markers_of(BoardOverlays.Layer.GROUND_ICONS):
+		if (marker["pos"] as Vector3).is_equal_approx(expected):
+			found = true
+	assert_bool(found).override_failure_message(
+			"no ring sits on the cell the unit moved to -- the anchor is a stored copy again"
+			).is_true()
+
+
+# The rings stand down for the WHOLE resolution pass (a marker sits on its unit's projected
+# destination, which mid-pass is a cell the unit has not reached) and come back on the settled
+# board. The restore is last in _end_squad_turn because that method OPENS by clearing the channel --
+# an ordering no assertion about the two ends could catch.
+func test_rings_come_back_after_a_pass_settles() -> void:
+	_rings_on()
+	var pair := _pair()
+	await _settle()
+	assert_int(_ringed_units().size()).is_equal(2)   # precondition, not the claim
+	await game.order_executor.execute_orders(pair[0])
+	await _settle()
+	assert_int(_ringed_units().size()).override_failure_message(
+			"the standing rings never came back after the pass -- the restore runs before the clear"
+			).is_equal(2)

--- a/tests/presentation/test_standing_squad_rings.gd
+++ b/tests/presentation/test_standing_squad_rings.gd
@@ -166,3 +166,25 @@ func test_rings_come_back_after_a_pass_settles() -> void:
 	assert_int(_ringed_units().size()).override_failure_message(
 			"the standing rings never came back after the pass -- the restore runs before the clear"
 			).is_equal(2)
+
+
+# The per-squad redraw clears the WHOLE icon channel and then draws ONE squad, and HoverPresenter
+# calls it on every hover-move preview. Standing rings are the first thing that ever needed to
+# survive that, so without a standing set inside the redraw, hovering one squad silently strips
+# every OTHER squad's rings -- the state the board would sit in for most of a feel-test.
+func test_hovering_one_squad_keeps_another_squads_standing_rings() -> void:
+	_rings_on()
+	var first := _pair()
+	var second_leader := _spawn(Vector2i(8, 2))
+	var second_member := _spawn(Vector2i(9, 2))
+	game.squad_manager.join_squad(second_member, second_leader.squad)
+	await _settle()
+	assert_int(_ringed_units().size()).is_equal(4)   # precondition, not the claim
+	# The seam HoverPresenter drives when the cursor crosses a reachable cell.
+	game.overlay_manager.redraw_squad_unit_icons(first[0].squad)
+	await _settle()
+	var ringed := _ringed_units()
+	assert_bool(ringed.has(second_leader) and ringed.has(second_member)).override_failure_message(
+			"the other squad lost its standing rings when this one was redrawn -- a per-squad redraw clears the whole channel"
+			).is_true()
+	assert_int(ringed.size()).is_equal(4)

--- a/tests/presentation/test_standing_squad_rings.gd
+++ b/tests/presentation/test_standing_squad_rings.gd
@@ -188,3 +188,39 @@ func test_hovering_one_squad_keeps_another_squads_standing_rings() -> void:
 			"the other squad lost its standing rings when this one was redrawn -- a per-squad redraw clears the whole channel"
 			).is_true()
 	assert_int(ringed.size()).is_equal(4)
+
+
+# THE BUG THE DEV FOUND BY PLAYING (2026-08-21): rings drew at load and then vanished, and only a
+# hover brought them back. _hover_idle clears the icon channel on EVERY hover change while nothing
+# is selected -- hovering bare ground included -- so the first mouse movement after the board came
+# up wiped the standing set. Every case above passed because none of them ever moved the mouse,
+# which is the one thing a player does constantly.
+func test_hovering_empty_ground_does_not_wipe_the_standing_rings() -> void:
+	_rings_on()
+	var pair := _pair()
+	await _settle()
+	assert_int(_ringed_units().size()).is_equal(2)   # precondition, not the claim
+	# The real seam: HoverPresenter's IDLE branch, over a cell with no unit on it.
+	var empty := Vector2i(1, 6)
+	assert_object(game.get_unit_at_cell(empty)).is_null()   # fixture setup
+	game.hover_presenter.update_hover_visuals(empty)
+	await _settle()
+	var ringed := _ringed_units()
+	assert_bool(ringed.has(pair[0]) and ringed.has(pair[1])).override_failure_message(
+			"moving the cursor over empty ground wiped the standing rings -- a SELECTION clear is removing markers the selection does not own"
+			).is_true()
+
+
+# The same clear, reached the other way: hovering a unit that is not in a standing squad.
+func test_hovering_a_solo_unit_does_not_wipe_another_squads_standing_rings() -> void:
+	_rings_on()
+	var pair := _pair()
+	var loner := _spawn(Vector2i(9, 6))
+	await _settle()
+	assert_int(_ringed_units().size()).is_equal(2)   # the loner has no squadmates, so no ring
+	game.hover_presenter.update_hover_visuals(loner.movement.cell)
+	await _settle()
+	var ringed := _ringed_units()
+	assert_bool(ringed.has(pair[0]) and ringed.has(pair[1])).override_failure_message(
+			"hovering an unsquadded unit wiped the other squad's standing rings"
+			).is_true()

--- a/tests/presentation/test_standing_squad_rings.gd.uid
+++ b/tests/presentation/test_standing_squad_rings.gd.uid
@@ -1,0 +1,1 @@
+uid://dhkj8lrp1jhbi


### PR DESCRIPTION
Closes #435. Prerequisite for #423, which cannot be built as written.

## Why this and not #423

#423 asks the squad ring to **form** on join, **dissolve** on leave, **shatter** on a forceful removal. The thing it proposed to animate **does not persist**: `SQUADMEMBER` icons are produced only by selection and hover paths and destroyed by `clear_selection_icons`. `visual-clarity.md` already said it about #325 — *"the icon lifecycle never moved."*

That kills the half #423 called most valuable. `OrderExecutor.execute_orders` clears the channel at line 60; `_process_downed_pending` and `enforce_contact` run at 95 and 99, and the turn-start sweep fires when nothing is selected. **At both settle points there was no ring on screen to shatter.** Fifth instance of #228's law.

Also worth recording: **#423's declared dependency on #358 was wrong.** `OverlayIcon` is its own overlay `Node2D`; #358's stack rides the unit's `MapSprite`. Different node, different channel — #423 was never gated on it.

Dev's call (2026-08-21): ship the persistence first, behind a toggle, and feel it before any animation.

## What's here

- **`PlayerSettings.ALWAYS_SHOW_SQUAD_RINGS`**, default **off** — so the setting cannot regress the old board by existing. One enum member + one `DEFS` row; `SettingsScreen` is a pure projection, so no UI work.
- **`game.refresh_squad_rings()`**, the one sweep. It **rebuilds** the channel rather than adding to it, because `create_unit_icon` only ever adds and a squad shrinking back to one member has to lose its rings.
- Gated on having squadmates (`Unit.has_squad`'s question), **not** on `ring_hue` — a hue is dealt once at the first squadmate and never reset, so that gate would leave a lone leftover wearing a colour forever. There's a case pinning exactly that.
- `draw_squad_unit_icons` split out of `redraw_squad_unit_icons` so the sweep reuses the "what does a squad wear" answer instead of copying it.
- Triggers: `squad_member_joined`, `squad_created`, `squad_deleted`, turn start after `enforce_contact()`, pass settle, and the settings-screen return. **`squad_created` covers every leave** (`leave_squad` ends in `create_squad`), so the ejection sweeps needed no new signal.

## The bug persistence exposed

`OverlayIcon` stored the cell it was built on; `OverlayMirror` anchored on that copy. It only ever worked because markers were rebuilt constantly — a ring that outlives a move sat on the cell its unit walked off, **in both views**. The marker now asks its unit (`current_cell`), one answer read by the 2D position and the mirror alike. #308's law on a second shelf.

## Declared scope decision — please judge this in the feel-test

**Standing rings stand down for a whole resolution pass** and return on the settled board. A marker sits on its unit's *projected destination*, which mid-pass is a cell the unit has not reached, so a ring left up would jump ahead of the unit rather than travel with it. Riding the animated position is a separate build. **If that reads wrong while you're playing, it's the follow-up.**

## Knobs

The setting is boolean and lives on the existing settings screen (pause → Settings). No feel value is pinned; `SQUAD_RING_ALPHA` is untouched.

## Verification

`presentation` (306 cases) and `core ui squad flow` (588 cases) — all green, 0 orphans. Never the full tree; CI owns it.

Six new cases in `tests/presentation/test_standing_squad_rings.gd`, driven through the real seams (spawn, `join_squad`, `leave_squad`, a real pass) rather than by calling the sweep, because the claim is that membership changes reach the channel at all: off-by-default draws nothing; two members wear rings in **both** views; solo squads wear none; a squad shrunk back to one wears none *and* still has its hue (so the case still covers the trap it was written for); the ring follows a unit that moved; rings come back after a pass settles.

**Falsified:** freezing the cell at creation — the pre-fix behaviour — reds `test_a_standing_ring_follows_the_unit_that_moved` **alone**, with the four cases before it still green. That was the assertion most likely to be written blind.

**Not checked:** these assert on the marker store and the mirror's anchors, never on pixels. Whether standing rings read well on a busy board is exactly the question the toggle exists to let you answer.

## What this owes

Same shape as #325's play-both-then-decide: **when you call it, the loser gets deleted** — either the setting goes away and standing rings become unconditional, or it stays a preference. #423's animation waits on that answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
