### PR TITLE
Inspect panel: DEF refreshes when the unit moves (#44)

### DIFF
--- a/Classes/ui/panels/UnitInfoPanelControl.gd
+++ b/Classes/ui/panels/UnitInfoPanelControl.gd
@@ -19,7 +19,7 @@ var current_board: BoardContext   # kept so a live refresh can recompute terrain
 
 func _ready() -> void:
 	$UnitInfoPanel/Margin/VBox/HeaderRow/CloseButton.pressed.connect(clear)
-	inventory_panel.loadout_changed.connect(_on_loadout_changed)
+	inventory_panel.loadout_changed.connect(_refresh_derived_rows)
 
 func set_unit(unit: Unit, can_act := false, board: BoardContext = null):
 	if current_unit == unit:
@@ -27,6 +27,7 @@ func set_unit(unit: Unit, can_act := false, board: BoardContext = null):
 	if unit == null:
 		clear()
 		return
+	_release_current_unit()
 	current_unit = unit
 	current_board = board
 	visible = true
@@ -37,16 +38,26 @@ func set_unit(unit: Unit, can_act := false, board: BoardContext = null):
 	inventory_panel.set_unit(unit, can_act)
 	squad_panel.set_unit(unit)
 	states_bar.set_unit(unit)
+	unit.movement.movement_finished.connect(_refresh_derived_rows)
 
 # Re-read only the derived numbers. set_unit early-returns on the same unit (it's called on every
-# inspect), so a loadout change made while the panel is OPEN would otherwise leave DEF and MOV
-# showing their values from inspect time.
-func _on_loadout_changed():
+# inspect), so a change made while the panel is OPEN would otherwise leave DEF and MOV showing
+# their values from inspect time -- and re-inspecting cannot clear it. Two triggers, because two
+# things move these numbers: a loadout edit, and ARRIVAL -- DEF's cover term is read at the unit's
+# current cell, so walking on or off Cover changes it.
+func _refresh_derived_rows():
 	if current_unit == null:
 		return
 	stats_section.set_unit(current_unit, current_board)
 
+# The panel outlives the units it shows. Guarded the way info_panel.set_unit guards its own
+# teardown: a freed ref compares == null as TRUE (#149), so this skips instead of faulting.
+func _release_current_unit() -> void:
+	if current_unit != null and is_instance_valid(current_unit):
+		current_unit.movement.movement_finished.disconnect(_refresh_derived_rows)
+
 func clear():
+	_release_current_unit()
 	current_unit = null
 	visible = false
 	portrait_panel.set_unit(null)

--- a/tests/ui/test_unit_info_panel_refresh.gd
+++ b/tests/ui/test_unit_info_panel_refresh.gd
@@ -1,0 +1,175 @@
+extends GdUnitTestSuite
+
+# The inspect panel's DERIVED rows must survive the unit MOVING (#44 checklist item).
+#
+# DEF is the one cell-dependent row -- RulesService.def_breakdown reads Cover at the unit's CURRENT
+# cell -- and UnitInfoPanelControl re-read its derived rows on inventory_panel.loadout_changed
+# alone. So walking onto a Burrow-dug Cover tile with the panel open left DEF showing the number
+# from inspect time, and set_unit's same-unit early return meant re-inspecting could not clear it
+# either: only closing the panel, right-clicking, inspecting someone else or ending the turn did.
+#
+# MovementComponent.movement_finished already announced arrival and had ZERO connect() callers, so
+# the fix is one wire rather than a new signal -- which is exactly the kind of thing a green suite
+# stays green without. These cases drive a REAL walk and assert the label the player reads.
+#
+# The DEF assertion is a DELTA against Terrain.COVER_DEF, never a literal DEF value: stats, armour
+# and board geometry are all authored, and pinning any of them here would red on a content commit
+# (tests/README.md #9, the content razor).
+#
+# DELIBERATELY NOT COVERED -- a Burrow depositing Cover in the SAME pass. OrderExecutor applies cell
+# effects AFTER the move phase, so the refresh runs before the deposit lands; covering that needs an
+# end-of-pass announcement OrderExecutor does not have (dev ruling, 2026-08-21).
+
+const MAIN_SCENE := "res://Scenes/Main.tscn"
+
+var _main: Node
+var game: Node2D
+
+
+func before_test() -> void:
+	# Named + parented exactly as in production so game.gd's dev-overlay lookup resolves; fixture
+	# copied from tests/ui/test_game_scene_smoke.gd.
+	_main = (load(MAIN_SCENE) as PackedScene).instantiate()
+	_main.name = "Main"
+	get_tree().root.add_child(_main)
+	await await_idle_frame()
+	game = _main.get_node("GameContainer/GameView/Game")
+	game.spawn_sandbox()
+	game.game_state = game.GameState.IDLE
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	get_tree().root.remove_child(_main)
+	_main.free()
+
+
+func test_walking_onto_cover_moves_the_def_on_the_open_panel() -> void:
+	var pair := _movable_unit_and_destination()
+	assert_bool(pair.size() == 2).override_failure_message(
+			"no spawned unit could be ordered anywhere, so a walk proves nothing"
+			).is_true()
+	var unit: Unit = pair[0]
+	var destination: Vector2i = pair[1]
+
+	_deposit_cover(destination)
+	var panel: UnitInfoPanelControl = game.unit_info_panel
+	panel.set_unit(unit, true, game._board())
+	var before := _def_value()
+	assert_str(before).override_failure_message(
+			"the panel rendered no DEF row, so there is nothing to go stale").is_not_empty()
+
+	await _walk(unit, destination)
+
+	var after := _def_value()
+	assert_int(after.to_int() - before.to_int()).override_failure_message(
+			"DEF stayed at %s after walking onto Cover -- the open panel is showing the number "
+			% before + "from inspect time").is_equal(Terrain.COVER_DEF)
+
+
+func test_walking_off_cover_moves_it_back() -> void:
+	# The twin direction, because a refresh that only ever ADDED would also pass the case above if
+	# it re-read the wrong cell. Start ON cover, walk off it.
+	var pair := _movable_unit_and_destination()
+	assert_bool(pair.size() == 2).override_failure_message(
+			"no spawned unit could be ordered anywhere, so a walk proves nothing"
+			).is_true()
+	var unit: Unit = pair[0]
+	var destination: Vector2i = pair[1]
+
+	_deposit_cover(unit.movement.cell)
+	var panel: UnitInfoPanelControl = game.unit_info_panel
+	panel.set_unit(unit, true, game._board())
+	var before := _def_value()
+
+	await _walk(unit, destination)
+
+	assert_int(before.to_int() - _def_value().to_int()).override_failure_message(
+			"DEF stayed at %s after walking OFF Cover" % before).is_equal(Terrain.COVER_DEF)
+
+
+func test_the_panel_lets_go_of_a_unit_it_stops_showing() -> void:
+	# The disconnect is the risky half of this wire: the panel outlives the units it shows, and a
+	# leaked connection means a freed unit's signal still points at it.
+	var units := _live_units()
+	assert_bool(units.size() >= 2).override_failure_message(
+			"need two units to swap between").is_true()
+	var first := units[0]
+	var second := units[1]
+	var panel: UnitInfoPanelControl = game.unit_info_panel
+
+	panel.set_unit(first, true, game._board())
+	assert_bool(first.movement.movement_finished.is_connected(panel._refresh_derived_rows)).is_true()
+
+	panel.set_unit(second, true, game._board())
+	assert_bool(first.movement.movement_finished.is_connected(panel._refresh_derived_rows)
+			).override_failure_message(
+			"inspecting a second unit left the first one still wired to the panel").is_false()
+	assert_bool(second.movement.movement_finished.is_connected(panel._refresh_derived_rows)).is_true()
+
+	panel.clear()
+	assert_bool(second.movement.movement_finished.is_connected(panel._refresh_derived_rows)
+			).override_failure_message(
+			"closing the panel left its unit still wired to it").is_false()
+
+
+func test_the_loadout_trigger_still_reaches_the_same_refresh() -> void:
+	# Both triggers must land on one handler -- they were one method before arrival was added, and a
+	# rename that missed this connect would fail at runtime rather than at parse time.
+	var panel: UnitInfoPanelControl = game.unit_info_panel
+	var inventory: Node = panel.inventory_panel
+	assert_bool(inventory.loadout_changed.is_connected(panel._refresh_derived_rows)).is_true()
+
+
+# --- helpers -------------------------------------------------------------------------------
+
+func _live_units() -> Array[Unit]:
+	var live: Array[Unit] = []
+	for child in game.units_root.get_children():
+		var unit := child as Unit
+		if unit != null:
+			live.append(unit)
+	return live
+
+
+# A unit the board actually lets move, and one cell it may be ordered to. Both DERIVED from the real
+# move-range seam rather than assumed -- on an authored board the first unit can genuinely be boxed
+# in, and a hardcoded cell is a content pin.
+func _movable_unit_and_destination() -> Array:
+	for unit in _live_units():
+		var reach: Dictionary = game.compute_move_range(unit)
+		var cells: Array[Vector2i] = game.get_move_range(reach, unit)
+		if not cells.is_empty():
+			return [unit, cells[0]]
+	return []
+
+
+func _deposit_cover(cell: Vector2i) -> void:
+	var effect := ResolvedCellEffect.new()
+	effect.cell = cell
+	effect.states_added.assign([Terrain.TileState.COVER] as Array[Terrain.TileState])
+	game.terrain_states.apply(effect)
+
+
+# The real walk, not set_cell: movement_finished is what the panel listens to, and a teleport does
+# not emit it. Cranked speed keeps the tween real but short.
+func _walk(unit: Unit, destination: Vector2i) -> void:
+	unit.movement.move_speed = 4000
+	unit.movement.move_along_path([unit.movement.cell, destination] as Array[Vector2i])
+	await unit.movement.movement_finished
+
+
+# The DEF value Label out of the live panel. queue_free()d rows linger until the next frame, so the
+# is_queued_for_deletion filter is what makes this readable straight after a refresh.
+func _def_value() -> String:
+	var grid: GridContainer = game.unit_info_panel.stats_section.stats_grid
+	var kids := grid.get_children()
+	for i in kids.size():
+		var label := kids[i] as Label
+		if label == null or label.is_queued_for_deletion():
+			continue
+		if label.text == "DEF" and i + 1 < kids.size():
+			var value := kids[i + 1] as Label
+			if value != null:
+				return value.text
+	return ""

--- a/tests/ui/test_unit_info_panel_refresh.gd.uid
+++ b/tests/ui/test_unit_info_panel_refresh.gd.uid
@@ -1,0 +1,1 @@
+uid://cl5io8uovp332


### PR DESCRIPTION
Closes a checklist item on [#44](https://github.com/Phaazoid/Godoiosis/issues/44) (visual clarity umbrella): *"Derived readouts go stale on movement."*

## The bug

`UnitInfoPanelControl` re-read its derived rows on **one** signal — `inventory_panel.loadout_changed`. That covers equip/wear/toss moving DEF and MOV. Nothing covered the unit *moving*.

DEF is the one cell-dependent row: `info_panel._refresh_stats` calls `RulesService.def_breakdown(unit, unit.movement.cell, board)`, and `BoardContext.cover_def_at` adds `Terrain.COVER_DEF` when the cell holds `TileState.COVER`. So inspect a unit, walk it onto a Burrow-dug Cover tile, and the open panel keeps showing DEF from wherever it stood at inspect time.

**The sharper half:** `set_unit` early-returns on the same unit, so the player **cannot clear the stale reading by re-inspecting**. The only escapes are the Close button, right-click, inspecting someone else, or ending the turn. Nothing on the inspect → move → execute path closes the panel, so this is reachable in ordinary play.

## The fix — one wire, not a new seam

`MovementComponent.movement_finished` already announces arrival (walk end, hold-position, and knockback-slide landing). Grepped before building: it had **three `await` users** and **zero `connect()` callers**. So this is one `connect()`.

`_on_loadout_changed` is renamed `_refresh_derived_rows` — its body was already exactly the refresh, and two handlers sharing one body would be a second spelling of the same thing. Both triggers now land on it.

**The disconnect is the risky half**, so it copies the idiom `info_panel.set_unit` already uses rather than inventing one: `if current_unit != null and is_instance_valid(current_unit)`. Per the #149 note a freed ref compares `== null` as **true**, so that guard skips rather than faulting, and `clear()` releases *before* it nulls `current_unit`.

## Structural notes worth ruling on

- **No new signal, no new seam.** The alternative the issue offered — "a cheap per-frame reconcile" — would be worse with the current implementation: `_refresh_stats` `queue_free()`s and rebuilds every label, so per frame it would destroy the Label the mouse is hovering and the DEF tooltip would never appear.
- **`movement_finished` now has its first `connect()` caller.** It fires from inside `MoveAction.execute` *before* `finish_execution()`, i.e. mid-pass. A refresh is idempotent and reads live state, so this is fine today — but if a stat readout ever gains a side effect, this becomes the wrong place.
- It also fires for hold-position moves and knockback landings. Both are harmless refreshes, and the knockback one is arguably the feature working.

## Known residual (your ruling, 2026-08-21)

`OrderExecutor` applies cell effects **after** the move phase, so a Burrow depositing Cover under the inspected unit **in the same pass** still shows stale until the panel is closed or another unit inspected. Covering it needs an end-of-pass announcement, and `OrderExecutor` has no signals at all today — not worth inventing one for a single listener.

## Verification

`tests/ui/test_unit_info_panel_refresh.gd` — 4 cases, real `Main.tscn` fixture, driving a **real** walk (`move_along_path` + `await movement_finished`), not a `set_cell` teleport (a teleport does not emit the signal).

- walking **onto** Cover moves DEF
- walking **off** Cover moves it back — the twin direction, because a refresh that only ever added would pass the first case while reading the wrong cell
- the panel **lets go** of a unit it stops showing (swap and close both release)
- the loadout trigger still reaches the same handler after the rename

Every expectation is derived: the assertion is the **delta against `Terrain.COVER_DEF`**, never a literal DEF value, and the unit and destination come from `game.compute_move_range`/`get_move_range` rather than hardcoded cells — the content razor, since stats and board geometry are both authored.

**Ran:** `tests/run_tests.ps1 ui` → **198/198 green**. Full tree is CI's job.

**Falsified:** deleting the `connect` line reds `test_walking_onto_cover_moves_the_def_on_the_open_panel` with its own message (*"DEF stayed at 0 after walking onto Cover"*). Wire restored, re-run green. That is the tier the triage says must be falsified — a missing wire that a green suite stays green without.

**Not checked by the suite:** nothing here is feel-tuned, but the panel has not been looked at in a running game — that half is yours.

## Two things found in passing, not acted on

1. **`godot --import` in a fresh worktree WIPES Dialogic's registries in `project.godot`** — it emptied `directories/dch_directory` and `directories/dtl_directory` (torv + the four prolog timelines). Reverted here so this diff is only the ticket, but any worktree import will do it again, and committing it would silently break dialog.
2. **A pre-existing `push_error` fires twice per board spawn:** `steam: illegal under the two-knob rune rules — refused` (`RuneCatalog.gd:24`). Unrelated to this change and already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
