### PR TITLE
#449 follow-up: derive the look-away cell instead of hardcoding it

### DIFF
--- a/tests/presentation/test_standing_squad_rings.gd
+++ b/tests/presentation/test_standing_squad_rings.gd
@@ -79,6 +79,16 @@ func _ringed_units() -> Array[Unit]:
 	return ringed
 
 
+# Somewhere on the board with nobody on it. DERIVED, never a literal: update_hover_visuals returns
+# early on a tileless cell, so a hardcoded "look away" cell that stops being painted turns every
+# case using it into a silent no-op -- and which tiles exist is authored content (#449).
+func _empty_cell() -> Vector2i:
+	for cell: Vector2i in game.grid.get_used_cells():
+		if game.get_unit_at_cell(cell) == null:
+			return cell
+	return GridUtils.NO_CELL
+
+
 # --- The setting -------------------------------------------------------------------
 
 # Off is a promise that nothing changed: the channel still belongs to the selection paths, so the
@@ -202,8 +212,9 @@ func test_hovering_empty_ground_does_not_wipe_the_standing_rings() -> void:
 	await _settle()
 	assert_int(_ringed_units().size()).is_equal(2)   # precondition, not the claim
 	# The real seam: HoverPresenter's IDLE branch, over a cell with no unit on it.
-	var empty := Vector2i(1, 6)
-	assert_object(game.get_unit_at_cell(empty)).is_null()   # fixture setup
+	var empty := _empty_cell()
+	assert_bool(empty != GridUtils.NO_CELL).override_failure_message(
+			"the fixture board has no empty painted tile to look away at").is_true()
 	game.hover_presenter.update_hover_visuals(empty)
 	await _settle()
 	var ringed := _ringed_units()
@@ -242,8 +253,9 @@ func test_the_crown_stands_with_the_rings_and_outlives_a_hover_out() -> void:
 	# Hover the MEMBER and then look away: the clear that raises a selection crown and drops it.
 	game.hover_presenter.update_hover_visuals(pair[1].movement.cell)
 	await _settle()
-	var empty := Vector2i(1, 6)
-	assert_object(game.get_unit_at_cell(empty)).is_null()   # fixture setup, not the claim
+	var empty := _empty_cell()
+	assert_bool(empty != GridUtils.NO_CELL).override_failure_message(
+			"the fixture board has no empty painted tile to look away at").is_true()
 	game.hover_presenter.update_hover_visuals(empty)
 	await _settle()
 


### PR DESCRIPTION
Follow-up to #457 (#449). **This commit was written before #457 merged and missed the merge by about a minute** — it went to the branch after the PR had already closed, so it needs its own door. Nothing here is new work; it is the last finding from falsifying #457's own case.

## What it fixes

The crown case #457 added hovered `Vector2i(1, 6)` to "look away". That is a painted tile on today's boot board and nothing more than that. `HoverPresenter.update_hover_visuals` **returns early on a tileless cell**, so if that tile is ever repainted the hover becomes a no-op, the crown trivially survives, and the case passes while testing nothing.

**Falsification cannot see this**, which is why it is worth a commit rather than a shrug: the mutant (skip `CROWN` in `draw_squad_unit_icons`) reds the case whether or not the hover actually ran, because the crown never gets drawn in the first place. What ruled it out today was reading `clear_board` — it clears units, squads, zones, terrain states and heights, but **not the grid** — so the boot board's tiles survive and the cell is painted. That is a fact about content, not about the code under test.

Which makes it #449's own finding one level down: a case leaning on content it did not author. The cell is derived from the grid now, with a non-vacuity message instead of a literal — `test_overlay_mirror`'s idiom, the one that suite's own comment already spells out:

> `# ... which tiles exist is authored content this suite must not pin.`

`test_hovering_empty_ground_does_not_wipe_the_standing_rings` carried the same literal and shares the helper now — deliberately, rather than leaving two idioms side by side in one file for the same question.

## Verification

`run_tests.ps1 res://tests/presentation/test_standing_squad_rings.gd` — **12/12**, exit 0.

No falsification here on purpose: this change cannot be falsified by mutating production code (that is the whole point above), and the assertions it guards were already falsified in #457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
