### PR TITLE
Solo units stop wearing a white squad ring (#441)

### DIFF
--- a/Classes/board/OverlayManager.gd
+++ b/Classes/board/OverlayManager.gd
@@ -581,7 +581,16 @@ func redraw_squad_unit_icons(squad: Squad):
 # redraw above so the standing-ring sweep (game.refresh_squad_rings) can draw many squads without
 # each one wiping the last -- the alternative was a second copy of this pair, which is how the two
 # would have drifted.
+#
+# The membership gate lives HERE rather than at the call sites (#441): a ring means "this unit is in
+# a squad with somebody", so a solo squad has nothing to say on this channel -- and two of the three
+# callers had no gate, which put a ring tinted with the UNDEALT ring_hue sentinel (Color.WHITE) under
+# solo units between AI turns. A sentinel that can reach the screen is being read as a colour.
+# The crown rides the same gate on purpose: a solo unit leads nobody, which is the rule
+# _on_squad_became_active already applied to its own crown.
 func draw_squad_unit_icons(squad: Squad) -> void:
+	if squad == null or not squad.has_squadmates():
+		return
 	for member in squad.get_members():
 		create_unit_icon(member, OverlayIcon.IconType.SQUADMEMBER)
 		if member == squad.get_leader():

--- a/Classes/squads/Squad.gd
+++ b/Classes/squads/Squad.gd
@@ -36,6 +36,14 @@ func get_leader() -> Unit:
 func get_members() -> Array[Unit]:
 	return members
 
+# Does this squad actually have MEMBERSHIP -- THE one answer, since every unit is born into a solo
+# squad of its own and "in a squad" is therefore never the question anyone means. It was spelled
+# three different ways (Unit.has_squad, _repaint_squad_plan's has_squadmates, #435's standing-ring
+# sweep) before #441, which is a fourth spelling waiting to happen.
+func has_squadmates() -> bool:
+	return members.size() > 1
+
+
 
 func _add_member(unit: Unit):
 	if not members.has(unit):

--- a/Classes/units/Unit.gd
+++ b/Classes/units/Unit.gd
@@ -436,7 +436,7 @@ func get_faction() -> Team.Faction:
 
 # NB: "has squadMATES" — a solo unit still belongs to a managed squad of one.
 func has_squad() -> bool:
-	return squad.get_members().size() > 1
+	return squad != null and squad.has_squadmates()
 
 func is_leader() -> bool:
 	return squad.get_leader() == self

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -7,7 +7,7 @@ its child [#49 Action Queue UX](https://github.com/Phaazoid/Godoiosis/issues/49)
 This is a *guidelines* doc, not a spec — it captures the principles we're holding the work to,
 plus the running order of the queue-UX checklist. Update it as items land.
 
-**Canon checked through #432 (2026-08-21).**
+**Canon checked through #443 (2026-08-21).**
 
 ## Principles
 
@@ -468,6 +468,28 @@ another in `game`.
 **The sharpened form: find the clears by grepping for them, not by imagining which ones matter.**
 Both misses were writers that clear the channel for a reason unrelated to the new feature, and the
 second was reachable by a mouse movement on a board with nothing selected — the most ordinary state
+
+**A SENTINEL MUST NOT BE REACHABLE AS A DISPLAY VALUE ([#441](https://github.com/Phaazoid/Godoiosis/issues/441), 2026-08-21).**
+The dev found solo units flashing a **white** ring between AI turns in Prolog. `Color.WHITE` is
+`Squad.ring_hue`'s *undealt* sentinel — dealt only at a squad's first squadmate — so the instant it
+rendered it was being read as a colour. Cause: `redraw_squad_unit_icons` drew a ring for every member
+of whatever squad it was handed, and **two of its three callers had no membership gate**
+(`_on_squad_has_no_actions`, `_on_unit_action_cancelled`; only `_repaint_squad_plan` checked). The
+timing was the tell — `_end_squad_turn` drains the queue with `remove_action`, each firing
+`action_cancelled` into the ungated redraw, which is exactly *"after one ends their move and another
+starts theirs"*. **It predated the rings' standing lifecycle entirely** (verified byte-identical on
+`main`), so #435 neither caused nor could have caught it.
+
+The gate now lives in `draw_squad_unit_icons`, where the *meaning* is — a ring says "this unit is in
+a squad with somebody", so a solo squad has nothing to say on the channel and every caller inherits
+the answer. The crown rides the same gate: a solo unit leads nobody, which is the rule
+`_on_squad_became_active` already applied to its own crown, so the two now agree.
+
+**The question had three spellings and was one gate away from a fourth** — `Unit.has_squad()`,
+`_repaint_squad_plan`'s `has_squadmates`, and #435's standing sweep each re-derived
+`get_members().size() > 1`. It is now `Squad.has_squadmates()`, and all three route through it;
+Law #4 says extend the existing answer rather than add another, and the *fourth* spelling is exactly
+what a bug fix is tempted to write.
 the game has.
 
 **Two findings worth keeping.** First, **persistence is what made a stale copy visible**:

--- a/game.gd
+++ b/game.gd
@@ -875,7 +875,7 @@ func _on_unit_action_queued(squad: Squad, action: BaseAction):
 # lets the batch collapse N of these into one (docs/performance.md).
 func _repaint_squad_plan(squad: Squad) -> void:
 	# Squad-wide, so equivalent to the old per-actor unit.has_squad().
-	var has_squadmates: bool = squad.get_members().size() > 1
+	var has_squadmates: bool = squad.has_squadmates()
 	if squad_manager.active_squad == squad and has_squadmates:
 		draw_squad_leader_range(squad, squad.leader.get_projected_destination())
 	squad_manager.validate_squad_plan(squad)
@@ -1038,7 +1038,7 @@ func standing_ring_squads() -> Array[Squad]:
 	if not PlayerSettings.is_on(PlayerSettings.Setting.ALWAYS_SHOW_SQUAD_RINGS):
 		return standing
 	for squad: Squad in squad_manager.squads:
-		if is_instance_valid(squad) and squad.get_members().size() > 1:
+		if is_instance_valid(squad) and squad.has_squadmates():
 			standing.append(squad)
 	return standing
 

--- a/tests/presentation/test_standing_squad_rings.gd
+++ b/tests/presentation/test_standing_squad_rings.gd
@@ -224,3 +224,49 @@ func test_hovering_a_solo_unit_does_not_wipe_another_squads_standing_rings() -> 
 	assert_bool(ringed.has(pair[0]) and ringed.has(pair[1])).override_failure_message(
 			"hovering an unsquadded unit wiped the other squad's standing rings"
 			).is_true()
+
+
+# --- Solo units wear no ring (#441) ------------------------------------------------
+
+# The dev found this in Prolog: a solo unit flashed a WHITE ring between AI turns. redraw_squad_unit_icons
+# drew a ring for every member of whatever squad it was handed, and two of its three callers had no
+# membership gate -- so a solo squad, whose ring_hue is still the UNDEALT Color.WHITE sentinel, wore one.
+# Predates the standing-rings setting entirely (verified identical on main), so this drives the DEFAULT
+# off state; the case below covers the setting-on half.
+#
+# Driven through the executor rather than the seam, because the timing is the tell: _end_squad_turn
+# drains the queue with remove_action, each firing action_cancelled -> game._on_unit_action_cancelled
+# -> the ungated redraw. That is exactly "after one ends their move and another starts theirs".
+func test_a_solo_unit_wears_no_ring_after_its_turn_resolves() -> void:
+	var loner := _spawn(Vector2i(3, 3))
+	assert_bool(loner.squad.has_squadmates()).is_false()   # fixture setup, not the claim
+	# The hold order a squad's own activation queues -- what puts an action in the queue for
+	# _end_squad_turn to cancel.
+	game.squad_manager.setup_hold_move_actions(loner.squad)
+	await game.order_executor.execute_orders(loner)
+	await _settle()
+	assert_array(_ringed_units()).override_failure_message(
+			"a solo unit wore a squad ring -- ring_hue's undealt WHITE sentinel reached the screen as a colour"
+			).is_empty()
+	assert_int(_overlays.markers_of(BoardOverlays.Layer.GROUND_ICONS).size()).override_failure_message(
+			"the solo ring reached the 3D ground channel").is_equal(0)
+
+
+# The same, with standing rings ON: a solo squad is still not membership, so the setting must not
+# become a second way for one to appear.
+func test_a_solo_unit_wears_no_ring_with_standing_rings_on() -> void:
+	_rings_on()
+	var pair := _pair()
+	var loner := _spawn(Vector2i(3, 3))
+	await _settle()
+	assert_int(_ringed_units().size()).override_failure_message(
+			"the standing sweep drew a ring for the solo squad").is_equal(2)
+	game.squad_manager.setup_hold_move_actions(loner.squad)
+	await game.order_executor.execute_orders(loner)
+	await _settle()
+	var ringed := _ringed_units()
+	assert_bool(ringed.has(loner)).override_failure_message(
+			"the solo unit picked up a ring when its own turn resolved").is_false()
+	assert_bool(ringed.has(pair[0]) and ringed.has(pair[1])).override_failure_message(
+			"the real squad lost its standing rings when a solo unit's turn resolved"
+			).is_true()


### PR DESCRIPTION
Closes #441.

## The bug

Reported in play: a solo unit flashes a **white** ring under it between AI turns in Prolog.

`Color.WHITE` is `Squad.ring_hue`'s **undealt sentinel** — dealt only at a squad's first squadmate — so the moment it rendered it was being read as a colour.

`redraw_squad_unit_icons` drew a ring for every member of whatever squad it was handed, with no check that the squad has members *plural*, and **two of its three callers had no gate of their own**:

| caller | gated? |
|---|---|
| `_repaint_squad_plan` | yes (`has_squadmates`) |
| `_on_squad_has_no_actions` | **no** |
| `_on_unit_action_cancelled` | **no** |

The timing is the tell: `_end_squad_turn` drains the queue with `remove_action`, each firing `action_cancelled` into the ungated redraw — exactly *"after one ends their move and another starts theirs"*.

**Not a regression from #435.** Verified byte-identical on `main` before that PR, so this dates to #325 when the ring became the membership marker. The dev's own guess was right.

## The fix

The gate goes in `draw_squad_unit_icons`, where the **meaning** is: a ring says "this unit is in a squad with somebody", so a solo squad has nothing to say on the channel and all three callers inherit one answer — rather than patching the two that happened to be wrong and leaving the next caller to rediscover it.

The crown rides the same gate: a solo unit leads nobody, which is the rule `_on_squad_became_active` already applied to its own crown, so the two now agree.

## Structural note

**The question had three spellings and this fix was one line from writing a fourth.** `Unit.has_squad()`, `_repaint_squad_plan`'s `has_squadmates`, and #435's standing sweep each re-derived `get_members().size() > 1`. It is now **`Squad.has_squadmates()`** and all three route through it — Law #4 says extend the existing answer rather than add another, and a bug fix reaching for a predicate is exactly when the fourth copy gets written.

`Unit.has_squad()` also picks up a null guard it did not have (`squad != null and …`); otherwise behaviour is identical.

## Verification

Areas only, never the full tree: `presentation squad` (469) and `ai flow ui unit` (507) — **976 cases, 0 failures, 0 orphans.** The second batch is because `has_squad()` is read across all four.

Two new cases in `tests/presentation/test_standing_squad_rings.gd`, driven through the **executor** rather than the seam, since the timing is what identifies the bug: one with the setting off (the pre-existing condition), one with standing rings on (so the setting cannot become a second way for a solo ring to appear).

**Falsified:** dropping the gate back to a bare null-check reds `test_a_solo_unit_wears_no_ring_after_its_turn_resolves` **and nothing before it** — the dev's bug reproduced exactly.

**Not checked:** whether it *looks* right in play — the assertions are on the marker store and the mirror's ground channel, never pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
