### PR TITLE
#476: ask has_meta before get_meta - the drop pointer's guard no longer error-spams every frame

### DIFF
--- a/Classes/presentation/OverlayMirror.gd
+++ b/Classes/presentation/OverlayMirror.gd
@@ -327,9 +327,12 @@ func _split_knockback(om: OverlayManager, trails: Array[Dictionary], ghosts: Arr
 # quad IS the travel direction, i.e. straight out of that wall. That is what a coplanar marker has
 # always needed, and it is why the pointer can depth-test honestly rather than x-raying the board.
 func _append_drop(trails: Array[Dictionary], sprite: Sprite2D) -> void:
-	var rail: Texture2D = sprite.get_meta("kb_rail_texture", null)
-	if rail == null or not sprite.has_meta("kb_dir"):
+	# has_meta first, never a null default: get_meta(name, null) is a NO-OP -- Godot treats a null
+	# default exactly like no default and raises for an absent key, so the guard that exists to
+	# handle the missing-meta case was what error-spammed the log, once per cell per frame (#476).
+	if not sprite.has_meta("kb_rail_texture") or not sprite.has_meta("kb_dir"):
 		return   # the first cell of a trail: no edge was crossed to reach it
+	var rail: Texture2D = sprite.get_meta("kb_rail_texture")
 	var heights := _heights()
 	var px := sprite.global_position
 	var cell := _cell_of_px(px)

--- a/tests/presentation/test_overlay_mirror.gd
+++ b/tests/presentation/test_overlay_mirror.gd
@@ -1221,6 +1221,19 @@ func test_the_drop_pointer_wears_the_trail_it_hangs_from() -> void:
 			"the cliff drew no drop pointer; the case is vacuous").is_true()
 
 
+# #476: a null default on get_meta is a NO-OP -- Godot treats it exactly like no default and
+# raises when the key is absent, so the guard that exists to handle the meta-less first trail
+# cell is what error-spammed the log, once per such cell per frame. The guard must ask has_meta
+# first. This case pins the ERROR CHANNEL rather than the early return -- the return happens
+# either way, so the log is the only observable difference. gdUnit4's assert_error registers an
+# OS logger with both report flags forced true, so the engine's ERR_FAIL_V_MSG lands in its
+# entries and is_success() fails on it.
+func test_the_drop_pointer_guard_stays_silent_on_the_meta_less_first_cell() -> void:
+	var sprite := Sprite2D.new()
+	await assert_error(func (): _mirror._append_drop([], sprite)).is_success()
+	sprite.free()
+
+
 # The knob has to move a preview that is ALREADY up, or it is a slider that appears to do nothing
 # until the next shove (#324's lesson, and the reason restyle_squad_markers exists next door).
 func test_tuning_the_shove_colour_moves_a_preview_already_on_the_board() -> void:


### PR DESCRIPTION
🤖 Claude says:

Fixes [#476](https://github.com/Phaazoid/Godoiosis/issues/476).

## The bug

`OverlayMirror._append_drop` read its rail texture via `sprite.get_meta("kb_rail_texture", null)`. Godot only honours a `get_meta` default that is **not** null (`null` is `Variant()`), so on the meta-less first cell of every knockback trail — the documented normal case the guard exists for — the call raised `ERR_FAIL_V_MSG` before the guard could return. Once per such sprite, per frame, from `_process`: the tester logs for #472 were 80 lines of this one error.

## The fix

The guard now asks `has_meta` first and reads unconditionally — the same shape the `kb_dir` half already used one line down. A comment records the no-op-null-default trap so the pattern doesn't get written again. A sweep confirms this was the only `get_meta(..., null)` in project code (the rest live in vendored `addons/dialogic/`).

## Verification

- **New case** `test_the_drop_pointer_guard_stays_silent_on_the_meta_less_first_cell` pins the *error channel* (the early return happens either way, so the log is the only observable difference) via gdUnit4's `assert_error(...).is_success()`.
- **Falsified**: the new case failed against the unfixed guard, capturing the engine error; green after the fix.
- `tests/presentation/test_overlay_mirror.gd`: 42/42. `tests/presentation/` whole area: 383/383, exit 0.
- **Not checked**: a real launched session — the defect is the log channel itself; one playtest with a knockback preview on screen is the honest confirmation. (The log also still carries a pre-existing `steam: illegal under the two-knob rune rules` error from an authored rune on board load — unrelated to this PR.)

— Claude (DeepSeek V4 Pro) · 2026-08-24
