### PR TITLE
#519: dramatic timing profiles - one beat table, CINEMATIC and BOARD

### DIFF
--- a/Classes/actions/OrderExecutor.gd
+++ b/Classes/actions/OrderExecutor.gd
@@ -77,15 +77,23 @@ func execute_orders(unit):
 				side_channel[action.action_type] = []
 			side_channel[action.action_type].append(action)
 
-	# One beat for the whole pass (#118). Keyed on the SAME is_ai_faction read the concede above
-	# makes, so a hotseat faction with AI off is a human and paces like one: an AI plan is being
-	# read for the first time, a player's was authored by the person watching it.
-	var beat: float = Pacing.AI_ACTION if game.ai_controller.is_ai_faction(squad.leader.get_faction()) else Pacing.PLAYER_ACTION
+	# The pass's own reading of itself (#524), consulted for PAUSES ONLY -- every action below still
+	# executes in this function's phase order, so nothing here can reorder playback (Law #2).
+	var sheet := BeatSheet.read(squad, plan)
+	var profile := Pacing.active_profile()
+	# Keyed on the SAME is_ai_faction read the concede above makes, so a hotseat faction with AI off
+	# is a human and paces like one: an AI plan is being read for the first time, a player's was
+	# authored by the person watching it. CINEMATIC ignores the fork (#410); BOARD keeps it.
+	var is_ai: bool = game.ai_controller.is_ai_faction(squad.leader.get_faction())
+	var beat: float = Pacing.base_for(profile, is_ai)
 
 	await _execute_action_phase_parallel(move_actions)
-	await _execute_action_sequence(plan.attacks, beat)
+	await _execute_action_sequence(plan.attacks, beat, _beat_holds(sheet.volleys(false), profile, is_ai))
 	_apply_cell_effects(plan.cell_effects)
-	await _execute_action_sequence(plan.counters, beat)
+	# The act break, held once between the two montages rather than folded into the first counter --
+	# a turnover the counters then pace on top of, not instead of.
+	await Pacing.beat(self, Pacing.duration_for(sheet.turnover(), profile, is_ai) if sheet.turnover() != null else 0.0)
+	await _execute_action_sequence(plan.counters, beat, _beat_holds(sheet.volleys(true), profile, is_ai))
 	for type in BaseAction.SIDE_CHANNEL_ORDER:
 		var batch: Array = side_channel.get(type, [])
 		await _execute_action_sequence(batch, beat)
@@ -171,17 +179,32 @@ func _execute_action_phase_parallel(actions: Array):
 # (the parallel move phase, then each side-channel batch) with no separate between-phases pause, and
 # leaves no trailing pause before the squad's turn ends. An empty batch returns above, so a phase
 # with nothing in it costs nothing.
-func _execute_action_sequence(actions: Array, beat: float = 0.0):
+func _execute_action_sequence(actions: Array, beat: float = 0.0, holds: Dictionary = {}):
 	if actions.is_empty():
 		return
 
 	for action in actions:
-		await Pacing.beat(self, beat)
+		# With a hold schedule, only the action that OPENS a beat pauses -- one blast is one moment
+		# however many it hits (#410), so a three-victim volley holds once instead of three times.
+		# Without one (the side-channel tail) every action takes the flat base beat, as before.
+		var hold: float = float(holds.get(action, 0.0)) if not holds.is_empty() else beat
+		await Pacing.beat(self, hold)
 		action.begin_execution()
 		action.execute()
 
 		while not action.execution_complete:
 			await get_tree().process_frame
+
+# Pause schedule for one phase: the action that OPENS each beat -> how long to hold before it.
+# Keyed by the beat's first SURVIVING member, so a volley whose lead was skipped (R7 downs the
+# counter-er) still pauses before the member that actually swings. Every action is executed either
+# way -- a skipped one is already a no-op inside AttackAction.execute; this decides only WHEN.
+func _beat_holds(beats: Array[BeatSheet.Beat], profile: Pacing.Profile, is_ai: bool) -> Dictionary:
+	var holds: Dictionary = {}
+	for beat in beats:
+		if not beat.actions.is_empty():
+			holds[beat.actions[0]] = Pacing.duration_for(beat, profile, is_ai)
+	return holds
 
 # Play the resolved terrain deposits into the live store, then redraw the board (#50). Runs after
 # the attack phase that produced them.

--- a/Classes/actions/resolution/BeatSheet.gd
+++ b/Classes/actions/resolution/BeatSheet.gd
@@ -85,6 +85,24 @@ var cast: Array[Unit] = []
 var cells: Array[Vector2i] = []
 
 
+# The VOLLEY beats of one phase, in order. OrderExecutor's pause schedule reads these; the
+# punctuation beats around them are not things it executes.
+func volleys(counter: bool) -> Array[Beat]:
+	var found: Array[Beat] = []
+	for beat in beats:
+		if beat.kind == Kind.VOLLEY and beat.is_counter == counter:
+			found.append(beat)
+	return found
+
+
+# The act break before the counters, or null when the defending line never answers.
+func turnover() -> Beat:
+	for beat in beats:
+		if beat.kind == Kind.TURNOVER:
+			return beat
+	return null
+
+
 static func read(squad: Squad, plan: ResolvedPlan) -> BeatSheet:
 	var sheet := BeatSheet.new()
 	if squad == null or plan == null:

--- a/Classes/core/Pacing.gd
+++ b/Classes/core/Pacing.gd
@@ -1,9 +1,8 @@
 extends Object
 class_name Pacing
 
-# How long turn playback PAUSES so a human can read it (#118). A tuning table in the shape of
-# UiLayers -- five numbers, one reader each, named beside each other so they can be tuned as a set
-# instead of hunted across four files. Not a system: nothing here decides anything.
+# How long turn playback PAUSES so a human can read it (#118, widened into a beat table by #519).
+# Named beside each other so they can be tuned as a set instead of hunted across four files.
 #
 # Execution is pure playback of an already-resolved plan (R3), so a beat changes only WHEN frames
 # land -- never what the queue claimed or what the resolver computed (Law #2).
@@ -12,12 +11,88 @@ class_name Pacing
 # safety property, not a convenience: OrderExecutor.execute_orders is awaited directly by the
 # suite, so a literal timer at an await site would put real wall clock on every case that resolves
 # a plan.
+#
+# STATIC VAR, NOT CONST, since #519: every value here is tuned from the Game tab's Playback group,
+# and a const is a slider that moves nothing. Same move ATTACK_MODULATE made for #212.
 
-const AI_SQUAD_PAN := 0.7     # camera glide from squad to squad -- CameraController.pan_to
-const AI_PLAN_READ := 0.6     # AI squad's plan is drawn; hold before it resolves -- AIController
-const AI_ACTION := 0.45       # between sequential actions in an AI pass -- OrderExecutor
-const PLAYER_ACTION := 0.0    # the same gap on the player's own Execute -- deliberately none (dev, 2026-08-10)
-const TURN_HANDOFF := 1.0     # hold at every faction turn start -- game.start_faction_turn
+enum Profile { BOARD, CINEMATIC }
+
+# --- the pass beats (#118) -------------------------------------------------------------------
+
+static var AI_SQUAD_PAN := 0.7     # camera glide from squad to squad -- CameraController.pan_to
+static var AI_PLAN_READ := 0.6     # AI squad's plan is drawn; hold before it resolves -- AIController
+static var AI_ACTION := 0.45       # BOARD base beat on an AI pass -- an unread plan
+static var PLAYER_ACTION := 0.3    # BOARD base beat on the player's own Execute (#519)
+static var TURN_HANDOFF := 1.0     # hold at every faction turn start -- game.start_faction_turn
+
+# PLAYER_ACTION was 0.0 from #118 until #519 -- "deliberately none" (dev, 2026-08-10), reversed on
+# 2026-08-26: "small pauses everywhere", because a pass with no gap at all is what made the health
+# readouts flash in and out (#475, subsumed) and battles read "way too fast".
+
+# --- the beat shape (#519, umbrella #410) ----------------------------------------------------
+
+# CINEMATIC does not fork on whose plan it is: #410 rules the zoom fires for all combats, AI-vs-AI
+# included, because an enemy assault deserves the drama too.
+static var CINEMATIC_ACTION := 0.4
+
+# What a beat earns for what it WAS. These do not stack -- the loudest single hold wins -- so the
+# drama ranking is whatever these NUMBERS say rather than an order written into code. Tune
+# HOLD_KNOCKBACK above HOLD_DOWN and a shove outranks a death, deliberately.
+static var HOLD_DOWN := 0.6        # a unit goes down, is killed, maimed, or removed from the board
+static var HOLD_CRISIS := 0.9      # someone stands up surged instead of falling
+static var HOLD_IRON_WILL := 0.45  # the cap BIT: that should have killed them and did not
+static var HOLD_KNOCKBACK := 0.2   # the hit shoved its target
+static var HOLD_TURNOVER := 0.5    # the act break: the defending line raises weapons
+
+# How much of a hold actually applies, per profile. BOARD ships at 0.0 -- flat, "small pauses
+# everywhere" (dev, 2026-08-26) -- so the shape exists but is dialled out rather than absent. That
+# is the whole reason the holds are separate from the base: wanting shape on the plain board later
+# is one number, not a restructure.
+static var BOARD_DRAMA := 0.0
+static var CINEMATIC_DRAMA := 1.0
+
+
+# Which profile playback is running under. ONE answer, so a caller never re-reads the setting.
+static func active_profile() -> Profile:
+	return Profile.CINEMATIC if PlayerSettings.is_on(PlayerSettings.Setting.BATTLE_ZOOM) else Profile.BOARD
+
+
+# How long to hold before this beat. The one collapse from a beat's FACTS to a length -- BeatSheet
+# deliberately carries neither a duration nor a severity ranking, because both are this table's.
+static func duration_for(beat: BeatSheet.Beat, profile: Profile, is_ai: bool) -> float:
+	if beat == null:
+		return 0.0
+	return base_for(profile, is_ai) + drama_of(profile) * hold_for(beat)
+
+
+static func base_for(profile: Profile, is_ai: bool) -> float:
+	if profile == Profile.CINEMATIC:
+		return CINEMATIC_ACTION
+	return AI_ACTION if is_ai else PLAYER_ACTION
+
+
+static func drama_of(profile: Profile) -> float:
+	return CINEMATIC_DRAMA if profile == Profile.CINEMATIC else BOARD_DRAMA
+
+
+# The loudest hold this beat earns, by VALUE rather than by rung order (see the holds above).
+static func hold_for(beat: BeatSheet.Beat) -> float:
+	if beat.kind == BeatSheet.Kind.TURNOVER:
+		return HOLD_TURNOVER
+	var hold := 0.0
+	if beat.has_removal \
+			or beat.has_lethality(ResolvedOutcome.Lethality.DOWNED) \
+			or beat.has_lethality(ResolvedOutcome.Lethality.KILLED) \
+			or beat.has_lethality(ResolvedOutcome.Lethality.MAIMED):
+		hold = maxf(hold, HOLD_DOWN)
+	if beat.has_lethality(ResolvedOutcome.Lethality.CRISIS):
+		hold = maxf(hold, HOLD_CRISIS)
+	if beat.iron_will_held:
+		hold = maxf(hold, HOLD_IRON_WILL)
+	if beat.has_knockback:
+		hold = maxf(hold, HOLD_KNOCKBACK)
+	return hold
+
 
 static func beat(host: Node, seconds: float) -> void:
 	if seconds <= 0.0 or DisplayServer.get_name() == "headless":

--- a/Classes/core/PlayerSettings.gd
+++ b/Classes/core/PlayerSettings.gd
@@ -23,6 +23,7 @@ enum Setting {
 	ALWAYS_SHOW_SQUAD_RINGS,
 	SHOW_DIALOG,
 	PHOTOSENSITIVITY,
+	BATTLE_ZOOM,
 }
 
 # Per-setting metadata. Literal-only, so it can be a compile-time const (the Experiments.DEFS shape).
@@ -49,6 +50,11 @@ const DEFS := {
 		"title": "Photosensitivity toggle",
 		"desc": "Hold flickering and strobing effects (like fire) at a steady brightness instead of animating them. For players sensitive to flashing lights.",
 		"default": false,
+	},
+	Setting.BATTLE_ZOOM: {
+		"title": "Battle zoom",
+		"desc": "Play out each clash with dramatic timing -- a killing blow, a Crisis or a last-gasp survival get held on. Turn off for a plainer, quicker pass.",
+		"default": true,
 	},
 }
 

--- a/Classes/dev/GameKnobs.gd
+++ b/Classes/dev/GameKnobs.gd
@@ -260,6 +260,7 @@ const OVERLAYS_SCRIPT := "res://Classes/presentation/BoardOverlays.gd"
 const OVERLAY_MANAGER_SCRIPT := "res://Classes/board/OverlayManager.gd"
 const MOVEMENT_SCRIPT := "res://Classes/units/MovementComponent.gd"
 const ACTION_MENU_SCRIPT := "res://Classes/ui/ActionMenuController.gd"
+const PACING_SCRIPT := "res://Classes/core/Pacing.gd"
 
 const CLASS_KNOBS: Array[Dictionary] = [
 	{"group": "Board markup colours", "label": "Move fill", "layer": BoardOverlays.Layer.MOVE,
@@ -327,6 +328,40 @@ const CLASS_KNOBS: Array[Dictionary] = [
 	{"group": "Playback", "label": "Void fall time", "static": "VOID_PLUMMET_SECONDS",
 		"script": MOVEMENT_SCRIPT, "min": 0.0, "max": 4.0, "step": 0.05,
 		"tip": "How long that fall takes, in seconds. Zero removes the unit at the lip with no fall at all -- the pre-#431 behaviour. Does not affect the preview arrow, only the playback."},
+
+	# The beat table (#519, umbrella #410). Playback pacing had never had a door -- these are the
+	# five #118 constants plus the battle-beat shape, all read at each pass, so a change applies
+	# from the next Execute with nothing standing to re-apply it to.
+	{"group": "Playback", "label": "Beat: your own Execute", "static": "PLAYER_ACTION",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 2.0, "step": 0.05,
+		"tip": "Base pause before each blast on YOUR pass, in seconds, with the battle zoom off. Was 0.0 until 2026-08-26 -- no gap at all is what made health readouts flash in and out. Zero restores that."},
+	{"group": "Playback", "label": "Beat: an AI pass", "static": "AI_ACTION",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 2.0, "step": 0.05,
+		"tip": "The same base pause on an AI faction's pass, zoom off. Longer than yours on purpose: their plan is being read for the first time, yours was authored by the person watching it."},
+	{"group": "Playback", "label": "Beat: battle zoom on", "static": "CINEMATIC_ACTION",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Base pause before each blast with the battle zoom ON. Does not fork on whose pass it is -- the zoom fires for every combat, enemy assaults included."},
+	{"group": "Playback", "label": "Drama: zoom off", "static": "BOARD_DRAMA",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 2.0, "step": 0.05,
+		"tip": "How much of the holds below apply with the zoom off. Ships at 0 -- flat, small pauses everywhere. Raise it to let a death land harder than a scratch on the plain board too."},
+	{"group": "Playback", "label": "Drama: zoom on", "static": "CINEMATIC_DRAMA",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "The same multiplier with the zoom on. At 0 the zoom paces flat; above 1 every big moment stretches together, so this is the one dial for 'more dramatic' overall."},
+	{"group": "Playback", "label": "Hold: a unit goes down", "static": "HOLD_DOWN",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time a blast earns for downing, killing, maiming or removing someone. Holds do NOT stack -- the largest single one wins -- so these numbers ARE the drama ranking. Set this under the shove hold and a shove outranks a death."},
+	{"group": "Playback", "label": "Hold: Crisis", "static": "HOLD_CRISIS",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time when someone stands up surged instead of falling. The loudest thing that can happen to a unit, so it ships as the longest hold."},
+	{"group": "Playback", "label": "Hold: Iron Will save", "static": "HOLD_IRON_WILL",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time when the Iron Will cap actually BIT -- that should have killed them and did not. The held breath, as against the blow that lands."},
+	{"group": "Playback", "label": "Hold: a shove", "static": "HOLD_KNOCKBACK",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time when the hit knocked its target back. Pre-set small: a shove is worth a moment, not the moment a death gets."},
+	{"group": "Playback", "label": "Hold: counter turnover", "static": "HOLD_TURNOVER",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "The act break between the attacker's last swing and the defending line's answer. Held once per pass, not per counter."},
 
 	# The action ring (#467). Statics on a TRANSIENT node, which is why they are class knobs: the
 	# menu exists only while the player holds it open, so there is no standing property for a KNOBS
@@ -459,6 +494,16 @@ static func read_static(name: String) -> Variant:
 		"MOVE_ARROW_MODULATE": return OverlayManager.MOVE_ARROW_MODULATE
 		"INVALID_ARROW_MODULATE": return OverlayManager.INVALID_ARROW_MODULATE
 		"TRAILING_ARROW_MODULATE": return OverlayManager.TRAILING_ARROW_MODULATE
+		"PLAYER_ACTION": return Pacing.PLAYER_ACTION
+		"AI_ACTION": return Pacing.AI_ACTION
+		"CINEMATIC_ACTION": return Pacing.CINEMATIC_ACTION
+		"BOARD_DRAMA": return Pacing.BOARD_DRAMA
+		"CINEMATIC_DRAMA": return Pacing.CINEMATIC_DRAMA
+		"HOLD_DOWN": return Pacing.HOLD_DOWN
+		"HOLD_CRISIS": return Pacing.HOLD_CRISIS
+		"HOLD_IRON_WILL": return Pacing.HOLD_IRON_WILL
+		"HOLD_KNOCKBACK": return Pacing.HOLD_KNOCKBACK
+		"HOLD_TURNOVER": return Pacing.HOLD_TURNOVER
 		"SHOVE_SLIDE_SPEED": return MovementComponent.SHOVE_SLIDE_SPEED
 		"SHOVE_FALL_SPEED": return MovementComponent.SHOVE_FALL_SPEED
 		"VOID_PLUMMET_CELLS": return MovementComponent.VOID_PLUMMET_CELLS
@@ -500,6 +545,38 @@ static func write_static(host: Node3D, name: String, value: Variant) -> void:
 		"MOVE_ARROW_MODULATE": OverlayManager.MOVE_ARROW_MODULATE = value
 		"INVALID_ARROW_MODULATE": OverlayManager.INVALID_ARROW_MODULATE = value
 		"TRAILING_ARROW_MODULATE": OverlayManager.TRAILING_ARROW_MODULATE = value
+		# The beat table (#519). Every one of these is read at the START of a pass, so there is never
+		# a standing pause to re-apply one to -- SHOVE_SLIDE_SPEED's early return, same reason.
+		"PLAYER_ACTION":
+			Pacing.PLAYER_ACTION = value
+			return
+		"AI_ACTION":
+			Pacing.AI_ACTION = value
+			return
+		"CINEMATIC_ACTION":
+			Pacing.CINEMATIC_ACTION = value
+			return
+		"BOARD_DRAMA":
+			Pacing.BOARD_DRAMA = value
+			return
+		"CINEMATIC_DRAMA":
+			Pacing.CINEMATIC_DRAMA = value
+			return
+		"HOLD_DOWN":
+			Pacing.HOLD_DOWN = value
+			return
+		"HOLD_CRISIS":
+			Pacing.HOLD_CRISIS = value
+			return
+		"HOLD_IRON_WILL":
+			Pacing.HOLD_IRON_WILL = value
+			return
+		"HOLD_KNOCKBACK":
+			Pacing.HOLD_KNOCKBACK = value
+			return
+		"HOLD_TURNOVER":
+			Pacing.HOLD_TURNOVER = value
+			return
 		"SHOVE_SLIDE_SPEED":
 			MovementComponent.SHOVE_SLIDE_SPEED = value
 			return   # read at each shove -- nothing standing to re-apply

--- a/tests/core/test_beat_timing.gd
+++ b/tests/core/test_beat_timing.gd
@@ -1,0 +1,165 @@
+# The beat table (#519, umbrella #410): how a BeatSheet.Beat's facts become a pause length.
+#
+# NOTHING HERE ASSERTS WHAT A VALUE IS. Every one of these numbers is tuned by feel from the Game
+# tab's Playback group, and tuning must never redden the suite -- test_pacing.gd's own law says so
+# and this is its sibling. So every case pins a RELATIONSHIP that survives any tuning: which beat
+# outlasts which, which profile is the quieter one, whether a fork exists at all.
+#
+# Pacing's values are static vars that outlive a case, so the whole table is snapshotted and put
+# back around each one -- a suite that tuned a knob and walked away would poison every case after
+# it, which is exactly the class of bug #449 found in PlayerSettings.
+extends GdUnitTestSuite
+
+const BOARD := Pacing.Profile.BOARD
+const CINEMATIC := Pacing.Profile.CINEMATIC
+
+var _saved: Dictionary = {}
+
+
+func before_test() -> void:
+	PlayerSettings.reset_for_test()
+	_saved = {
+		"player": Pacing.PLAYER_ACTION, "ai": Pacing.AI_ACTION, "cine": Pacing.CINEMATIC_ACTION,
+		"bd": Pacing.BOARD_DRAMA, "cd": Pacing.CINEMATIC_DRAMA,
+		"down": Pacing.HOLD_DOWN, "crisis": Pacing.HOLD_CRISIS, "iron": Pacing.HOLD_IRON_WILL,
+		"knock": Pacing.HOLD_KNOCKBACK, "turn": Pacing.HOLD_TURNOVER,
+	}
+
+
+func after_test() -> void:
+	Pacing.PLAYER_ACTION = _saved["player"]
+	Pacing.AI_ACTION = _saved["ai"]
+	Pacing.CINEMATIC_ACTION = _saved["cine"]
+	Pacing.BOARD_DRAMA = _saved["bd"]
+	Pacing.CINEMATIC_DRAMA = _saved["cd"]
+	Pacing.HOLD_DOWN = _saved["down"]
+	Pacing.HOLD_CRISIS = _saved["crisis"]
+	Pacing.HOLD_IRON_WILL = _saved["iron"]
+	Pacing.HOLD_KNOCKBACK = _saved["knock"]
+	Pacing.HOLD_TURNOVER = _saved["turn"]
+	PlayerSettings.reset_for_test()
+
+
+# --- the profile fork -------------------------------------------------------------------------
+
+# The dev's 2026-08-26 ruling, as a property rather than a number: with the zoom OFF every blast
+# holds for the same length, whatever happened in it. Ships as BOARD_DRAMA = 0.
+func test_the_board_profile_paces_a_kill_and_a_scratch_alike() -> void:
+	assert_float(Pacing.duration_for(_kill(), BOARD, false)) \
+		.override_failure_message("BOARD ships FLAT -- a death and a scratch hold the same") \
+		.is_equal_approx(Pacing.duration_for(_chip(), BOARD, false), 0.0001)
+
+
+# ... and the shape is DIALLED OUT, not absent: raising the one multiplier brings it back without
+# any other change. That is the whole reason the holds are separate from the base.
+func test_raising_board_drama_brings_the_shape_back() -> void:
+	Pacing.BOARD_DRAMA = 1.0
+	assert_float(Pacing.duration_for(_kill(), BOARD, false)) \
+		.is_greater(Pacing.duration_for(_chip(), BOARD, false))
+
+
+func test_the_cinematic_profile_holds_longer_on_a_kill_than_on_a_scratch() -> void:
+	assert_float(Pacing.duration_for(_kill(), CINEMATIC, false)) \
+		.is_greater(Pacing.duration_for(_chip(), CINEMATIC, false))
+
+
+# --- whose pass it is -------------------------------------------------------------------------
+
+# BOARD keeps #118's fork: an AI plan is being read for the first time, a player's was authored by
+# the person watching it.
+func test_board_still_paces_an_ai_pass_apart_from_the_players_own() -> void:
+	assert_float(Pacing.duration_for(_chip(), BOARD, true)) \
+		.is_not_equal(Pacing.duration_for(_chip(), BOARD, false))
+
+
+# CINEMATIC drops it: #410 rules the zoom fires for every combat, enemy assaults included.
+func test_the_zoom_does_not_care_whose_pass_it_is() -> void:
+	assert_float(Pacing.duration_for(_kill(), CINEMATIC, true)) \
+		.is_equal_approx(Pacing.duration_for(_kill(), CINEMATIC, false), 0.0001)
+
+
+# --- the holds --------------------------------------------------------------------------------
+
+# Holds do NOT stack -- the loudest single one wins -- and "loudest" is read off the NUMBERS, so
+# the drama ranking is tunable rather than written into code. Falsifiable both ways: this case
+# fails if they sum, and fails again if the ranking is hardcoded by rung.
+func test_the_loudest_hold_wins_and_the_ranking_follows_the_knobs() -> void:
+	Pacing.HOLD_DOWN = 0.5
+	Pacing.HOLD_KNOCKBACK = 0.1
+	var both := _kill()
+	both.has_knockback = true
+	# Not the sum: the death alone decides it.
+	assert_float(Pacing.hold_for(both)).is_equal_approx(0.5, 0.0001)
+
+	# Now make a shove the louder thing. Nothing else changes.
+	Pacing.HOLD_KNOCKBACK = 0.9
+	assert_float(Pacing.hold_for(both)).is_equal_approx(0.9, 0.0001)
+
+
+func test_the_turnover_beat_earns_the_turnover_hold() -> void:
+	Pacing.HOLD_TURNOVER = 0.77
+	assert_float(Pacing.hold_for(_turnover())).is_equal_approx(0.77, 0.0001)
+
+
+# An Iron Will save is its OWN beat, not a quiet one: the cap bit, so something happened. Pinned
+# because the beat carries no lethality at all in that case -- the unit is still standing.
+func test_an_iron_will_save_outlasts_a_plain_scratch() -> void:
+	var held := _chip()
+	held.iron_will_held = true
+	assert_float(Pacing.duration_for(held, CINEMATIC, false)) \
+		.is_greater(Pacing.duration_for(_chip(), CINEMATIC, false))
+
+
+# --- which profile is live --------------------------------------------------------------------
+
+func test_the_profile_follows_the_battle_zoom_setting() -> void:
+	PlayerSettings.set_on(PlayerSettings.Setting.BATTLE_ZOOM, true)
+	assert_int(Pacing.active_profile()).is_equal(CINEMATIC)
+	PlayerSettings.set_on(PlayerSettings.Setting.BATTLE_ZOOM, false)
+	assert_int(Pacing.active_profile()).is_equal(BOARD)
+
+
+# --- the safety property, on the new path -----------------------------------------------------
+
+# test_pacing.gd pins this for beat() itself; repeated here because duration_for is a NEW way to
+# reach it, and a table that can return a big number is exactly what would put wall clock on the
+# nine suites that await execute_orders.
+func test_a_computed_beat_still_costs_a_headless_run_nothing() -> void:
+	assert_str(DisplayServer.get_name()).is_equal("headless")
+	Pacing.CINEMATIC_ACTION = 30.0
+	Pacing.HOLD_CRISIS = 30.0
+	var before := Engine.get_process_frames()
+	await Pacing.beat(self, Pacing.duration_for(_crisis(), CINEMATIC, false))
+	assert_int(Engine.get_process_frames() - before) \
+		.override_failure_message("a computed beat waited headlessly -- every resolve pass now pays wall clock") \
+		.is_equal(0)
+
+
+# --- beat builders ----------------------------------------------------------------------------
+
+func _chip() -> BeatSheet.Beat:
+	var beat := BeatSheet.Beat.new()
+	beat.kind = BeatSheet.Kind.VOLLEY
+	beat.lethalities.append(ResolvedOutcome.Lethality.NONE)
+	return beat
+
+
+func _kill() -> BeatSheet.Beat:
+	var beat := BeatSheet.Beat.new()
+	beat.kind = BeatSheet.Kind.VOLLEY
+	beat.lethalities.append(ResolvedOutcome.Lethality.KILLED)
+	return beat
+
+
+func _crisis() -> BeatSheet.Beat:
+	var beat := BeatSheet.Beat.new()
+	beat.kind = BeatSheet.Kind.VOLLEY
+	beat.lethalities.append(ResolvedOutcome.Lethality.CRISIS)
+	return beat
+
+
+func _turnover() -> BeatSheet.Beat:
+	var beat := BeatSheet.Beat.new()
+	beat.kind = BeatSheet.Kind.TURNOVER
+	beat.is_counter = true
+	return beat

--- a/tests/core/test_beat_timing.gd.uid
+++ b/tests/core/test_beat_timing.gd.uid
@@ -1,0 +1,1 @@
+uid://cyv0lfm3jtxbf

--- a/tests/squad/test_beat_sheet.gd
+++ b/tests/squad/test_beat_sheet.gd
@@ -231,6 +231,67 @@ func _held_damage(attacker_stats: Dictionary, wears_iron_will: bool) -> bool:
 	return held
 
 
+# --- the wire into the beat table (#519) ------------------------------------------------------
+
+# The sheet's whole point downstream is that a beat KNOWS what it was before anything plays. Both
+# ends were pinned separately -- the sheet builds beats, the table reads their facts -- and this is
+# the case that fails if a REAL lethal blow reaches the table looking like a scratch. Asserted as a
+# relationship (something to hold for vs nothing) rather than a rung, because whether a felled unit
+# reads DOWNED or KILLED is the lifecycle rules' business, not this suite's.
+func test_a_real_felling_blow_reaches_the_beat_table_as_one() -> void:
+	var lethal := _hold_for_a_hit({Stats.Stat.STR: 60}, 1)
+	var scratch := _hold_for_a_hit({Stats.Stat.STR: 0}, 99)
+
+	assert_float(lethal).override_failure_message(
+			"a blow that felled someone earned no hold -- the sheet's facts are not reaching Pacing").is_greater(0.0)
+	assert_float(scratch).override_failure_message(
+			"a scratch earned a hold -- every beat now reads as a big moment").is_equal_approx(0.0, 0.0001)
+
+
+# The PAUSE SCHEDULE itself: one hold per volley, keyed on the action that opens it, valued by the
+# table. Pinned here because a schedule that came back empty would silently restore the old
+# per-action pacing and nothing headless could see it -- Pacing.beat costs a headless run nothing
+# by design, so the await it feeds is invisible. This closes everything up to that await.
+func test_a_volley_gets_ONE_hold_on_the_action_that_opens_it() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var a := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	var b := H.spawn_solo(self, _sm, ENEMY, Vector2i(2, 0), {Stats.Stat.LDR: 3})
+	var c := H.spawn_solo(self, _sm, ENEMY, Vector2i(3, 0), {Stats.Stat.LDR: 3})
+
+	var plan := ResolvedPlan.new()
+	var victims: Array[Unit] = [a, b, c]
+	plan.attacks.assign(AttackAction.create_volley(attacker, Vector2i(0, 0), Vector2i(1, 0),
+			victims, attacker.get_equipped_weapon().template.main_attack))
+
+	var sheet := BeatSheet.read(attacker.squad, plan)
+	var executor := OrderExecutor.new()
+	auto_free(executor)
+	var holds: Dictionary = executor._beat_holds(sheet.volleys(false), Pacing.Profile.BOARD, false)
+
+	# One entry for three hits: the blast is one moment, not three.
+	assert_int(holds.size()).override_failure_message(
+			"three hits took three pauses -- a volley is one moment (#410)").is_equal(1)
+	assert_bool(holds.has(plan.attacks[0])).override_failure_message(
+			"the hold is not on the action that OPENS the volley").is_true()
+	assert_float(holds[plan.attacks[0]]).is_equal_approx(
+			Pacing.duration_for(sheet.volleys(false)[0], Pacing.Profile.BOARD, false), 0.0001)
+	_break_volleys(plan)
+
+
+# Resolve one real hit and report what the beat it produces is worth to the table.
+func _hold_for_a_hit(attacker_stats: Dictionary, target_mhp: int) -> float:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), attacker_stats)
+	var foe := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3, Stats.Stat.MHP: target_mhp})
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker, foe]))
+	var sheet := BeatSheet.read(attacker.squad, plan)
+	var hold := Pacing.hold_for(sheet.volleys(false)[0])
+	_break_volleys(plan)
+	return hold
+
+
 func _armor_granting(id: Abilities.Id) -> ArmorData:
 	var armor := ArmorData.new()
 	armor.display_name = "Test Armor"


### PR DESCRIPTION
Closes #519. Also closes #475, which this subsumes. Slice 2 of the #410 battle zoom — board-only, no diorama, no new art.

## What this is

Playback pacing becomes a table over a beat's **facts**:

- a **base** per profile — the pause before every beat;
- five **holds** for what a beat *was* — a unit goes down, a Crisis, an Iron Will save, a shove, the counter turnover;
- a per-profile **drama** multiplier deciding how much of a hold applies.

**BOARD ships at drama 0** — flat, *"small pauses everywhere"* (dev, 2026-08-26). The shape exists but is dialled out rather than absent, which is the whole reason the holds are separate from the base: wanting shape on the plain board later is **one number**, not a restructure.

## Two reversals, both deliberate

**`PLAYER_ACTION` goes 0.0 → 0.3**, reversing its own `deliberately none (dev, 2026-08-10)` annotation. A pass with no gap at all is what made health readouts flash in and out — which is #475's whole complaint, and #475's own diagnosis. That ticket is closed as subsumed with its three *un*-answered questions written out, so the gate/linger decisions aren't silently lost.

**`Pacing`'s constants become `static var`.** A const is a knob that moves nothing — the move `ATTACK_MODULATE` made for #212.

## Knobs

All ten values, in the Game tab's existing **Playback** group (beside shove slide/fall speed): three bases, two drama multipliers, five holds. Playback pacing had never had a door.

Two things worth knowing while tuning:

- **Holds do not stack — the loudest single one wins — and "loudest" is read off the numbers.** So the drama ranking is *tunable*, not written into code: set the shove hold above the down hold and a shove outranks a death, deliberately.
- **`Drama: zoom off` is the one dial** if flat turns out too flat. Nothing else needs to move.

## Where it lands

`OrderExecutor` builds the sheet once and consults it for **pauses only** — every action still executes in `execute_orders`' own phase order, so nothing here can reorder playback (Law #2). Deliberately *not* driving playback from the sheet; that's #520's seam, and it would put Law #2 risk on a slice that doesn't need any.

The pause moves to the action that **opens** each volley, so a three-victim blast holds once instead of three times. **That changes the feel even with the zoom off** — flagging it because it's a real change to something you've been playing.

Two details that made this safe rather than lucky:
- A skipped counter's `execute()` is *already* a no-op, so the sheet dropping its beat costs nothing — every action still runs.
- The schedule is keyed on a beat's first **surviving** member, so a volley whose lead was skipped (R7 downs the counter-er) still pauses before the member that actually swings.

Ships `PlayerSettings.BATTLE_ZOOM` (default on), which today selects the profile and later gates the zoom itself.

**Embedded-content sweep:** not applicable. Nothing here adds a field to an embeddable content type — `Pacing` is a static class and `PlayerSettings` persists to `user://settings.cfg`, not to any `.tres`.

## Verification

`tests/core/test_beat_timing.gd` (10) + two new cases in `tests/squad/test_beat_sheet.gd`. **Nothing asserts what any value is** — `test_pacing.gd`'s own law says tuning must never redden the suite, so every case pins a relationship that survives any tuning.

Areas: `core` + `squad` **229/229**, and `squad core dev` **578/578** before the last case landed. 0 orphans, 0 failures. Full tree is CI's.

**Falsified — five mutants, each killed exactly the case it was aimed at:**

| mutant | case that reddened |
|---|---|
| holds STACK instead of loudest-wins | `test_the_loudest_hold_wins_and_the_ranking_follows_the_knobs` |
| BOARD ignores its own drama | `test_the_board_profile_paces_a_kill_and_a_scratch_alike` |
| schedule holds every volley member, not the lead | `test_a_volley_gets_ONE_hold_on_the_action_that_opens_it` |
| the sheet stops recording lethalities | `test_a_real_felling_blow_reaches_the_beat_table_as_one` |
| the profile ignores the player setting | `test_the_profile_follows_the_battle_zoom_setting` |

## What I could NOT verify, and it's the important part

**`Pacing.beat` returns instantly in a headless run — deliberately, as a safety property** (nine suites await `execute_orders`; a real timer there would put wall clock on every one). So the tests cover the table, the sheet's facts reaching it, and the pause *schedule* the executor builds — but **nothing headless can see the executor actually spending those durations.**

That last hop is a launch check and it's yours. Concretely: does a pass now read at a sensible speed, and does a death land harder than a scratch with the zoom on? If the answer is "close but not quite", it's a knob, not a rebuild.
