### PR TITLE
#524: BeatSheet - read a ResolvedPlan into a cinematic shot list

### DIFF
--- a/Classes/actions/resolution/BeatSheet.gd
+++ b/Classes/actions/resolution/BeatSheet.gd
@@ -1,0 +1,222 @@
+extends RefCounted
+class_name BeatSheet
+
+# The cinematic's reading of one resolved pass (#524, umbrella #410): "what is in this fight?"
+# The cast, the cells the fight touches, and an ordered beat list -- the shot list that #519's
+# timing table and #520's camera director both read. Consumes a ResolvedPlan and the squad's
+# queue; computes no damage and no geometry, and if it ever needs to, that is the bug (Law #2:
+# the zoom is a mirror, never an authority).
+#
+# The beat order MIRRORS OrderExecutor.execute_orders and its phase order rather than restating
+# it: moves, attack volleys in queue order, cell effects, the counter turnover, counter volleys,
+# then the side-channel tail in SIDE_CHANNEL_ORDER. A phase with nothing in it produces no beat.
+#
+# Volley grouping is the RESOLVER's rule, not a second one: is_secondary_hit marks the non-lead
+# members (create_volley / create_counter_volley stamp it) and PlanResolver.resolve_counters
+# already walks the flat array exactly this way.
+#
+# A beat's WEIGHT is facts, never a duration and never a severity ranking: the lethality rungs it
+# contains, whether it shoves, drops, removes, or was held by Iron Will. Collapsing those into a
+# beat length is #519's table under a chosen profile, and ranking KILLED against MAIMED is that
+# same table's call. Doing either here would be a second answer to a question #519 owns (Law #4).
+
+enum Kind { MOVES, VOLLEY, CELL_EFFECTS, TURNOVER, CODA }
+
+
+# One shot. A VOLLEY is one blast in one moment however many it hits (#410: an AoE striking three
+# victims is a single sweep, not three cuts); the rest is the phase punctuation around them.
+class Beat:
+	var kind: int = Kind.VOLLEY
+	var is_counter := false
+
+	# The volley's members in strike order. Empty on a punctuation beat.
+	var actions: Array[AttackAction] = []
+	var actor: Unit = null
+
+	# Aligned by index, and BOTH MAY BE EMPTY on a real beat: #47 lets a legal aim at cells with
+	# no unit resolve as a cell attack (target stays null), so a swing at open ground is a beat
+	# with no victim at all. Nothing may assume victims[0] exists.
+	var victims: Array[Unit] = []
+	var lethalities: Array[ResolvedOutcome.Lethality] = []
+
+	var has_knockback := false
+	var has_fall := false
+	var has_removal := false
+	var iron_will_held := false
+
+	# CODA only: which side-channel order this is (RESCUE, RALLY, GUARD, ...).
+	var coda_type: BaseAction.ActionType = BaseAction.ActionType.ATTACK
+
+	func has_lethality(rung: ResolvedOutcome.Lethality) -> bool:
+		return lethalities.has(rung)
+
+	# Drop this volley's no-op members and read the surviving facts off their outcomes. R7 skips a
+	# counter-er, not a volley, so this runs AFTER grouping -- dropping a skipped LEAD any earlier
+	# would orphan its own secondaries into a beat of their own.
+	func _absorb() -> void:
+		var played: Array[AttackAction] = []
+		for attack in actions:
+			var out := attack.resolved
+			if out != null and out.skipped:
+				continue
+			played.append(attack)
+			if attack.target != null and is_instance_valid(attack.target):
+				victims.append(attack.target)
+				lethalities.append(ResolvedOutcome.Lethality.NONE if out == null else out.lethality)
+			if out == null:
+				continue
+			has_knockback = has_knockback or out.knockback_applied
+			has_fall = has_fall or out.fall_levels > 0
+			has_removal = has_removal or out.removed
+			iron_will_held = iron_will_held or out.iron_will_held
+		actions = played
+
+
+var beats: Array[Beat] = []
+
+# Everyone on stage: the acting squad plus every squad it strikes, all members -- #410's "everyone
+# in every participating squad is on stage". Counter-ers and their victims fall inside those squads
+# by construction, so they are never gathered separately.
+var cast: Array[Unit] = []
+
+# Every cell the fight touches: attacker origins, aimed cells, whole knockback flights and their
+# landings, terrain deposits, and the standing cell of any cast member none of that mentions.
+# Slice #521's tear-out set is exactly this, computed once here rather than again there.
+var cells: Array[Vector2i] = []
+
+
+static func read(squad: Squad, plan: ResolvedPlan) -> BeatSheet:
+	var sheet := BeatSheet.new()
+	if squad == null or plan == null:
+		return sheet
+
+	var movers: Array[Unit] = []
+	var codas: Dictionary = {}
+	for action in squad.action_queue:
+		if action.action_type == BaseAction.ActionType.MOVE:
+			if action.actor != null:
+				movers.append(action.actor)
+		elif BaseAction.SIDE_CHANNEL_ORDER.has(action.action_type):
+			if not codas.has(action.action_type):
+				codas[action.action_type] = []
+			codas[action.action_type].append(action)
+
+	if not movers.is_empty():
+		var moves := Beat.new()
+		moves.kind = Kind.MOVES
+		moves.victims.assign(movers)   # a MOVES beat strikes nobody; these are the movers
+		sheet.beats.append(moves)
+
+	sheet.beats.append_array(_group(plan.attacks, false))
+
+	if not plan.cell_effects.is_empty():
+		var deposits := Beat.new()
+		deposits.kind = Kind.CELL_EFFECTS
+		sheet.beats.append(deposits)
+
+	# The act break exists only if the defending line actually answers -- #410's "when the
+	# attacker's last swing lands, a beat, the defending line raises weapons in unison". A counter
+	# phase that is entirely skipped plays nothing, so it earns no turnover either.
+	var counter_beats := _group(plan.counters, true)
+	if not counter_beats.is_empty():
+		var turnover := Beat.new()
+		turnover.kind = Kind.TURNOVER
+		turnover.is_counter = true
+		sheet.beats.append(turnover)
+		sheet.beats.append_array(counter_beats)
+
+	for type in BaseAction.SIDE_CHANNEL_ORDER:
+		if not codas.has(type):
+			continue
+		var coda := Beat.new()
+		coda.kind = Kind.CODA
+		coda.coda_type = type
+		var batch: Array = codas[type]
+		coda.actor = batch[0].actor
+		sheet.beats.append(coda)
+
+	sheet._gather_cast(squad, plan)
+	sheet._gather_cells(plan)
+	return sheet
+
+
+# Walk a flat action list into volleys. A lead member (is_secondary_hit false) opens a beat and
+# every secondary after it joins it -- the same read PlanResolver.resolve_counters makes over the
+# same flat array. A beat left empty by skipped members is dropped entirely.
+static func _group(actions: Array, is_counter: bool) -> Array[Beat]:
+	var grouped: Array[Beat] = []
+	var current: Beat = null
+	for action in actions:
+		var attack := action as AttackAction
+		if attack == null:
+			continue
+		if current == null or not attack.is_secondary_hit:
+			current = Beat.new()
+			current.kind = Kind.VOLLEY
+			current.is_counter = is_counter
+			current.actor = attack.actor
+			grouped.append(current)
+		current.actions.append(attack)
+
+	var played: Array[Beat] = []
+	for beat in grouped:
+		beat._absorb()
+		if not beat.actions.is_empty():
+			played.append(beat)
+	return played
+
+
+func _gather_cast(squad: Squad, plan: ResolvedPlan) -> void:
+	var seen: Dictionary = {}
+	_enlist(squad, seen)
+	for list in [plan.attacks, plan.counters]:
+		for action in list:
+			var attack := action as AttackAction
+			if attack != null and attack.target != null and is_instance_valid(attack.target):
+				_enlist(attack.target.squad, seen)
+
+
+func _enlist(squad: Squad, seen: Dictionary) -> void:
+	if squad == null or not is_instance_valid(squad):
+		return
+	var roster: Array[Unit] = [squad.leader]
+	roster.append_array(squad.members)
+	for unit in roster:
+		if unit == null or not is_instance_valid(unit):
+			continue
+		if seen.has(unit.get_instance_id()):
+			continue
+		seen[unit.get_instance_id()] = true
+		cast.append(unit)
+
+
+func _gather_cells(plan: ResolvedPlan) -> void:
+	var seen: Dictionary = {}
+	for list in [plan.attacks, plan.counters]:
+		for action in list:
+			var attack := action as AttackAction
+			if attack == null:
+				continue
+			_mark(attack.origin_cell, seen)
+			_mark(attack.target_cell, seen)
+			var out := attack.resolved
+			if out == null or not out.knockback_applied:
+				continue
+			# The whole flight, not just its ends: #520 pans ALONG this and #521 has to tear out
+			# every cell it crosses. knockback_path is already the resolver's own route.
+			for cell in out.knockback_path:
+				_mark(cell, seen)
+			_mark(out.knockback_from, seen)
+			_mark(out.knockback_to, seen)
+	for effect in plan.cell_effects:
+		_mark(effect.cell, seen)
+	# A squadmate who neither acts nor is hit is still on stage, so its ground is torn out too.
+	for unit in cast:
+		_mark(unit.get_projected_destination(), seen)
+
+
+func _mark(cell: Vector2i, seen: Dictionary) -> void:
+	if seen.has(cell):
+		return
+	seen[cell] = true
+	cells.append(cell)

--- a/Classes/actions/resolution/BeatSheet.gd.uid
+++ b/Classes/actions/resolution/BeatSheet.gd.uid
@@ -1,0 +1,1 @@
+uid://dttglwfkcw471

--- a/Classes/actions/resolution/PlanResolver.gd
+++ b/Classes/actions/resolution/PlanResolver.gd
@@ -228,6 +228,9 @@ static func _resolve_one(action: AttackAction, reactions: Array[ElementalReactio
 	# damage cap on the holder. Composes with the floor above as an ordinary clamp — order is
 	# a non-issue since cap >= 0 makes max(0,min(cap,x)) == min(cap,max(0,x)) always.
 	if target.has_live_ability(Abilities.Id.IRON_WILL):
+		# Recorded BEFORE the clamp, because afterwards nothing can tell a capped hit from one that
+		# happened to land on the cap (#524).
+		outcome.iron_will_held = outcome.damage > Abilities.IRON_WILL_DAMAGE_CAP
 		outcome.damage = mini(outcome.damage, Abilities.IRON_WILL_DAMAGE_CAP)
 
 	# --- thread the hypothetical forward (R4) ---

--- a/Classes/actions/resolution/ResolvedOutcome.gd
+++ b/Classes/actions/resolution/ResolvedOutcome.gd
@@ -57,6 +57,12 @@ var lethality: Lethality = Lethality.NONE
 
 var skipped: bool = false                        # counter-er downed/killed earlier in the pass (R7) — no-op: don't play or preview
 
+# The Iron Will cap actually BIT on this hit (#524): incoming damage exceeded the cap and was
+# clamped, so the target is standing because of the ability rather than in spite of the hit. A
+# RECORDED decision like lethality, not a derivation — by the time anything plays back, `damage`
+# is already the clamped number and the fact is unrecoverable. #410's held-breath beat reads it.
+var iron_will_held: bool = false
+
 var hp_before: int = 0   # target's HP going into this hit; recorded by the resolver, not derived
 
 # Target height minus attacker height at resolve time (#258) — the wire a future height-damage rule

--- a/tests/squad/test_beat_sheet.gd
+++ b/tests/squad/test_beat_sheet.gd
@@ -1,0 +1,273 @@
+# BeatSheet (#524, umbrella #410): the cinematic's reading of one resolved pass. These cases pin
+# the SHAPE of that reading -- what counts as one shot, what earns a beat at all, and the order the
+# beats come in -- because every later slice (#519 timing, #520 camera, #521 tear-out) consumes it
+# and none of them can see a mis-grouping until it is already on screen.
+#
+# Two fixture styles on purpose. The structural cases drive the REAL resolve_plan, so the sheet is
+# checked against what the resolver actually emits rather than what this suite imagines. The fact
+# cases hand-build a plan from create_volley / create_counter_volley (real stamping, throwaway
+# outcomes), which is the only way to pin a fall or a skipped counter without standing up terrain.
+extends GdUnitTestSuite
+
+const H := preload("res://tests/support/squad_fixtures.gd")
+
+const PLAYER := Team.Faction.PLAYER
+const ENEMY := Team.Faction.ENEMY
+
+var _sm: SquadManager
+
+
+func before_test() -> void:
+	_sm = H.make_manager(self)
+
+
+# --- structural: driven by the real resolver ------------------------------------------------
+
+func test_a_single_pair_is_one_volley_beat() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var foe := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker, foe]))
+	var sheet := BeatSheet.read(attacker.squad, plan)
+
+	var volleys := _of_kind(sheet, BeatSheet.Kind.VOLLEY)
+	assert_int(volleys.size()).is_greater_equal(1)
+	assert_object(volleys[0].actor).is_same(attacker)
+	assert_int(volleys[0].victims.size()).is_equal(1)
+	assert_object(volleys[0].victims[0]).is_same(foe)
+	assert_bool(volleys[0].is_counter).is_false()
+	_break_volleys(plan)
+
+
+# #47's cell attack: a legal aim at empty ground resolves and PLAYS, so it earns a beat -- with no
+# victim at all. The sheet must carry an empty victim list rather than dropping the swing, or the
+# camera has nothing to cut to while terrain effects land there (#50).
+func test_a_swing_at_empty_ground_is_a_beat_with_no_victim() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker]))
+	assert_int(plan.attacks.size()).is_equal(1)
+	assert_object(plan.attacks[0].target).is_null()
+
+	var sheet := BeatSheet.read(attacker.squad, plan)
+	var volleys := _of_kind(sheet, BeatSheet.Kind.VOLLEY)
+	assert_int(volleys.size()).is_equal(1)
+	assert_array(volleys[0].victims).is_empty()
+	assert_array(volleys[0].lethalities).is_empty()
+	assert_int(volleys[0].actions.size()).is_equal(1)
+	_break_volleys(plan)
+
+
+# The act break only exists when the defending line actually answers, and it must sit BEFORE the
+# counters it introduces -- that ordering is the whole point of the beat (#410 counter turnover).
+func test_a_countered_attack_puts_the_turnover_before_the_counters() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var foe := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker, foe]))
+	assert_int(plan.counters.size()).is_greater(0)
+
+	var sheet := BeatSheet.read(attacker.squad, plan)
+	var turnover := _index_of_kind(sheet, BeatSheet.Kind.TURNOVER)
+	assert_int(turnover).is_greater_equal(0)
+
+	var first_counter := -1
+	for i in sheet.beats.size():
+		if sheet.beats[i].is_counter and sheet.beats[i].kind == BeatSheet.Kind.VOLLEY:
+			first_counter = i
+			break
+	assert_int(first_counter).is_greater(turnover)
+	_break_volleys(plan)
+
+
+# Both squads are on stage, not just the two units trading blows (#410: "everyone in every
+# participating squad"). The bystander squadmate is the case that separates cast from combatants.
+func test_the_cast_holds_every_member_of_every_participating_squad() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var mate := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 1), {Stats.Stat.LDR: 3})
+	_sm.join_squad(mate, attacker.squad)
+	var foe := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	var foe_mate := H.spawn_solo(self, _sm, ENEMY, Vector2i(2, 0), {Stats.Stat.LDR: 3})
+	_sm.join_squad(foe_mate, foe.squad)
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker, mate, foe, foe_mate]))
+	var sheet := BeatSheet.read(attacker.squad, plan)
+
+	for unit in [attacker, mate, foe, foe_mate]:
+		assert_bool(sheet.cast.has(unit)).override_failure_message(
+				"cast is missing %s" % unit).is_true()
+	# The bystander squadmate never acts and is never hit, so only the cast sweep puts its ground
+	# in the tear-out set.
+	assert_bool(sheet.cells.has(Vector2i(0, 1))).is_true()
+	_break_volleys(plan)
+
+
+# --- fact cases: hand-built plans -----------------------------------------------------------
+
+# One blast is one shot however many it hits -- #410 rules an AoE striking three victims a single
+# sweep, not three cuts. Grouping follows is_secondary_hit, the same read the resolver makes.
+func test_a_three_victim_volley_is_one_beat_in_strike_order() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var a := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	var b := H.spawn_solo(self, _sm, ENEMY, Vector2i(2, 0), {Stats.Stat.LDR: 3})
+	var c := H.spawn_solo(self, _sm, ENEMY, Vector2i(3, 0), {Stats.Stat.LDR: 3})
+
+	var plan := ResolvedPlan.new()
+	var victims: Array[Unit] = [a, b, c]
+	plan.attacks.assign(AttackAction.create_volley(attacker, Vector2i(0, 0), Vector2i(1, 0),
+			victims, attacker.get_equipped_weapon().template.main_attack))
+
+	var sheet := BeatSheet.read(attacker.squad, plan)
+	var volleys := _of_kind(sheet, BeatSheet.Kind.VOLLEY)
+	assert_int(volleys.size()).is_equal(1)
+	assert_int(volleys[0].actions.size()).is_equal(3)
+	assert_object(volleys[0].victims[0]).is_same(a)
+	assert_object(volleys[0].victims[1]).is_same(b)
+	assert_object(volleys[0].victims[2]).is_same(c)
+	_break_volleys(plan)
+
+
+# Two separate aims stay two beats -- the control for the case above. Without it, a grouping bug
+# that merged everything into one beat would still pass the three-victim assertion.
+func test_two_separate_aims_stay_two_beats() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var a := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	var b := H.spawn_solo(self, _sm, ENEMY, Vector2i(2, 0), {Stats.Stat.LDR: 3})
+
+	var plan := ResolvedPlan.new()
+	plan.attacks.append(H.stamped_attack(attacker, a))
+	plan.attacks.append(H.stamped_attack(attacker, b))
+
+	var sheet := BeatSheet.read(attacker.squad, plan)
+	assert_int(_of_kind(sheet, BeatSheet.Kind.VOLLEY).size()).is_equal(2)
+	_break_volleys(plan)
+
+
+# R7 skips a counter whose counter-er was downed earlier in the pass: it neither plays nor previews,
+# so it gets no beat -- and a counter phase that is ENTIRELY skipped earns no turnover either.
+func test_an_all_skipped_counter_phase_produces_no_beats_and_no_turnover() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var foe := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+
+	var plan := ResolvedPlan.new()
+	var source := H.stamped_attack(attacker, foe)
+	plan.attacks.append(source)
+	var victims: Array[Unit] = [attacker]
+	for counter in CounterAttackAction.create_counter_volley(foe, Vector2i(1, 0), victims, source):
+		counter.resolved = ResolvedOutcome.new()
+		counter.resolved.skipped = true
+		plan.counters.append(counter)
+
+	var sheet := BeatSheet.read(attacker.squad, plan)
+	assert_int(_index_of_kind(sheet, BeatSheet.Kind.TURNOVER)).is_equal(-1)
+	for beat in sheet.beats:
+		assert_bool(beat.is_counter).is_false()
+	_break_volleys(plan)
+
+
+# The camera pans ALONG a knockback and follows a drop all the way down (#520), and #521 tears out
+# every cell the flight crosses -- so the whole path lands in the cell set, not just its ends.
+func test_a_knockback_puts_its_whole_flight_in_the_cell_set() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var foe := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+
+	var plan := ResolvedPlan.new()
+	var attack := H.stamped_attack(attacker, foe)
+	attack.origin_cell = Vector2i(0, 0)
+	attack.target_cell = Vector2i(1, 0)
+	var out := ResolvedOutcome.new()
+	out.knockback_applied = true
+	out.knockback_from = Vector2i(1, 0)
+	out.knockback_path.assign([Vector2i(2, 0), Vector2i(3, 0), Vector2i(4, 0)])
+	out.knockback_to = Vector2i(4, 0)
+	out.fall_levels = 2
+	attack.resolved = out
+	plan.attacks.append(attack)
+
+	var sheet := BeatSheet.read(attacker.squad, plan)
+	var beat: BeatSheet.Beat = _of_kind(sheet, BeatSheet.Kind.VOLLEY)[0]
+	assert_bool(beat.has_knockback).is_true()
+	assert_bool(beat.has_fall).is_true()
+	for cell in [Vector2i(2, 0), Vector2i(3, 0), Vector2i(4, 0)]:
+		assert_bool(sheet.cells.has(cell)).override_failure_message(
+				"flight cell %s missing from the tear-out set" % cell).is_true()
+	_break_volleys(plan)
+
+
+# --- the resolver's new record --------------------------------------------------------------
+
+# iron_will_held means the cap BIT, not that the target wears the ability -- the held-breath beat
+# is "that should have killed them and did not", which a hit landing under the cap never was.
+func test_iron_will_records_the_clamp_only_when_it_actually_bites() -> void:
+	var big := _held_damage({Stats.Stat.STR: 60}, true)
+	assert_bool(big).is_true()
+
+	# Control 1: the same crushing hit with no Iron Will.
+	assert_bool(_held_damage({Stats.Stat.STR: 60}, false)).is_false()
+	# Control 2: Iron Will worn, but the hit lands under the cap -- nothing was held.
+	assert_bool(_held_damage({Stats.Stat.STR: 0}, true)).is_false()
+
+
+# Resolve one hit and report whether the Iron Will clamp recorded itself.
+func _held_damage(attacker_stats: Dictionary, wears_iron_will: bool) -> bool:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), attacker_stats)
+	var foe := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3, Stats.Stat.MHP: 99})
+	if wears_iron_will:
+		foe.worn_armor = _armor_granting(Abilities.Id.IRON_WILL)
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker, foe]))
+	var held: bool = plan.attacks[0].resolved.iron_will_held
+	_break_volleys(plan)
+	return held
+
+
+func _armor_granting(id: Abilities.Id) -> ArmorData:
+	var armor := ArmorData.new()
+	armor.display_name = "Test Armor"
+	var ability := AbilityData.new()
+	ability.id = id
+	ability.kind = AbilityData.AbilityKind.PASSIVE
+	armor.granted_abilities = [ability]
+	return armor
+
+
+# --- helpers ---------------------------------------------------------------------------------
+
+func _board_with(units_in: Array) -> BoardContext:
+	var units: Array[Unit] = []
+	units.assign(units_in)
+	return BoardContext.new(_sm.grid, units, _sm)
+
+
+func _of_kind(sheet: BeatSheet, kind: BeatSheet.Kind) -> Array:
+	var found: Array = []
+	for beat in sheet.beats:
+		if beat.kind == kind:
+			found.append(beat)
+	return found
+
+
+func _index_of_kind(sheet: BeatSheet, kind: BeatSheet.Kind) -> int:
+	for i in sheet.beats.size():
+		if sheet.beats[i].kind == kind:
+			return i
+	return -1
+
+
+# create_volley links siblings into a shared self-referential array (a RefCounted cycle, #35).
+func _break_volleys(plan: ResolvedPlan) -> void:
+	var empty: Array[AttackAction] = []
+	for atk in plan.attacks:
+		atk.volley = empty
+	for ctr in plan.counters:
+		ctr.volley = empty

--- a/tests/squad/test_beat_sheet.gd.uid
+++ b/tests/squad/test_beat_sheet.gd.uid
@@ -1,0 +1,1 @@
+uid://comi2v811goy4


### PR DESCRIPTION
Closes #524. Slice 1 of the #410 battle zoom — headless, no visuals, no art.

## What this is

`BeatSheet.read(squad, plan)` turns one resolved pass into the shot list every later slice consumes: the **cast** (the acting squad plus every squad it strikes, all members), the **touched-cell set** (attacker origins, aimed cells, whole knockback flights and their landings, terrain deposits, plus the standing cell of any cast member none of that mentions), and the ordered **beat list**.

It computes no damage and no geometry. Law #2 — the zoom is a mirror, never an authority.

## Two things the umbrella got wrong about its own data, both in our favour

**`ResolvedOutcome` is richer than #410's description.** It lists "damage, hp before/after, knockback from/to, states, lethality"; the class also carries `knockback_path` — the *whole flight, cell by cell* — plus `knockback_landing_index`, `fall_levels`, `elevation_delta`, `removed`, `skipped`, `hp_before`. So #520's "the camera pans with the flight" and "follows them off the cliff" are **derivations, not builds**.

**Volley grouping already exists.** `AttackAction.volley` is shared across a volley with `is_secondary_hit` marking the non-lead members, and `PlanResolver.resolve_counters` already walks the flat array exactly that way. The sheet reuses that read rather than inventing a second one (Law #4).

## Beat order mirrors the executor, it does not restate it

`MOVES` → attack `VOLLEY`s in queue order → `CELL_EFFECTS` → `TURNOVER` → counter `VOLLEY`s → `CODA` per side-channel type in `SIDE_CHANNEL_ORDER`. A phase with nothing in it produces no beat, and an entirely-skipped counter phase earns no turnover either — the act break exists only when the defending line actually answers.

**A beat with no victim is legal and deliberate.** #47 lets a legal aim at empty ground resolve as a cell attack (`target` stays null); it plays out and is where #50's terrain effects land, so it earns a beat with an empty victim list. Nothing may assume `victims[0]`.

## Weight is facts, never a number

Each beat carries the lethality rungs it contains, plus `has_knockback` / `has_fall` / `has_removal` / `iron_will_held`. It deliberately does **not** collapse these to a duration, and deliberately does not rank KILLED against MAIMED — both are #519's table under a chosen profile. Doing either here would be a second answer to a question #519 owns.

## One resolver addition

`ResolvedOutcome.iron_will_held` — the cap actually **bit** on this hit. Recorded *before* the clamp, because afterwards nothing can tell a capped hit from one that happened to land on the cap, and #410's held-breath beat ("that should have killed them and did not") cannot re-derive it. A recorded decision like `lethality`, not a derivation.

**Embedded-content sweep:** not applicable, stated explicitly rather than skipped. `ResolvedOutcome` is a runtime `RefCounted` produced fresh by every resolve pass — no `.tres` embeds it, nothing serializes it, so no committed fixture can predate the field.

## Knobs

None. There are no feel-tuned values in this slice; the durations that will need tuning are #519's, and they arrive with their table.

## Verification

`tests/squad/test_beat_sheet.gd`, 9 cases. Structural cases drive the **real** `resolve_plan` so the sheet is checked against what the resolver actually emits; fact cases hand-build a plan from `create_volley` / `create_counter_volley` (real stamping) for the falls and skips that would otherwise need terrain stood up.

Area run: `squad` — **185 cases / 26 suites, 0 failures, 0 orphans, 23.9s.** Full tree is CI's.

**Falsified — five mutants, each killed exactly the case it was aimed at** (checked which case reddened, since a mutant that reds an earlier case truncates the rest of the suite file):

| mutant | case that reddened |
|---|---|
| grouping ignores `is_secondary_hit` | `test_a_three_victim_volley_is_one_beat_in_strike_order` |
| `_absorb` keeps skipped members | `test_an_all_skipped_counter_phase_produces_no_beats_and_no_turnover` |
| turnover appended *after* its counters | `test_a_countered_attack_puts_the_turnover_before_the_counters` |
| `iron_will_held` = "wears it" not "bit" | `test_iron_will_records_the_clamp_only_when_it_actually_bites` |
| drop a beat with no victim | `test_a_swing_at_empty_ground_is_a_beat_with_no_victim` |

## Not launched

Nothing here renders, so there is nothing to see in the game yet — the first visible slice is #519 (dramatic timing on the board). Flagged rather than implied.
