### PR TITLE
Make ai_locked the authority on the board lock, so dev mode cannot weld the camera to the mouse

### DIFF
--- a/Classes/flow/ScenarioManager.gd
+++ b/Classes/flow/ScenarioManager.gd
@@ -366,6 +366,11 @@ func clear_board():
 	# untyped, and a literal passed through it is not coerced to the typed parameter.
 	var no_ai_factions: Array[Team.Faction] = []
 	game.ai_controller.set_ai_factions(no_ai_factions)
+	# And the AI's claim on the camera (#484). A new board owns no AI turn, same reasoning as the line
+	# above -- but load-bearing rather than tidy since that flag became the board lock's authority: a
+	# reload mid-enemy-phase rests game_state on _base_state() through exit_current_mode below, so an
+	# ai_locked left standing by an interrupted turn would lock the fresh board for good.
+	game.camera_controller.set_ai_locked(false)
 	game.zone_manager.load_dict({})   # zones are board content; load_scenario refills them after
 	overlay_manager.redraw_zones(game.zone_manager)
 	game.terrain_states.clear()   # tile states are board content too -- a sandbox spawn inherits no fire (#174)

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -502,12 +502,18 @@ func _process(_delta: float) -> void:
 # second follow seam, and because the 2D camera owns the tween the 3D inherits
 # Pacing.AI_SQUAD_PAN exactly — one number, one reader.
 #
-# ai_locked is the gate, NOT _board_locked_for_player(): the latter also covers MENU,
-# and Mission Select opts out of the modal lock, so mirroring there would yank the rig
+# ai_locked is the gate, NARROWER than _board_locked_for_player(): the latter also covers
+# MENU, and Mission Select opts out of the modal lock, so mirroring there would yank the rig
 # to a stale 2D position the moment a menu opened. ai_locked IS the fact "the AI owns
 # the 2D camera" — set in the same block as AI_TURN, cleared the moment it returns.
 # Re-read every frame, never latched: a turn handoff can re-enter set_ai_locked inside
 # the previous turn's stack, so the flag can legitimately flicker for a frame.
+#
+# Narrower, and since #484 strictly so: the board lock READS this flag, so whenever this gate
+# is open _update_pointer's is shut. That is what keeps the two apart, and it has to be
+# structural — they write to each other (this READS the 2D camera, _update_pointer WRITES it),
+# so a frame running both marches the view to the pan limit on every mouse move. It used to
+# rest on game_state carrying AI_TURN for the whole turn, which set_dev_mode falsified.
 func _mirror_camera() -> void:
 	var cam: CameraController = game.camera_controller
 	# Square-on for the enemy phase (dev call 2026-08-14), on the EDGE into the turn rather

--- a/docs/design/presentation-effects.md
+++ b/docs/design/presentation-effects.md
@@ -2,7 +2,7 @@
 
 **Status: an idea wall plus two locked decisions.** Solicited by the dev on 2026-08-12, the day Stage 0 (#203) passed its GO gate: *"a full thought experiment, all ideas on the wall."* Nothing below the Decisions section is a commitment — it is the candidate pool for #176's stage 5 and beyond, kept so it can't evaporate from chat. The look-dev scene (`Scenes/LookDev/LookDev.tscn`) is the standing playground where any of it gets prototyped before it's real — and since #212 (2026-08-15) the **Moods tab** in the dev-tools window tunes the *shipping* view live, so a value on this wall can be judged on a real board rather than in the diorama. **It is a playground, not a scratch scene ([#393](https://github.com/Phaazoid/Godoiosis/issues/393), 2026-08-19)** — five presentation suites fixture on it, `Battle3D.tscn` loads its MeshLibrary, and `BoardMirror`/`BoardOverlays` read textures out of `Art/LookDev/`, so it is edited with the same care as shipping code. Its four moods stopped being a second copy at the same time: `look_dev.gd` held them as a hardcoded `PRESETS` table, seeded from the same values four of the twelve `LookPreset` files now carry, and it resolves them by NAME through `LookKnobs` instead.
 
-**Canon checked through #478 (2026-08-23).**
+**Canon checked through #484 (2026-08-23).**
 
 ---
 
@@ -266,11 +266,28 @@ be worth fixing. It compares the camera's whole transform rather than the rig's 
 yaw and zoom move the pick too and both lerp for frames after the input that started them.
 
 **The invariant that keeps two authorities apart, worth stating because nothing in the code says
-it:** `_update_pointer` WRITES the hidden 2D camera and `_mirror_camera` READS it, so the two would
-chase each other if they ever ran in the same frame. They cannot, because `ai_locked` is only ever
-set in the same block as `AI_TURN` and the poll stands down on any locked board. That is now a fact
-the poll depends on rather than a coincidence — a fixture holding `ai_locked` *without* `AI_TURN` is
-in a state the game cannot reach, and `test_camera_follow.gd` says so where it sets both.
+it:** `_update_pointer` WRITES the hidden 2D camera and `_mirror_camera` READS it, so the two chase
+each other to the pan limit if they ever run in the same frame. `ai_locked` opens the second gate and
+the board lock shuts the first, so what keeps them apart is that a locked board is implied by
+`ai_locked` — which is why, since [#484](https://github.com/Phaazoid/Godoiosis/issues/484),
+`_board_locked_for_player()` **reads that flag** rather than only `game_state == AI_TURN`.
+
+**This paragraph used to claim the pair was unreachable, and that claim is what shipped the bug.** It
+argued the two are written in one block by `start_faction_turn`, so `ai_locked` without a locked board
+could not happen. But `game_state` is TRANSIENT — `set_dev_mode` and `clear_board` both rest it on
+`_base_state()` from anywhere — so toggling dev mode mid-enemy-phase (either direction; *off* lands on
+`IDLE`) reached it, and the mouse became welded to the camera. **The lesson is the shape, not the
+path:** an invariant that holds because of *who writes what, in what order* is a coincidence with good
+manners, and the fix is to make the pair unrepresentable rather than to enumerate the ways in. Two
+other things that same window opened, both worse than the camera: board clicks stopped refusing during
+an enemy phase, and `can_control` returns `true` for *any* unit in `DEV_MODE`, so enemy units became
+commandable.
+
+Note the containment is one-way and deliberate. `_mirror_camera` still gates on `ai_locked` alone,
+**narrower** than the board lock, because that predicate also covers `MENU` and Mission Select opts out
+of the modal lock — mirroring there would yank the rig to a stale 2D position the moment a menu opened.
+Widening *it* was the obvious-looking fix and is the wrong one; the two `test_camera_follow.gd` guard
+cases still say so.
 
 ### The rig aims at the SURFACE, never at the board's ceiling (dev report, 2026-08-23)
 

--- a/game.gd
+++ b/game.gd
@@ -42,6 +42,9 @@ enum GameState {
 	BETWEEN_TURNS,
 	DEV_MODE,
 	PICKING_TARGET,
+	# Never read this member to ask "is the board locked?" -- ask _board_locked_for_player(), which
+	# also reads camera_controller.ai_locked. game_state is transient and gets rested on _base_state()
+	# mid-AI-turn (set_dev_mode, clear_board); the flag is what actually spans the turn (#484).
 	AI_TURN,
 	MISSION_OVER,
 	MENU
@@ -565,8 +568,20 @@ func _run_turn_start_ticks(faction: Team.Faction) -> void:
 
 # The board is fully hands-off for the player while an AI faction resolves its turn, while the
 # end-of-mission card is up, and while Mission Select is up.
+#
+# ai_locked is the AUTHORITY on the first of those, never game_state (#484). The two are written in
+# one block by start_faction_turn, but game_state is TRANSIENT -- set_dev_mode and clear_board both
+# rest it on _base_state() from anywhere, AI turn or not -- so reading the state alone let a dev-mode
+# toggle mid-enemy-phase report the board unlocked while the camera was still AI-owned. That pair is
+# the one combination battle3d's two camera gates may never see at once: _update_pointer writes the
+# hidden 2D camera when this is false and _mirror_camera reads it when ai_locked is true, so they
+# chased each other to the pan limit on every mouse move. Asking the flag makes the pair
+# unrepresentable rather than merely unreached, whatever writes game_state next.
 func _board_locked_for_player() -> bool:
-	return game_state == GameState.AI_TURN or game_state == GameState.MISSION_OVER or game_state == GameState.MENU
+	return (camera_controller.ai_locked
+		or game_state == GameState.AI_TURN
+		or game_state == GameState.MISSION_OVER
+		or game_state == GameState.MENU)
 
 func can_control(unit: Unit) -> bool:
 	if unit == null:

--- a/tests/presentation/test_camera_follow.gd
+++ b/tests/presentation/test_camera_follow.gd
@@ -98,10 +98,14 @@ func _picked(cell: Vector2i) -> Vector3i:
 func test_the_3d_camera_follows_the_ai_camera() -> void:
 	var unit := _player_unit()
 	assert_object(unit).is_not_null()
-	# AI_TURN travels WITH the lock. start_faction_turn writes both in one block and clears the lock
-	# first, so `ai_locked and not _board_locked_for_player()` is a state the game cannot reach --
-	# and since #471 the pointer poll re-derives on CAMERA movement, so a fixture holding that
-	# impossible pair lets the hover snap drag the 2D camera the mirror below is reading.
+	# `ai_locked and not _board_locked_for_player()` is the pair that must never exist -- the poll
+	# re-derives on CAMERA movement since #471, so a fixture holding it lets the hover snap drag the
+	# 2D camera the mirror below is reading, and the two march the view to the pan limit.
+	#
+	# This comment used to say the pair was unreachable BECAUSE start_faction_turn writes AI_TURN and
+	# the flag together. That was false: game_state is transient, and set_dev_mode rested it on
+	# _base_state() mid-enemy-phase, which is #484. The predicate now READS ai_locked, so the line
+	# below is what makes the pair impossible rather than a claim about who writes what.
 	_game.game_state = _game.GameState.AI_TURN
 	_cam().set_ai_locked(true)
 	await _cam().pan_to(unit)   # headless: lands on the destination and hands to follow
@@ -160,6 +164,64 @@ func test_opening_a_menu_does_not_yank_the_3d_camera() -> void:
 
 	assert_that(_rig.position).override_failure_message(
 			"the menu yanked the rig — the mirror is gated on the wrong predicate").is_equal(before)
+
+
+# #484, reported in play: the mouse became welded to the camera and ran the view to its limit in
+# whatever direction it moved. Toggling dev mode mid-enemy-phase rested game_state on _base_state(),
+# which unlocked the board while ai_locked stayed true -- opening _update_pointer's gate (it writes
+# the hidden 2D camera) at the same time as _mirror_camera's (it reads it).
+#
+# Drives the REAL door: set_dev_mode, not a game_state poke. The rig assertion is the point -- the
+# predicate going false is the rule, but the camera running away is what the dev saw, and a case
+# that only read the predicate would pass against a mirror wired straight to game_state.
+func test_toggling_dev_mode_during_an_ai_turn_leaves_the_board_locked() -> void:
+	_game.game_state = _game.GameState.AI_TURN
+	_cam().set_ai_locked(true)
+	await _settle()
+	var before := _rig.position
+
+	_game.set_dev_mode(true)
+	assert_int(_game.game_state).override_failure_message(
+			"set_dev_mode no longer rests game_state -- this case is asserting nothing"
+			).is_equal(_game.GameState.DEV_MODE)
+	assert_bool(_game._board_locked_for_player()).override_failure_message(
+			"dev mode unlocked the board mid-AI-turn: game_state moved and the lock followed it"
+			).is_true()
+
+	# The runaway itself. A hover would snap the 2D camera and the mirror would drag the rig after it.
+	var unit := _player_unit()
+	var screen := _screen_of(unit.movement.cell)
+	var motion := InputEventMouseMotion.new()
+	motion.position = screen
+	motion.global_position = screen
+	Input.parse_input_event(motion)
+	Input.flush_buffered_events()
+	await _settle()
+
+	assert_that(_rig.position).override_failure_message(
+			"the mouse dragged the 3D camera -- the pointer and the mirror both ran in one frame"
+			).is_equal(before)
+	_game.set_dev_mode(false)
+	_cam().set_ai_locked(false)
+	_game.game_state = _game.GameState.IDLE
+
+
+# The second door onto the same pair (#484): clear_board rests game_state through exit_current_mode,
+# so a reload mid-enemy-phase reaches it too. Now that the lock READS ai_locked, an interrupted AI
+# turn leaving the flag standing would lock the FRESH board for good -- so clear_board drops it,
+# beside the ai_factions reset it already does for the same "a new board inherits nothing" reason.
+func test_clearing_the_board_during_an_ai_turn_drops_the_ai_camera_lock() -> void:
+	_cam().set_ai_locked(true)
+	await _settle()
+
+	_game.scenario_manager.clear_board()
+	await _settle()
+
+	assert_bool(_cam().ai_locked).override_failure_message(
+			"a cleared board kept the last turn's camera lock -- the new board is locked for good"
+			).is_false()
+	assert_bool(_game._board_locked_for_player()).override_failure_message(
+			"the fresh board came up locked").is_false()
 
 
 func test_a_locked_board_refuses_the_players_camera_but_keeps_the_rig_running() -> void:


### PR DESCRIPTION
Closes #484.

Your report `2026-08-23_11-56-54` -- mouse movement welded to camera position, running the view to its limit in whatever direction it moved. Your hunch about dev mode was right.

## What was wrong

"Does the AI own the board?" had two answers, written in one block by `start_faction_turn` and hand-synced:

- `game_state == GameState.AI_TURN`
- `camera_controller.ai_locked`, cleared only after the awaited `take_faction_turn` returns

`game_state` is **transient** -- `set_dev_mode` and `clear_board` both rest it on `_base_state()` from anywhere, AI turn or not. So toggling dev mode mid-enemy-phase reported the board unlocked while the camera stayed AI-owned. Either direction does it: toggling *off* lands on `IDLE`, which is equally unlocked.

That pair is the one combination `battle3d`'s two camera gates may never see at once:

- `_update_pointer` **writes** the hidden 2D camera when the board is unlocked (it is what parks the hover card)
- `_mirror_camera` **reads** that camera and drives the 3D rig when `ai_locked`

Since #471 the pointer poll re-derives on camera movement as well as mouse movement, so each mouse move snapped the 2D camera, the rig followed, the pick re-ran against the moved camera and landed further in whatever direction the cursor sat off screen-centre. It marched to `pan_limit` and stayed there, and every later mouse move kept driving it.

**The worse half:** the same window unlocked the board itself. Clicks, the queue verbs and Execute all stopped refusing during an enemy phase, and `can_control` returns `true` for *any* unit in `DEV_MODE` -- so enemy units became commandable mid-turn.

## The fix

`_board_locked_for_player()` now reads `ai_locked`, per your ruling. That makes the pair **unrepresentable** for all 15 call sites, whatever writes `game_state` next -- rather than unreachable-by-the-paths-audited-today, which is exactly the claim that shipped this.

Your standing requirement was that a player must never be able to reach it. Two things carry that:

- **`game_state == AI_TURN` had exactly ONE production reader** -- this predicate. Grepped across all non-test code; every other hit is the enum member, the writer, or a comment. So widening the predicate genuinely covers every consumer, and nothing else needed touching.
- **The change is a no-op in normal play.** The predicate only changes answer when `ai_locked` is true *and* `game_state` is not already AI_TURN/MISSION_OVER/MENU -- i.e. precisely the broken window. I checked all 15 sites and none needs to be false during an enemy phase; inside the window each becomes correct (Esc routes to the report card, board clicks and queue verbs refuse, Execute disables, and the rig's `manual_input_enabled` goes false, which independently stands WASD and orbit down).

Per your ruling I did **not** fold in the `clear_selection` half -- `game_state` is still free to rest on `_base_state()`. There is a note at the `AI_TURN` enum member saying the lock is read through the predicate, not off the member.

`clear_board` also drops the flag now, beside the `ai_factions` reset it already does. That one is load-bearing rather than tidy *because* the flag became authoritative: a reload that stranded an AI turn would otherwise lock the fresh board for good, which would be a worse bug than the one being fixed.

## Verification

- `tests/presentation/test_camera_follow.gd` -- 15 cases green, including two new ones.
- `presentation` + `ui` areas: **602 cases, 52 suites, 0 failures, 0 errors, 0 orphans.** Full tree is CI's.

The suite file **carried the false invariant as a comment** (*"a state the game cannot reach"*) and described this exact failure as the reason it mattered. Rewritten to say what actually makes the pair impossible.

Both new cases drive the real door rather than poking state, and both were falsified one at a time against a committed tree:

| Mutant | Case that reddened |
| --- | --- |
| drop the `ai_locked` clause from the predicate | `test_toggling_dev_mode_during_an_ai_turn_leaves_the_board_locked` (4th case -- the three before it passed, so it is the one that caught it) |
| drop the `clear_board` reset | `test_clearing_the_board_during_an_ai_turn_drops_the_ai_camera_lock` (both its assertions) |

The dev-mode case asserts the **rig did not move** after a synthesized hover, not just that the predicate went false -- the predicate is the rule, but the camera running away is what you saw, and a case reading only the predicate would pass against a mirror wired straight to `game_state`.

## Not checked

**Whether the runaway is actually gone in play** -- that is your feel-check. The repro is: start an enemy phase on a board with an AI faction (Prolog), press F1 or click the dev-mode checkbox while it runs, then move the mouse.

Nothing embeds a content type here, so the `.tres` staleness class does not apply.

## Riding along, not done

`report.md` records the game state and the view (yaw/zoom/centre) but nothing about the camera controller -- so the one fact that identifies this bug was not in your report. Say the word and I will file it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
