### PR TITLE
Visual clarity: drop three items the dev ruled out (#44)

### DIFF
--- a/Classes/board/HoverPresenter.gd
+++ b/Classes/board/HoverPresenter.gd
@@ -124,7 +124,10 @@ func _hover_idle(cell: Vector2i) -> Dictionary:
 	_show_hover_panel(hovered, cell)
 	game.overlay_manager.show_overlay(OverlayManager.OverlayType.INVALIDMOVE, moverange.squad_unreachable.keys(), OverlayManager.ATLAS_COORDS)
 
-	if hovered.has_squad() and game.squad_manager.active_squad == null:   #TODO later change this to muted colors if other squads are active
+	# Idle only: an active squad's own markers are already up, and a second set for whoever the
+	# mouse happens to be over competes with them. The "draw them muted instead" TODO that used to
+	# sit here was dropped rather than built (dev, 2026-08-21, #44).
+	if hovered.has_squad() and game.squad_manager.active_squad == null:
 		return game.get_squad_icons(hovered.squad)
 	return {}
 

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -539,8 +539,15 @@ same value and needs a declared relationship with the authored default, not a se
 Flash-not-glow unit highlights; counter-hover -> show countering enemy's attack range;
 enemy attack-range on hover during player turn; real Will bars on panels (HP over a unit's head
 landed as #229 above; the PANEL half and Will are both still open); squad-target
-cursor color-coding; muted squad icons when another squad is active; simultaneous-movement
-legibility (needs design first — the umbrella's core problem).
+cursor color-coding; simultaneous-movement legibility (needs design first — the umbrella's core
+problem).
+
+**Dropped 2026-08-21 (dev), not deferred — deleted from the umbrella rather than left to rot:**
+*muted squad icons when another squad is active* (the mute motif above stands; this particular
+application does not), *fade queued move arrows and restore on hover* (the move to 3D made it
+unnecessary), and *downed units respond to no sprite effect* (since #222/#232/#321 the mirror
+copies `modulate` and `animation_offset` off the hidden 2D node ungated by lifecycle, so highlight,
+flash and pulse already reach a downed unit in the boot view).
 
 **A unit IN CRISIS must read as unmistakable at board glance (dev, 2026-08-09 — filed with
 [#158](https://github.com/Phaazoid/Godoiosis/issues/158)'s ability re-homing):** the skull in the

--- a/docs/todo-triage.md
+++ b/docs/todo-triage.md
@@ -41,8 +41,11 @@ table stale, and two rows describing one TODO that had only ever existed once.
 | Where | Depends on |
 |---|---|
 | `game.spawn_unit` — flyers spawning on non-walkable tiles | unit movement-classes |
-| `game.gd` (squad icons) — muted squad-icon colours when another squad is active | multi-squad visual layer — now tracked under **#44** (visual clarity) |
 | `Classes/squads/Squad.gd:94` — preserve status actions when clearing the queue | a status-effect system (explicitly "if that becomes a thing") |
+
+**One row left this bin by being DROPPED rather than done (2026-08-21):** the muted squad-icon
+colours TODO in `HoverPresenter._hover_idle`. The dev ruled the item out on #44, so the comment was
+deleted with it — a TODO pointing at work nobody intends to do is a reminder that can only mislead.
 
 ## 4 · Overdue — worth doing now
 


### PR DESCRIPTION
Tracker and canon cleanup for [#44](https://github.com/Phaazoid/Godoiosis/issues/44). Three checklist items ruled out 2026-08-21; this removes them and everything that pointed at them. **No behaviour changes.**

## What was dropped, and why

| Item | Ruling |
|---|---|
| Fade queued move arrows, restore on hover | The move to 3D made it unnecessary |
| Downed units respond to no sprite effect | Already works in the boot view |
| Mute squad-icon colours while another squad is active | Not something we need to do |

The downed-unit one was **stale rather than wrong**: since #222/#232/#321, `UnitMirror` copies `modulate` (`:339`) and `animation_offset` (`:319`) off the hidden 2D node **ungated by lifecycle**, so the queue-row highlight, `play_invalid_flash` and the aim pulse all reach a downed unit in HD-2D. The break was confined to FLAT_2D/CORNER, plus the hover z-bump — which is inert for **every** unit in 3D, not just downed ones, since `z_index` is not mirrored at all.

## Files

- **`Classes/board/HoverPresenter.gd`** — deletes the `#TODO later change this to muted colors…` comment. **Comment only.** The `active_squad == null` condition it rode is real behaviour and is untouched; it gains a terse note saying what it does and that the TODO was dropped rather than built, so the next reader doesn't re-derive the question.
- **`docs/design/visual-clarity.md`** — drops the muted-squad-icons clause from the #44 cross-reference list, and records all three drops explicitly as *dropped, not deferred*. Worth being loud about: the doc's own **mute motif** (`:21`) still stands as a legibility vocabulary — it is this one application of it that is out.
- **`docs/todo-triage.md`** — removes the far-future row that routed that TODO to #44, with a line saying it left the bin by being dropped rather than done. The ledger states a `Found: 13` count, so a silently-vanishing row would make it lie.

## Two deviations from the approved plan, both stated rather than silent

**1. I did NOT bump the canon marker on `visual-clarity.md`** (it stays at `#427`). The plan said to. The rule is *"when a sweep re-verifies a doc, bump its marker"* — and I did a **targeted grep for three items**, not a re-verification of a 550-line doc. Bumping it would claim the doc is verified through #437 and destroy exactly the at-a-glance staleness signal the marker exists to give. Say the word and I'll do the real sweep as its own pass.

**2. The #44 checklist comment is edited separately**, and it removes **only these three**. The stale-DEF item stays on the list until [#437](https://github.com/Phaazoid/Godoiosis/pull/437) actually merges — "done means gone" should mean merged, not in flight.

## One fact worth not losing with the arrow-fade item

The fade is being closed as unnecessary, which is your call. But the thing underneath it is still true and now has no ticket: **the existing hover feedback on planned paths does nothing in the 3D view.**

`OverlayManager.set_unit_path_hovered` expresses "you are hovering the unit that prepped this path" as a **z-lift** (`MoveAction.ARROW_BASE_Z_INDEX` 3 → `HOVERED_ARROW_Z_INDEX` 10), and `OverlayMirror._arrows` copies position, texture and modulate but **never z**. So that wire has been inert in the boot view since #222. There is also a live bug in it either way: `redraw_planned_paths()` rebuilds every sprite at the hardcoded base z and nothing re-applies the lift, and `_hover_choosing_move` redraws on every cell change — so the hover state is dropped on any redraw.

If it reads fine in play, nothing is owed and this is just a note. I have not acted on it.

## Verification

`tests/run_tests.ps1 presentation` → **300/300 green** (the area that loads `HoverPresenter`). Full tree is CI's job. Nothing here is testable beyond "it still parses" — the diff is one comment and two docs.

## Toolchain gotcha found twice today, worth a fix of its own

**`godot --headless --import` on a fresh worktree WIPES Dialogic's registries in `project.godot`** — it empties `directories/dch_directory` (torv) and `directories/dtl_directory` (the four prolog timelines). Reproduced on two separate worktrees this session. A new worktree *needs* that import to register `class_name`s, so anyone working this way will hit it, and committing the result would silently break dialog. Reverted in both branches so neither diff carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
