### PR TITLE
#520: the camera goes to the action, and playback waits for it

### DIFF
--- a/Classes/actions/AttackAction.gd
+++ b/Classes/actions/AttackAction.gd
@@ -175,6 +175,11 @@ func clear_preview_sprites():
 
 	preview_sprites.clear()
 
+# The victim. Null for a #47 cell attack, and the base's actor fallback is what covers that:
+# a swing at open ground is framed on the swinger.
+func aimed_at() -> Unit:
+	return target
+
 func get_target_name() -> String:
 	if target != null and is_instance_valid(target) and not target.is_queued_for_deletion():
 		return target.get_unit_name()

--- a/Classes/actions/BaseAction.gd
+++ b/Classes/actions/BaseAction.gd
@@ -76,6 +76,17 @@ func is_main_action() -> bool:
 func actor_can_perform() -> bool:
 	return true
 
+# Who this order is AIMED AT -- the unit it is done TO, rather than the one doing it. The default
+# is the actor, which is the honest answer for a verb that acts on itself (move, rally, reload);
+# Attack/Rescue/Intimidate/Guard override it with the `target` they each already store.
+#
+# Declared per Law #4: those four have held a private `var target: Unit` each, with no shared door,
+# since they were written -- this is the door, not a fifth copy. It exists because BeatSheet has to
+# ask the question of an order whose class it does not know (#520): a beat frames what is being
+# done to whom, and only the order can say who that is.
+func aimed_at() -> Unit:
+	return actor
+
 func get_actor_texture() -> Texture2D:
 	if actor == null or not is_instance_valid(actor):
 		return null

--- a/Classes/actions/GuardAction.gd
+++ b/Classes/actions/GuardAction.gd
@@ -30,6 +30,9 @@ func init(guarding_unit: Unit, warded_unit: Unit) -> void:
 	guard_range = guarding_unit.get_guard_range()
 	action_type = BaseAction.ActionType.GUARD
 
+func aimed_at() -> Unit:
+	return target   # the ward -- what a Guard is about is who it covers
+
 func execute() -> void:
 	begin_execution()
 	if target != null and is_instance_valid(target) and not target.is_queued_for_deletion():

--- a/Classes/actions/IntimidateAction.gd
+++ b/Classes/actions/IntimidateAction.gd
@@ -17,6 +17,9 @@ func init(intimidator: Unit, victim: Unit) -> void:
 	target = victim
 	action_type = BaseAction.ActionType.INTIMIDATE
 
+func aimed_at() -> Unit:
+	return target   # the one losing Will
+
 func execute() -> void:
 	begin_execution()
 	if target != null and is_instance_valid(target):

--- a/Classes/actions/OrderExecutor.gd
+++ b/Classes/actions/OrderExecutor.gd
@@ -87,16 +87,25 @@ func execute_orders(unit):
 	var is_ai: bool = game.ai_controller.is_ai_faction(squad.leader.get_faction())
 	var beat: float = Pacing.base_for(profile, is_ai)
 
+	# Playback owns where the camera looks for the rest of this pass (#520). SAVED and RESTORED, never
+	# cleared: an AI turn claims it for the whole turn and this runs inside one, so a blind release
+	# would unlock the camera mid-turn.
+	var camera_was_locked: bool = game.camera_controller.playback_locked
+	game.camera_controller.set_playback_locked(true)
+
 	await _execute_action_phase_parallel(move_actions)
-	await _execute_action_sequence(plan.attacks, beat, _beat_holds(sheet.volleys(false), profile, is_ai))
+	await _execute_action_sequence(plan.attacks, beat, _beat_holds(sheet.volleys(false), profile, is_ai),
+			_beat_subjects(sheet.volleys(false)))
 	_apply_cell_effects(plan.cell_effects)
 	# The act break, held once between the two montages rather than folded into the first counter --
 	# a turnover the counters then pace on top of, not instead of.
 	await Pacing.beat(self, Pacing.duration_for(sheet.turnover(), profile, is_ai) if sheet.turnover() != null else 0.0)
-	await _execute_action_sequence(plan.counters, beat, _beat_holds(sheet.volleys(true), profile, is_ai))
+	await _execute_action_sequence(plan.counters, beat, _beat_holds(sheet.volleys(true), profile, is_ai),
+			_beat_subjects(sheet.volleys(true)))
 	for type in BaseAction.SIDE_CHANNEL_ORDER:
 		var batch: Array = side_channel.get(type, [])
 		await _execute_action_sequence(batch, beat)
+	game.camera_controller.set_playback_locked(camera_was_locked)
 	# The last await has returned, so the pass is played out: released HERE rather than beside
 	# _end_squad_turn because everything below is synchronous (no frame renders between them) and
 	# the squad-validity bail below skips that call entirely.
@@ -179,7 +188,7 @@ func _execute_action_phase_parallel(actions: Array):
 # (the parallel move phase, then each side-channel batch) with no separate between-phases pause, and
 # leaves no trailing pause before the squad's turn ends. An empty batch returns above, so a phase
 # with nothing in it costs nothing.
-func _execute_action_sequence(actions: Array, beat: float = 0.0, holds: Dictionary = {}):
+func _execute_action_sequence(actions: Array, beat: float = 0.0, holds: Dictionary = {}, subjects: Dictionary = {}):
 	if actions.is_empty():
 		return
 
@@ -188,6 +197,12 @@ func _execute_action_sequence(actions: Array, beat: float = 0.0, holds: Dictiona
 		# however many it hits (#410), so a three-victim volley holds once instead of three times.
 		# Without one (the side-channel tail) every action takes the flat base beat, as before.
 		var hold: float = float(holds.get(action, 0.0)) if not holds.is_empty() else beat
+		# The camera goes FIRST and the action WAITS for it (#520, dev 2026-08-26) -- a blow that
+		# lands off-screen may as well not have happened. Same door AIController has always used, so
+		# the pan is one seam and one duration; headless it lands instantly like every other beat.
+		# Only a beat's OPENING action carries a subject, so a volley pans once and then plays.
+		if subjects.has(action):
+			await game.camera_controller.pan_to(subjects[action], Pacing.PLAYBACK_PAN)
 		await Pacing.beat(self, hold)
 		action.begin_execution()
 		action.execute()
@@ -205,6 +220,17 @@ func _beat_holds(beats: Array[BeatSheet.Beat], profile: Pacing.Profile, is_ai: b
 		if not beat.actions.is_empty():
 			holds[beat.actions[0]] = Pacing.duration_for(beat, profile, is_ai)
 	return holds
+
+# Who the camera frames for each beat, keyed the same way the hold schedule is (#520): the action
+# that OPENS the beat. A beat whose subject has already been freed is simply left out -- absence
+# means "don't move", which is the right answer when there is nothing left to look at.
+func _beat_subjects(beats: Array[BeatSheet.Beat]) -> Dictionary:
+	var subjects: Dictionary = {}
+	for beat in beats:
+		var who := beat.subject()
+		if who != null and not beat.actions.is_empty():
+			subjects[beat.actions[0]] = who
+	return subjects
 
 # Play the resolved terrain deposits into the live store, then redraw the board (#50). Runs after
 # the attack phase that produced them.

--- a/Classes/actions/OrderExecutor.gd
+++ b/Classes/actions/OrderExecutor.gd
@@ -93,6 +93,14 @@ func execute_orders(unit):
 	var camera_was_locked: bool = game.camera_controller.playback_locked
 	game.camera_controller.set_playback_locked(true)
 
+	# The camera goes to the walk and the walk WAITS for it (#520, dev 2026-08-26). Moves are
+	# parallel, so one subject is framed -- the leader when the leader is walking -- and pan_to's
+	# closing follow() carries the camera along beside it for free. No hold here: the pan IS the
+	# beat, and a pause would be dead air between pressing Execute and anything happening.
+	var walk := sheet.moves()
+	var walker: Unit = walk.subject() if walk != null else null
+	if walker != null:
+		await game.camera_controller.pan_to(walker, Pacing.PLAYBACK_PAN)
 	await _execute_action_phase_parallel(move_actions)
 	await _execute_action_sequence(plan.attacks, beat, _beat_holds(sheet.volleys(false), profile, is_ai),
 			_beat_subjects(sheet.volleys(false)))
@@ -102,9 +110,13 @@ func execute_orders(unit):
 	await Pacing.beat(self, Pacing.duration_for(sheet.turnover(), profile, is_ai) if sheet.turnover() != null else 0.0)
 	await _execute_action_sequence(plan.counters, beat, _beat_holds(sheet.volleys(true), profile, is_ai),
 			_beat_subjects(sheet.volleys(true)))
+	# The tail gets the same treatment the volleys do (dev 2026-08-26): a CODA beat per ORDER, so
+	# each rescue pans to the body it lifts and holds for it instead of the whole batch sharing one
+	# flat beat and one camera position.
 	for type in BaseAction.SIDE_CHANNEL_ORDER:
 		var batch: Array = side_channel.get(type, [])
-		await _execute_action_sequence(batch, beat)
+		var codas := sheet.codas(type)
+		await _execute_action_sequence(batch, beat, _beat_holds(codas, profile, is_ai), _beat_subjects(codas))
 	game.camera_controller.set_playback_locked(camera_was_locked)
 	# The last await has returned, so the pass is played out: released HERE rather than beside
 	# _end_squad_turn because everything below is synchronous (no frame renders between them) and
@@ -214,6 +226,7 @@ func _execute_action_sequence(actions: Array, beat: float = 0.0, holds: Dictiona
 # Keyed by the beat's first SURVIVING member, so a volley whose lead was skipped (R7 downs the
 # counter-er) still pauses before the member that actually swings. Every action is executed either
 # way -- a skipped one is already a no-op inside AttackAction.execute; this decides only WHEN.
+# Serves the side-channel tail unchanged, where a beat holds exactly one order.
 func _beat_holds(beats: Array[BeatSheet.Beat], profile: Pacing.Profile, is_ai: bool) -> Dictionary:
 	var holds: Dictionary = {}
 	for beat in beats:

--- a/Classes/actions/RescueAction.gd
+++ b/Classes/actions/RescueAction.gd
@@ -10,6 +10,9 @@ func init(rescuer: Unit, downed_ally: Unit) -> void:
 	target = downed_ally
 	action_type = BaseAction.ActionType.RESCUE
 
+func aimed_at() -> Unit:
+	return target   # the body, not the rescuer -- a pickup is read on who comes up
+
 func execute() -> void:
 	begin_execution()
 	if target != null and is_instance_valid(target) and target.is_downed():

--- a/Classes/actions/resolution/BeatSheet.gd
+++ b/Classes/actions/resolution/BeatSheet.gd
@@ -10,6 +10,9 @@ class_name BeatSheet
 # The beat order MIRRORS OrderExecutor.execute_orders and its phase order rather than restating
 # it: moves, attack volleys in queue order, cell effects, the counter turnover, counter volleys,
 # then the side-channel tail in SIDE_CHANNEL_ORDER. A phase with nothing in it produces no beat.
+# Mirroring is literal about GRANULARITY too, not just order: a volley is one beat because one
+# blast is one moment, and a side-channel verb is one beat EACH because execute_orders awaits them
+# one at a time. Where the two disagree, this is wrong and execution is right.
 #
 # Volley grouping is the RESOLVER's rule, not a second one: is_secondary_hit marks the non-lead
 # members (create_volley / create_counter_volley stamp it) and PlanResolver.resolve_counters
@@ -29,8 +32,10 @@ class Beat:
 	var kind: int = Kind.VOLLEY
 	var is_counter := false
 
-	# The volley's members in strike order. Empty on a punctuation beat.
-	var actions: Array[AttackAction] = []
+	# The orders this beat PLAYS, in execution order -- a volley's members in strike order, a MOVES
+	# beat's real moves, a CODA's single side-channel verb. Typed to the base so one field answers
+	# for every kind; empty only on punctuation (CELL_EFFECTS, TURNOVER).
+	var actions: Array[BaseAction] = []
 	var actor: Unit = null
 
 	# Aligned by index, and BOTH MAY BE EMPTY on a real beat: #47 lets a legal aim at cells with
@@ -43,6 +48,7 @@ class Beat:
 	var has_fall := false
 	var has_removal := false
 	var iron_will_held := false
+	var has_heal := false
 
 	# CODA only: which side-channel order this is (RESCUE, RALLY, GUARD, ...).
 	var coda_type: BaseAction.ActionType = BaseAction.ActionType.ATTACK
@@ -50,22 +56,30 @@ class Beat:
 	func has_lethality(rung: ResolvedOutcome.Lethality) -> bool:
 		return lethalities.has(rung)
 
-	# Who the camera goes to for this beat (#520). The first VICTIM, because what the player needs
-	# to read is what is being done to whom -- and the attacker is usually already in frame, since
-	# reach is short. Falls back to the actor for a beat with no victim at all, which #47's swing at
-	# open ground really is. Null on a punctuation beat: the turnover holds where it already looks.
+	# Who the camera goes to for this beat (#520). The ORDERS answer it -- BaseAction.aimed_at() --
+	# because what the player needs to read is what is being done to whom, and only the order knows
+	# who that is: a volley's victim, a rescue's body, a mover itself. The attacker is usually
+	# already in frame, since reach is short. Falls back to the beat's actor, which is what covers
+	# #47's swing at open ground. Null on a punctuation beat: the turnover holds where it looks.
+	#
+	# NOT read off `victims`: that list is aligned with `lethalities` for #519's table, and a beat
+	# with no victims (MOVES, CODA) still has a subject.
 	func subject() -> Unit:
-		for victim in victims:
-			if victim != null and is_instance_valid(victim):
-				return victim
+		for action in actions:
+			var who := action.aimed_at()
+			if who != null and is_instance_valid(who):
+				return who
 		return actor if actor != null and is_instance_valid(actor) else null
 
 	# Drop this volley's no-op members and read the surviving facts off their outcomes. R7 skips a
 	# counter-er, not a volley, so this runs AFTER grouping -- dropping a skipped LEAD any earlier
 	# would orphan its own secondaries into a beat of their own.
 	func _absorb() -> void:
-		var played: Array[AttackAction] = []
-		for attack in actions:
+		var played: Array[BaseAction] = []
+		for action in actions:
+			var attack := action as AttackAction
+			if attack == null:
+				continue
 			var out := attack.resolved
 			if out != null and out.skipped:
 				continue
@@ -79,6 +93,9 @@ class Beat:
 			has_fall = has_fall or out.fall_levels > 0
 			has_removal = has_removal or out.removed
 			iron_will_held = iron_will_held or out.iron_will_held
+			# The RESOLVER's own answer, like every other fact here -- never a re-read of
+			# fired_attack.heals. A heal that fired reads true even if the cap ate it.
+			has_heal = has_heal or out.heal_amount > 0
 		actions = played
 
 
@@ -113,26 +130,57 @@ func turnover() -> Beat:
 	return null
 
 
+# The walk that opens the pass, or null when nothing travels (an all-holds queue, or none at all).
+func moves() -> Beat:
+	for beat in beats:
+		if beat.kind == Kind.MOVES:
+			return beat
+	return null
+
+
+# One phase of the side-channel tail, in execution order -- one beat per ORDER, so a batch of
+# three rescues is three. execute_orders reads these the same way it reads volleys().
+func codas(type: BaseAction.ActionType) -> Array[Beat]:
+	var found: Array[Beat] = []
+	for beat in beats:
+		if beat.kind == Kind.CODA and beat.coda_type == type:
+			found.append(beat)
+	return found
+
+
 static func read(squad: Squad, plan: ResolvedPlan) -> BeatSheet:
 	var sheet := BeatSheet.new()
 	if squad == null or plan == null:
 		return sheet
 
-	var movers: Array[Unit] = []
-	var codas: Dictionary = {}
+	var walks: Array[BaseAction] = []
+	var coda_orders: Dictionary[BaseAction.ActionType, Array] = {}
 	for action in squad.action_queue:
 		if action.action_type == BaseAction.ActionType.MOVE:
-			if action.actor != null:
-				movers.append(action.actor)
+			var move := action as MoveAction
+			# A hold-position filler is NOT a move -- nobody ordered it and nothing travels. So a
+			# queue of nothing but fillers has no MOVES beat, which is the honest reading of a
+			# phase in which the board does not change.
+			if move != null and not move.is_hold_position and move.actor != null:
+				walks.append(move)
 		elif BaseAction.SIDE_CHANNEL_ORDER.has(action.action_type):
-			if not codas.has(action.action_type):
-				codas[action.action_type] = []
-			codas[action.action_type].append(action)
+			if not coda_orders.has(action.action_type):
+				coda_orders[action.action_type] = []
+			coda_orders[action.action_type].append(action)
 
-	if not movers.is_empty():
+	if not walks.is_empty():
 		var moves := Beat.new()
 		moves.kind = Kind.MOVES
-		moves.victims.assign(movers)   # a MOVES beat strikes nobody; these are the movers
+		# The LEADER opens it when it is walking: a squad's move is read from the unit the rest are
+		# following, and subject() takes the first order's aim. Otherwise queue order stands.
+		for i in walks.size():
+			if walks[i].actor == squad.leader:
+				var lead: BaseAction = walks[i]
+				walks.remove_at(i)
+				walks.insert(0, lead)
+				break
+		moves.actions.assign(walks)
+		moves.actor = walks[0].actor
 		sheet.beats.append(moves)
 
 	sheet.beats.append_array(_group(plan.attacks, false))
@@ -153,15 +201,23 @@ static func read(squad: Squad, plan: ResolvedPlan) -> BeatSheet:
 		sheet.beats.append(turnover)
 		sheet.beats.append_array(counter_beats)
 
+	# ONE BEAT PER ORDER, not per type: execute_orders plays the side-channel tail one verb at a
+	# time, each awaiting its own completion, so three rescues are three moments and not one. A
+	# beat per type would leave rescuers two and three acting off-camera and unheld (#520).
 	for type in BaseAction.SIDE_CHANNEL_ORDER:
-		if not codas.has(type):
+		if not coda_orders.has(type):
 			continue
-		var coda := Beat.new()
-		coda.kind = Kind.CODA
-		coda.coda_type = type
-		var batch: Array = codas[type]
-		coda.actor = batch[0].actor
-		sheet.beats.append(coda)
+		var batch: Array = coda_orders[type]
+		for entry in batch:
+			var order := entry as BaseAction
+			if order == null:
+				continue
+			var coda := Beat.new()
+			coda.kind = Kind.CODA
+			coda.coda_type = type
+			coda.actor = order.actor
+			coda.actions.append(order)
+			sheet.beats.append(coda)
 
 	sheet._gather_cast(squad, plan)
 	sheet._gather_cells(plan)

--- a/Classes/actions/resolution/BeatSheet.gd
+++ b/Classes/actions/resolution/BeatSheet.gd
@@ -50,6 +50,16 @@ class Beat:
 	func has_lethality(rung: ResolvedOutcome.Lethality) -> bool:
 		return lethalities.has(rung)
 
+	# Who the camera goes to for this beat (#520). The first VICTIM, because what the player needs
+	# to read is what is being done to whom -- and the attacker is usually already in frame, since
+	# reach is short. Falls back to the actor for a beat with no victim at all, which #47's swing at
+	# open ground really is. Null on a punctuation beat: the turnover holds where it already looks.
+	func subject() -> Unit:
+		for victim in victims:
+			if victim != null and is_instance_valid(victim):
+				return victim
+		return actor if actor != null and is_instance_valid(actor) else null
+
 	# Drop this volley's no-op members and read the surviving facts off their outcomes. R7 skips a
 	# counter-er, not a volley, so this runs AFTER grouping -- dropping a skipped LEAD any earlier
 	# would orphan its own secondaries into a beat of their own.

--- a/Classes/board/CameraController.gd
+++ b/Classes/board/CameraController.gd
@@ -1,10 +1,10 @@
 # The 2D board camera: WASD-scrolled with grid snapping, clamped to the board,
-# with AI-turn locks (set_ai_locked/follow) and the fixed-duration pan_to beat.
+# with playback locks (set_playback_locked/follow) and the fixed-duration pan_to beat.
 # center_on_position glides via the _process lerp; snap_to_position is the instant
 # form (the 3D input bridge maps clicks through the live transform, #220).
 #
 # Manual scrolling has THREE locks now: lock_manual_input (a glide owns the camera),
-# ai_locked (the AI does), and game.board_input_delegated (a 3D host does -- #176
+# playback_locked (an AI turn or a resolution pass does), and game.board_input_delegated (a 3D host does -- #176
 # stage 4d, where WASD would otherwise pan this camera AND the 3D rig off one press).
 # Only the keyboard branch is gated: pan_to/follow/snap_to_position must keep working,
 # and follow needs this _process to track its unit.
@@ -26,7 +26,13 @@ var keyboard_direction := Vector2.ZERO
 var lock_manual_input := false
 var last_move_dir := Vector2.ZERO
 var was_moving := false
-var ai_locked := false        # true for the whole duration of an AI-controlled turn
+# True while something other than the player owns where the camera looks: an AI faction's whole
+# turn, OR one squad's resolution pass (#520). Named for the FACT rather than its first caller --
+# it was ai_locked until #520, and the player's own Execute needs the identical treatment.
+#
+# It governs WHERE the camera looks, never how far out it sits: the player keeps the zoom wheel
+# throughout (dev, 2026-08-26), which is why battle3d gates zoom on the menu half alone.
+var playback_locked := false
 var follow_unit: Unit = null  # while set, target_position tracks this unit every frame
 var _panning := false         # true while pan_to's tween owns global_position -- _process yields to it
 
@@ -97,7 +103,7 @@ func _process(delta: float):
 	
 	#Always scroll at least one cell, and never snap back.  
 	keyboard_direction = Vector2.ZERO
-	if not lock_manual_input and not ai_locked and not _input_delegated():
+	if not lock_manual_input and not playback_locked and not _input_delegated():
 		if Input.is_action_pressed("cam_right"):
 			keyboard_direction.x += 1
 		if Input.is_action_pressed("cam_left"):
@@ -150,8 +156,8 @@ func _input_delegated() -> bool:
 	var delegated: bool = game.board_input_delegated
 	return delegated
 
-func set_ai_locked(locked: bool) -> void:
-	ai_locked = locked
+func set_playback_locked(locked: bool) -> void:
+	playback_locked = locked
 	if not locked:
 		follow_unit = null
 

--- a/Classes/core/Pacing.gd
+++ b/Classes/core/Pacing.gd
@@ -49,6 +49,19 @@ static var HOLD_CRISIS := 0.9      # someone stands up surged instead of falling
 static var HOLD_IRON_WILL := 0.45  # the cap BIT: that should have killed them and did not
 static var HOLD_KNOCKBACK := 0.2   # the hit shoved its target
 static var HOLD_TURNOVER := 0.5    # the act break: the defending line raises weapons
+static var HOLD_HEAL := 0.35       # HP came back -- the quiet beat this table had no row for
+
+# The side-channel tail (dev, 2026-08-26: "the side channel actions are going to need emphasis as
+# well"). PER VERB rather than one shared number, because a rescue and a reload are not the same
+# moment. coda_hold() below is the one lookup.
+static var HOLD_RESCUE := 0.5
+static var HOLD_RALLY := 0.4
+static var HOLD_INTIMIDATE := 0.4
+static var HOLD_RELOAD := 0.15
+static var HOLD_REV := 0.15
+static var HOLD_BURROW := 0.25
+static var HOLD_CAPTURE := 0.5
+static var HOLD_GUARD := 0.3
 
 # How much of a hold actually applies, per profile. BOARD ships at 0.0 -- flat, "small pauses
 # everywhere" (dev, 2026-08-26) -- so the shape exists but is dialled out rather than absent. That
@@ -85,6 +98,10 @@ static func drama_of(profile: Profile) -> float:
 static func hold_for(beat: BeatSheet.Beat) -> float:
 	if beat.kind == BeatSheet.Kind.TURNOVER:
 		return HOLD_TURNOVER
+	if beat.kind == BeatSheet.Kind.CODA:
+		# Floored, so an undeclared verb degrades to no hold rather than a negative beat. The law
+		# test is what actually refuses one -- a silent 0 in play is not a signal anybody sees.
+		return maxf(0.0, coda_hold(beat.coda_type))
 	var hold := 0.0
 	if beat.has_removal \
 			or beat.has_lethality(ResolvedOutcome.Lethality.DOWNED) \
@@ -97,7 +114,25 @@ static func hold_for(beat: BeatSheet.Beat) -> float:
 		hold = maxf(hold, HOLD_IRON_WILL)
 	if beat.has_knockback:
 		hold = maxf(hold, HOLD_KNOCKBACK)
+	if beat.has_heal:
+		hold = maxf(hold, HOLD_HEAL)
 	return hold
+
+
+# How long one side-channel verb holds. -1.0 for a verb nobody has declared one for, which is what
+# makes the omission VISIBLE: an undeclared verb is indistinguishable from a deliberate 0 otherwise,
+# and tests/law/test_action_registry.gd refuses the negative.
+static func coda_hold(type: BaseAction.ActionType) -> float:
+	match type:
+		BaseAction.ActionType.RESCUE: return HOLD_RESCUE
+		BaseAction.ActionType.RALLY: return HOLD_RALLY
+		BaseAction.ActionType.INTIMIDATE: return HOLD_INTIMIDATE
+		BaseAction.ActionType.RELOAD: return HOLD_RELOAD
+		BaseAction.ActionType.REV: return HOLD_REV
+		BaseAction.ActionType.BURROW: return HOLD_BURROW
+		BaseAction.ActionType.CAPTURE: return HOLD_CAPTURE
+		BaseAction.ActionType.GUARD: return HOLD_GUARD
+	return -1.0
 
 
 static func beat(host: Node, seconds: float) -> void:

--- a/Classes/core/Pacing.gd
+++ b/Classes/core/Pacing.gd
@@ -25,6 +25,12 @@ static var AI_ACTION := 0.45       # BOARD base beat on an AI pass -- an unread 
 static var PLAYER_ACTION := 0.3    # BOARD base beat on the player's own Execute (#519)
 static var TURN_HANDOFF := 1.0     # hold at every faction turn start -- game.start_faction_turn
 
+# How long the camera takes to reach the next beat's subject, and therefore how long the action
+# WAITS for it (#520). Shorter than AI_SQUAD_PAN because that one crosses the board between squads
+# while this hops between units already near each other. Fixed duration, not fixed speed: a short
+# hop and a long one read at the same pace, which is what makes it a beat rather than a lurch.
+static var PLAYBACK_PAN := 0.35
+
 # PLAYER_ACTION was 0.0 from #118 until #519 -- "deliberately none" (dev, 2026-08-10), reversed on
 # 2026-08-26: "small pauses everywhere", because a pass with no gap at all is what made the health
 # readouts flash in and out (#475, subsumed) and battles read "way too fast".

--- a/Classes/dev/GameKnobs.gd
+++ b/Classes/dev/GameKnobs.gd
@@ -367,6 +367,37 @@ const CLASS_KNOBS: Array[Dictionary] = [
 	{"group": "Playback", "label": "Hold: counter turnover", "static": "HOLD_TURNOVER",
 		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
 		"tip": "The act break between the attacker's last swing and the defending line's answer. Held once per pass, not per counter."},
+	{"group": "Playback", "label": "Hold: a heal", "static": "HOLD_HEAL",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time when HP came back -- a player-aimed heal or a reactive one. The table had no row for this until 2026-08-26, so a heal was the flattest thing a pass could contain."},
+
+	# One hold per side-channel verb (dev, 2026-08-26). Per VERB rather than one shared number
+	# because a rescue and a reload are not the same moment. Every SIDE_CHANNEL_ORDER member must
+	# have one -- tests/law/test_action_registry.gd refuses an undeclared verb.
+	{"group": "Playback", "label": "Hold: a rescue", "static": "HOLD_RESCUE",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time when a body is picked up off the floor. Ships long: it is the loudest thing in the tail."},
+	{"group": "Playback", "label": "Hold: a capture", "static": "HOLD_CAPTURE",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time when a zone is taken. Ships beside the rescue hold -- it is the moment a mission moves."},
+	{"group": "Playback", "label": "Hold: a rally", "static": "HOLD_RALLY",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time when Will comes back."},
+	{"group": "Playback", "label": "Hold: an intimidate", "static": "HOLD_INTIMIDATE",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time when Will is drained out of someone."},
+	{"group": "Playback", "label": "Hold: a guard arming", "static": "HOLD_GUARD",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time when a bodyguard takes up station. Arms last in the pass, after every hit it was resolved against has played."},
+	{"group": "Playback", "label": "Hold: a burrow", "static": "HOLD_BURROW",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time when a unit digs itself cover."},
+	{"group": "Playback", "label": "Hold: a reload", "static": "HOLD_RELOAD",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time for working the action. Ships short -- housekeeping, not drama."},
+	{"group": "Playback", "label": "Hold: a rev", "static": "HOLD_REV",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
+		"tip": "Extra time for spinning a chainsword up. Ships short, beside the reload."},
 
 	# The action ring (#467). Statics on a TRANSIENT node, which is why they are class knobs: the
 	# menu exists only while the player holds it open, so there is no standing property for a KNOBS
@@ -510,6 +541,15 @@ static func read_static(name: String) -> Variant:
 		"HOLD_IRON_WILL": return Pacing.HOLD_IRON_WILL
 		"HOLD_KNOCKBACK": return Pacing.HOLD_KNOCKBACK
 		"HOLD_TURNOVER": return Pacing.HOLD_TURNOVER
+		"HOLD_HEAL": return Pacing.HOLD_HEAL
+		"HOLD_RESCUE": return Pacing.HOLD_RESCUE
+		"HOLD_RALLY": return Pacing.HOLD_RALLY
+		"HOLD_INTIMIDATE": return Pacing.HOLD_INTIMIDATE
+		"HOLD_RELOAD": return Pacing.HOLD_RELOAD
+		"HOLD_REV": return Pacing.HOLD_REV
+		"HOLD_BURROW": return Pacing.HOLD_BURROW
+		"HOLD_CAPTURE": return Pacing.HOLD_CAPTURE
+		"HOLD_GUARD": return Pacing.HOLD_GUARD
 		"SHOVE_SLIDE_SPEED": return MovementComponent.SHOVE_SLIDE_SPEED
 		"SHOVE_FALL_SPEED": return MovementComponent.SHOVE_FALL_SPEED
 		"VOID_PLUMMET_CELLS": return MovementComponent.VOID_PLUMMET_CELLS
@@ -585,6 +625,33 @@ static func write_static(host: Node3D, name: String, value: Variant) -> void:
 			return
 		"HOLD_TURNOVER":
 			Pacing.HOLD_TURNOVER = value
+			return
+		"HOLD_HEAL":
+			Pacing.HOLD_HEAL = value
+			return
+		"HOLD_RESCUE":
+			Pacing.HOLD_RESCUE = value
+			return
+		"HOLD_RALLY":
+			Pacing.HOLD_RALLY = value
+			return
+		"HOLD_INTIMIDATE":
+			Pacing.HOLD_INTIMIDATE = value
+			return
+		"HOLD_RELOAD":
+			Pacing.HOLD_RELOAD = value
+			return
+		"HOLD_REV":
+			Pacing.HOLD_REV = value
+			return
+		"HOLD_BURROW":
+			Pacing.HOLD_BURROW = value
+			return
+		"HOLD_CAPTURE":
+			Pacing.HOLD_CAPTURE = value
+			return
+		"HOLD_GUARD":
+			Pacing.HOLD_GUARD = value
 			return
 		"SHOVE_SLIDE_SPEED":
 			MovementComponent.SHOVE_SLIDE_SPEED = value

--- a/Classes/dev/GameKnobs.gd
+++ b/Classes/dev/GameKnobs.gd
@@ -167,6 +167,8 @@ const KNOBS: Array[Dictionary] = [
 		"tip": "Degrees the view swings per pixel of mouse travel while dragging to orbit."},
 	{"group": "Camera handling", "node": "CameraRig", "prop": "pan_margin_cells", "label": "Pan margin (cells)", "min": 0.0, "max": 12.0, "step": 0.5,
 		"tip": "How far past the board's edge you may pan before being stopped. Some slack keeps a corner unit from being pinned against the screen edge."},
+	{"group": "Camera handling", "node": "CameraRig", "prop": "playback_distance", "label": "Playback zoom distance", "min": 4.0, "max": 30.0, "step": 0.5,
+		"tip": "How far out the camera sits when a pass or an AI turn takes it (#520). Applied ONCE as playback starts and then the wheel is yours again -- so this is where a fight opens from, not a leash."},
 	{"group": "Camera handling", "node": "CameraRig", "prop": "zoom_out_slack", "label": "Zoom-out slack", "min": 0.5, "max": 3.0, "step": 0.05,
 		"tip": "How far past the whole board you may zoom out. 1.0 means the board exactly fills the view at full zoom-out; above 1 lets you pull back and see it sitting in the world."},
 
@@ -332,6 +334,9 @@ const CLASS_KNOBS: Array[Dictionary] = [
 	# The beat table (#519, umbrella #410). Playback pacing had never had a door -- these are the
 	# five #118 constants plus the battle-beat shape, all read at each pass, so a change applies
 	# from the next Execute with nothing standing to re-apply it to.
+	{"group": "Playback", "label": "Camera travel to the action", "static": "PLAYBACK_PAN",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 2.0, "step": 0.05,
+		"tip": "How long the camera takes to reach the next blast, in seconds -- and therefore how long the action waits for it. Fixed duration, not speed, so a short hop and a long one read at the same pace. Zero snaps."},
 	{"group": "Playback", "label": "Beat: your own Execute", "static": "PLAYER_ACTION",
 		"script": PACING_SCRIPT, "min": 0.0, "max": 2.0, "step": 0.05,
 		"tip": "Base pause before each blast on YOUR pass, in seconds, with the battle zoom off. Was 0.0 until 2026-08-26 -- no gap at all is what made health readouts flash in and out. Zero restores that."},
@@ -494,6 +499,7 @@ static func read_static(name: String) -> Variant:
 		"MOVE_ARROW_MODULATE": return OverlayManager.MOVE_ARROW_MODULATE
 		"INVALID_ARROW_MODULATE": return OverlayManager.INVALID_ARROW_MODULATE
 		"TRAILING_ARROW_MODULATE": return OverlayManager.TRAILING_ARROW_MODULATE
+		"PLAYBACK_PAN": return Pacing.PLAYBACK_PAN
 		"PLAYER_ACTION": return Pacing.PLAYER_ACTION
 		"AI_ACTION": return Pacing.AI_ACTION
 		"CINEMATIC_ACTION": return Pacing.CINEMATIC_ACTION
@@ -547,6 +553,9 @@ static func write_static(host: Node3D, name: String, value: Variant) -> void:
 		"TRAILING_ARROW_MODULATE": OverlayManager.TRAILING_ARROW_MODULATE = value
 		# The beat table (#519). Every one of these is read at the START of a pass, so there is never
 		# a standing pause to re-apply one to -- SHOVE_SLIDE_SPEED's early return, same reason.
+		"PLAYBACK_PAN":
+			Pacing.PLAYBACK_PAN = value
+			return
 		"PLAYER_ACTION":
 			Pacing.PLAYER_ACTION = value
 			return

--- a/Classes/flow/ScenarioManager.gd
+++ b/Classes/flow/ScenarioManager.gd
@@ -368,8 +368,8 @@ func clear_board():
 	# And the AI's claim on the camera (#484). A new board owns no AI turn, same reasoning as the line
 	# above -- but load-bearing rather than tidy since that flag became the board lock's authority: a
 	# reload mid-enemy-phase rests game_state on _base_state() through exit_current_mode below, so an
-	# ai_locked left standing by an interrupted turn would lock the fresh board for good.
-	game.camera_controller.set_ai_locked(false)
+	# playback_locked left standing by an interrupted turn would lock the fresh board for good.
+	game.camera_controller.set_playback_locked(false)
 	game.zone_manager.load_dict({})   # zones are board content; load_scenario refills them after
 	overlay_manager.redraw_zones(game.zone_manager)
 	game.terrain_states.clear()   # tile states are board content too -- a sandbox spawn inherits no fire (#174)

--- a/Classes/presentation/CameraRig3D.gd
+++ b/Classes/presentation/CameraRig3D.gd
@@ -84,6 +84,18 @@ class_name CameraRig3D
 # tracking in _process have to keep running under it.
 @export var manual_input_enabled := true: set = _set_manual_input_enabled
 
+# The zoom wheel is gated SEPARATELY from everything else the player can do to the camera (#520,
+# dev 2026-08-26). While a pass or an AI turn plays, playback owns WHERE the camera looks and the
+# player keeps how far out it sits -- so manual_input_enabled goes false and this stays true. A
+# menu takes both, because the surface on screen wants the wheel for itself.
+@export var zoom_input_enabled := true
+
+# Where playback frames from: the distance the rig resets to whenever something other than the
+# player takes the camera. Without it you watch a whole enemy turn at whatever zoom you happened
+# to leave the last one at, which is the awkwardness this closes -- the reset is a STARTING point,
+# not a leash, and the wheel is live again immediately after.
+@export var playback_distance := 11.0
+
 @onready var _camera: Camera3D = $Pitch/Camera
 @onready var _attributes: CameraAttributesPractical = _camera.attributes as CameraAttributesPractical
 
@@ -108,6 +120,18 @@ func _ready() -> void:
 
 
 func _unhandled_input(event: InputEvent) -> void:
+	# ABOVE the manual gate, deliberately: zoom is the one thing the player keeps while playback
+	# owns the camera (#520). Its own switch is zoom_input_enabled; wheel_zoom_enabled stays the
+	# separate question of whether the WHEEL is this rig's to read at all (#285 hands it away).
+	var notch := event as InputEventMouseButton
+	if notch != null and notch.pressed and zoom_input_enabled and wheel_zoom_enabled:
+		if notch.button_index == MOUSE_BUTTON_WHEEL_UP:
+			zoom_by(-1)
+			return
+		elif notch.button_index == MOUSE_BUTTON_WHEEL_DOWN:
+			zoom_by(1)
+			return
+
 	if not manual_input_enabled:
 		return
 
@@ -136,12 +160,6 @@ func _unhandled_input(event: InputEvent) -> void:
 				position = _home_position
 				_target_yaw_degrees = _home_yaw_degrees
 				_target_distance = _home_distance
-	var wheel := event as InputEventMouseButton
-	if wheel != null and wheel.pressed and wheel_zoom_enabled:
-		if wheel.button_index == MOUSE_BUTTON_WHEEL_UP:
-			zoom_by(-1)
-		elif wheel.button_index == MOUSE_BUTTON_WHEEL_DOWN:
-			zoom_by(1)
 
 
 # One notch of zoom. Public so a host that has taken the wheel away can still hand a MODIFIED

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -106,8 +106,8 @@ var _pointer_vertex := Vector2i.ZERO
 # container SIZE to it (GameView keeps full resolution under stretch) and shrinks
 # only the display via scale.
 var _pip_native: Vector2 = Vector2(1280.0, 720.0)
-# Last frame's ai_locked, so the square-on realign fires once per AI turn, not per frame.
-var _ai_owned_camera := false
+# Last frame's playback_locked, so the square-on realign fires once per AI turn, not per frame.
+var _playback_owned_camera := false
 
 
 func _ready() -> void:
@@ -503,6 +503,9 @@ func _process(_delta: float) -> void:
 	# rig must keep SMOOTHING (the mirror below drives it) while refusing the player.
 	# Same predicate that refuses their clicks — one question, one answer.
 	_rig.manual_input_enabled = demo_mode or not game._board_locked_for_player()
+	# The ZOOM half is gated on the menu alone (#520, dev 2026-08-26): while playback owns where
+	# the camera looks, the player still owns how far out it sits. A menu takes both.
+	_rig.zoom_input_enabled = demo_mode or not game.menu_is_up()
 	_poll_pointer()
 	_sync_brush_bindings()
 	_sync_brush_ghost()
@@ -515,11 +518,11 @@ func _process(_delta: float) -> void:
 # second follow seam, and because the 2D camera owns the tween the 3D inherits
 # Pacing.AI_SQUAD_PAN exactly — one number, one reader.
 #
-# ai_locked is the gate, NARROWER than _board_locked_for_player(): the latter also covers
+# playback_locked is the gate, NARROWER than _board_locked_for_player(): the latter also covers
 # MENU, and Mission Select opts out of the modal lock, so mirroring there would yank the rig
-# to a stale 2D position the moment a menu opened. ai_locked IS the fact "the AI owns
+# to a stale 2D position the moment a menu opened. playback_locked IS the fact "the AI owns
 # the 2D camera" — set in the same block as AI_TURN, cleared the moment it returns.
-# Re-read every frame, never latched: a turn handoff can re-enter set_ai_locked inside
+# Re-read every frame, never latched: a turn handoff can re-enter set_playback_locked inside
 # the previous turn's stack, so the flag can legitimately flicker for a frame.
 #
 # Narrower, and since #484 strictly so: the board lock READS this flag, so whenever this gate
@@ -532,11 +535,15 @@ func _mirror_camera() -> void:
 	# Square-on for the enemy phase (dev call 2026-08-14), on the EDGE into the turn rather
 	# than every frame: idempotent either way today, but the moment orbit is allowed to stay
 	# live under an AI turn a per-frame snap would fight the player's own drag.
-	if cam.ai_locked != _ai_owned_camera:
-		_ai_owned_camera = cam.ai_locked
-		if _ai_owned_camera:
+	if cam.playback_locked != _playback_owned_camera:
+		_playback_owned_camera = cam.playback_locked
+		if _playback_owned_camera:
 			_rig.align_to_detent()
-	if not cam.ai_locked:
+			# ...and frame from a known distance (#520). The EDGE is the whole design: reset once
+			# as playback takes the camera, then leave the wheel alone, so the player may zoom
+			# freely for the rest of it. Re-applying per frame would be a leash instead.
+			_rig.set_zoom(_rig.playback_distance)
+	if not cam.playback_locked:
 		return
 	# The 2D camera answers WHERE on the board; the board answers HOW HIGH. It used to keep
 	# _rig.position.y, i.e. whatever the opening shot had left there — see _aim_over. Continuous

--- a/game.gd
+++ b/game.gd
@@ -43,7 +43,7 @@ enum GameState {
 	DEV_MODE,
 	PICKING_TARGET,
 	# Never read this member to ask "is the board locked?" -- ask _board_locked_for_player(), which
-	# also reads camera_controller.ai_locked. game_state is transient and gets rested on _base_state()
+	# also reads camera_controller.playback_locked. game_state is transient and gets rested on _base_state()
 	# mid-AI-turn (set_dev_mode, clear_board); the flag is what actually spans the turn (#484).
 	AI_TURN,
 	MISSION_OVER,
@@ -512,9 +512,9 @@ func start_faction_turn(faction: Team.Faction):
 
 	if ai_controller.is_ai_faction(faction):
 		game_state = GameState.AI_TURN
-		camera_controller.set_ai_locked(true)
+		camera_controller.set_playback_locked(true)
 		await ai_controller.take_faction_turn(faction, _board())
-		camera_controller.set_ai_locked(false)
+		camera_controller.set_playback_locked(false)
 		return
 
 	#TODO This should probably be it's own game state - IN_MENU or something.
@@ -569,19 +569,29 @@ func _run_turn_start_ticks(faction: Team.Faction) -> void:
 # The board is fully hands-off for the player while an AI faction resolves its turn, while the
 # end-of-mission card is up, and while Mission Select is up.
 #
-# ai_locked is the AUTHORITY on the first of those, never game_state (#484). The two are written in
+# playback_locked is the AUTHORITY on the first of those, never game_state (#484). The two are written in
 # one block by start_faction_turn, but game_state is TRANSIENT -- set_dev_mode and clear_board both
 # rest it on _base_state() from anywhere, AI turn or not -- so reading the state alone let a dev-mode
 # toggle mid-enemy-phase report the board unlocked while the camera was still AI-owned. That pair is
 # the one combination battle3d's two camera gates may never see at once: _update_pointer writes the
-# hidden 2D camera when this is false and _mirror_camera reads it when ai_locked is true, so they
+# hidden 2D camera when this is false and _mirror_camera reads it when playback_locked is true, so they
 # chased each other to the pan limit on every mouse move. Asking the flag makes the pair
 # unrepresentable rather than merely unreached, whatever writes game_state next.
 func _board_locked_for_player() -> bool:
-	return (camera_controller.ai_locked
-		or game_state == GameState.AI_TURN
-		or game_state == GameState.MISSION_OVER
-		or game_state == GameState.MENU)
+	return playback_owns_board() or menu_is_up()
+
+# The two halves, named because since #520 they have DIFFERENT readers. Playback owning the board
+# is compatible with the player still zooming (dev, 2026-08-26: "let the player zoom in and out
+# freely during AI turns and battle"); a menu being up is not, since the surface on screen wants
+# the wheel for itself. battle3d gates the rig's zoom on menu_is_up() alone for exactly that.
+#
+# Split rather than duplicated: _board_locked_for_player is COMPOSED of these, so there is no
+# second answer to the whole question -- only names for its parts.
+func playback_owns_board() -> bool:
+	return camera_controller.playback_locked or game_state == GameState.AI_TURN
+
+func menu_is_up() -> bool:
+	return game_state == GameState.MISSION_OVER or game_state == GameState.MENU
 
 func can_control(unit: Unit) -> bool:
 	if unit == null:

--- a/tests/core/test_beat_timing.gd
+++ b/tests/core/test_beat_timing.gd
@@ -22,7 +22,10 @@ func before_test() -> void:
 		"player": Pacing.PLAYER_ACTION, "ai": Pacing.AI_ACTION, "cine": Pacing.CINEMATIC_ACTION,
 		"bd": Pacing.BOARD_DRAMA, "cd": Pacing.CINEMATIC_DRAMA,
 		"down": Pacing.HOLD_DOWN, "crisis": Pacing.HOLD_CRISIS, "iron": Pacing.HOLD_IRON_WILL,
-		"knock": Pacing.HOLD_KNOCKBACK, "turn": Pacing.HOLD_TURNOVER,
+		"knock": Pacing.HOLD_KNOCKBACK, "turn": Pacing.HOLD_TURNOVER, "heal": Pacing.HOLD_HEAL,
+		"rescue": Pacing.HOLD_RESCUE, "rally": Pacing.HOLD_RALLY, "intim": Pacing.HOLD_INTIMIDATE,
+		"reload": Pacing.HOLD_RELOAD, "rev": Pacing.HOLD_REV, "burrow": Pacing.HOLD_BURROW,
+		"capture": Pacing.HOLD_CAPTURE, "guard": Pacing.HOLD_GUARD,
 	}
 
 
@@ -37,6 +40,15 @@ func after_test() -> void:
 	Pacing.HOLD_IRON_WILL = _saved["iron"]
 	Pacing.HOLD_KNOCKBACK = _saved["knock"]
 	Pacing.HOLD_TURNOVER = _saved["turn"]
+	Pacing.HOLD_HEAL = _saved["heal"]
+	Pacing.HOLD_RESCUE = _saved["rescue"]
+	Pacing.HOLD_RALLY = _saved["rally"]
+	Pacing.HOLD_INTIMIDATE = _saved["intim"]
+	Pacing.HOLD_RELOAD = _saved["reload"]
+	Pacing.HOLD_REV = _saved["rev"]
+	Pacing.HOLD_BURROW = _saved["burrow"]
+	Pacing.HOLD_CAPTURE = _saved["capture"]
+	Pacing.HOLD_GUARD = _saved["guard"]
 	PlayerSettings.reset_for_test()
 
 
@@ -110,6 +122,59 @@ func test_an_iron_will_save_outlasts_a_plain_scratch() -> void:
 		.is_greater(Pacing.duration_for(_chip(), CINEMATIC, false))
 
 
+# A heal is a thing that HAPPENED -- HP came back -- and until 2026-08-26 the table had no clause
+# for it, so it earned the bare base beat: the flattest moment a pass could contain, in the profile
+# that exists to make moments land. The dev found it in play ("the heal in the counter attack felt
+# left out of focus"); the camera was already going there, the beat was not.
+func test_a_heal_outlasts_a_plain_scratch() -> void:
+	var mended := _chip()
+	mended.has_heal = true
+	assert_float(Pacing.duration_for(mended, CINEMATIC, false)) \
+		.is_greater(Pacing.duration_for(_chip(), CINEMATIC, false))
+
+
+# ... and it takes part in the same by-VALUE ranking as everything else, rather than sitting
+# outside it: a heal that also killed somebody holds for whichever knob is larger.
+func test_a_heal_that_also_killed_takes_the_louder_knob() -> void:
+	Pacing.HOLD_HEAL = 0.2
+	Pacing.HOLD_DOWN = 0.8
+	var both := _kill()
+	both.has_heal = true
+	assert_float(Pacing.hold_for(both)).is_equal_approx(0.8, 0.0001)
+
+	Pacing.HOLD_HEAL = 1.5
+	assert_float(Pacing.hold_for(both)).is_equal_approx(1.5, 0.0001)
+
+
+# --- the side-channel tail --------------------------------------------------------------------
+
+# Each verb holds for its OWN knob, not one shared coda number -- a rescue and a reload are not the
+# same moment. Pinned as the relationship rather than the values, and driven from the knobs so a
+# hardcoded ranking would fail the second half.
+func test_each_side_channel_verb_holds_for_its_own_knob() -> void:
+	Pacing.HOLD_RESCUE = 0.9
+	Pacing.HOLD_RELOAD = 0.1
+	assert_float(Pacing.hold_for(_coda(BaseAction.ActionType.RESCUE))) \
+		.is_greater(Pacing.hold_for(_coda(BaseAction.ActionType.RELOAD)))
+
+	# Swap which one is loud. Nothing else changes.
+	Pacing.HOLD_RESCUE = 0.1
+	Pacing.HOLD_RELOAD = 0.9
+	assert_float(Pacing.hold_for(_coda(BaseAction.ActionType.RELOAD))) \
+		.is_greater(Pacing.hold_for(_coda(BaseAction.ActionType.RESCUE)))
+
+
+# hold_for FLOORS coda_hold's -1.0 sentinel, so an undeclared verb degrades to no hold in play
+# instead of subtracting from the base beat. The law suite is what refuses the omission; this pins
+# that the floor exists, since a negative reaching duration_for would shorten a real pause.
+func test_an_undeclared_verb_never_shortens_the_beat() -> void:
+	var stray := _coda(BaseAction.ActionType.ATTACK)   # never a side-channel verb
+	assert_float(Pacing.coda_hold(BaseAction.ActionType.ATTACK)).is_less(0.0)
+	assert_float(Pacing.hold_for(stray)).is_equal_approx(0.0, 0.0001)
+	assert_float(Pacing.duration_for(stray, CINEMATIC, false)) \
+		.is_equal_approx(Pacing.base_for(CINEMATIC, false), 0.0001)
+
+
 # --- which profile is live --------------------------------------------------------------------
 
 func test_the_profile_follows_the_battle_zoom_setting() -> void:
@@ -162,4 +227,11 @@ func _turnover() -> BeatSheet.Beat:
 	var beat := BeatSheet.Beat.new()
 	beat.kind = BeatSheet.Kind.TURNOVER
 	beat.is_counter = true
+	return beat
+
+
+func _coda(type: BaseAction.ActionType) -> BeatSheet.Beat:
+	var beat := BeatSheet.Beat.new()
+	beat.kind = BeatSheet.Kind.CODA
+	beat.coda_type = type
 	return beat

--- a/tests/law/test_action_registry.gd
+++ b/tests/law/test_action_registry.gd
@@ -38,6 +38,17 @@ func test_registry_lists_have_no_duplicates() -> void:
 			.is_false()
 		seen_main[type] = true
 
+# Every side-channel verb must declare how long its beat holds (#520, dev 2026-08-26). The tail is
+# played one order at a time and each one is a CODA beat, so a verb Pacing.coda_hold has no arm for
+# gets no emphasis at all -- which is invisible in play and indistinguishable from a deliberate 0.
+# The sentinel is what makes it visible: coda_hold answers -1.0 for a verb it does not know.
+# A miss here is fixed by adding the hold (and its Game-tab knob), not by editing this suite.
+func test_every_side_channel_verb_declares_a_beat_hold() -> void:
+	for type in BaseAction.SIDE_CHANNEL_ORDER:
+		assert_float(Pacing.coda_hold(type)) \
+			.override_failure_message("side-channel %s has no Pacing hold — add HOLD_<VERB>, an arm in coda_hold, and a GameKnobs Playback row, or it plays with no emphasis" % BaseAction.ActionType.keys()[type]) \
+			.is_greater_equal(0.0)
+
 func test_side_channels_are_main_actions_today() -> void:
 	# Every current side-channel is a main action. If a deliberate non-main side-channel ever
 	# lands (a "free" minor action), retire this test consciously rather than coding around it.

--- a/tests/presentation/test_camera_follow.gd
+++ b/tests/presentation/test_camera_follow.gd
@@ -6,7 +6,7 @@
 # in 3D was ~1.3s of dead air per squad in front of a motionless frame.
 #
 # The follow is a MIRROR of the 2D camera (which already knows where the action is),
-# gated on ai_locked. Two cases below decide that gate, and both are written to fail
+# gated on playback_locked. Two cases below decide that gate, and both are written to fail
 # loudly if the gate is widened to _board_locked_for_player(): that predicate also
 # covers MENU, where Mission Select opts out of the modal lock.
 extends GdUnitTestSuite
@@ -98,16 +98,16 @@ func _picked(cell: Vector2i) -> Vector3i:
 func test_the_3d_camera_follows_the_ai_camera() -> void:
 	var unit := _player_unit()
 	assert_object(unit).is_not_null()
-	# `ai_locked and not _board_locked_for_player()` is the pair that must never exist -- the poll
+	# `playback_locked and not _board_locked_for_player()` is the pair that must never exist -- the poll
 	# re-derives on CAMERA movement since #471, so a fixture holding it lets the hover snap drag the
 	# 2D camera the mirror below is reading, and the two march the view to the pan limit.
 	#
 	# This comment used to say the pair was unreachable BECAUSE start_faction_turn writes AI_TURN and
 	# the flag together. That was false: game_state is transient, and set_dev_mode rested it on
-	# _base_state() mid-enemy-phase, which is #484. The predicate now READS ai_locked, so the line
+	# _base_state() mid-enemy-phase, which is #484. The predicate now READS playback_locked, so the line
 	# below is what makes the pair impossible rather than a claim about who writes what.
 	_game.game_state = _game.GameState.AI_TURN
-	_cam().set_ai_locked(true)
+	_cam().set_playback_locked(true)
 	await _cam().pan_to(unit)   # headless: lands on the destination and hands to follow
 	await _settle()
 	# Where the 2D camera went, in the 3D metric. The 2D answers WHERE; the BOARD answers how high
@@ -125,7 +125,7 @@ func test_the_3d_camera_follows_the_ai_camera() -> void:
 
 	assert_that(_rig.position).override_failure_message(
 			"the 3D camera never followed the AI's pan").is_equal(expected)
-	_cam().set_ai_locked(false)
+	_cam().set_playback_locked(false)
 	_game.game_state = _game.GameState.IDLE
 
 
@@ -148,7 +148,7 @@ func test_hovering_does_not_drag_the_3d_camera() -> void:
 	assert_that(_scene._pointer_cell).is_equal(_picked(cell))
 	# ...and the 3D did not.
 	assert_that(_rig.position).override_failure_message(
-			"a hover dragged the 3D camera — the mirror is not gated on ai_locked").is_equal(before)
+			"a hover dragged the 3D camera — the mirror is not gated on playback_locked").is_equal(before)
 
 
 func test_opening_a_menu_does_not_yank_the_3d_camera() -> void:
@@ -158,7 +158,7 @@ func test_opening_a_menu_does_not_yank_the_3d_camera() -> void:
 	var before := _rig.position
 	_game.game_state = _game.GameState.MENU
 	assert_bool(_game._board_locked_for_player()).is_true()
-	assert_bool(_cam().ai_locked).is_false()
+	assert_bool(_cam().playback_locked).is_false()
 	_cam().snap_to_position(Vector2(-4000.0, -4000.0))
 	await _settle()
 
@@ -168,7 +168,7 @@ func test_opening_a_menu_does_not_yank_the_3d_camera() -> void:
 
 # #484, reported in play: the mouse became welded to the camera and ran the view to its limit in
 # whatever direction it moved. Toggling dev mode mid-enemy-phase rested game_state on _base_state(),
-# which unlocked the board while ai_locked stayed true -- opening _update_pointer's gate (it writes
+# which unlocked the board while playback_locked stayed true -- opening _update_pointer's gate (it writes
 # the hidden 2D camera) at the same time as _mirror_camera's (it reads it).
 #
 # Drives the REAL door: set_dev_mode, not a game_state poke. The rig assertion is the point -- the
@@ -176,7 +176,7 @@ func test_opening_a_menu_does_not_yank_the_3d_camera() -> void:
 # that only read the predicate would pass against a mirror wired straight to game_state.
 func test_toggling_dev_mode_during_an_ai_turn_leaves_the_board_locked() -> void:
 	_game.game_state = _game.GameState.AI_TURN
-	_cam().set_ai_locked(true)
+	_cam().set_playback_locked(true)
 	await _settle()
 	var before := _rig.position
 
@@ -202,22 +202,22 @@ func test_toggling_dev_mode_during_an_ai_turn_leaves_the_board_locked() -> void:
 			"the mouse dragged the 3D camera -- the pointer and the mirror both ran in one frame"
 			).is_equal(before)
 	_game.set_dev_mode(false)
-	_cam().set_ai_locked(false)
+	_cam().set_playback_locked(false)
 	_game.game_state = _game.GameState.IDLE
 
 
 # The second door onto the same pair (#484): clear_board rests game_state through exit_current_mode,
-# so a reload mid-enemy-phase reaches it too. Now that the lock READS ai_locked, an interrupted AI
+# so a reload mid-enemy-phase reaches it too. Now that the lock READS playback_locked, an interrupted AI
 # turn leaving the flag standing would lock the FRESH board for good -- so clear_board drops it,
 # beside the ai_factions reset it already does for the same "a new board inherits nothing" reason.
 func test_clearing_the_board_during_an_ai_turn_drops_the_ai_camera_lock() -> void:
-	_cam().set_ai_locked(true)
+	_cam().set_playback_locked(true)
 	await _settle()
 
 	_game.scenario_manager.clear_board()
 	await _settle()
 
-	assert_bool(_cam().ai_locked).override_failure_message(
+	assert_bool(_cam().playback_locked).override_failure_message(
 			"a cleared board kept the last turn's camera lock -- the new board is locked for good"
 			).is_false()
 	assert_bool(_game._board_locked_for_player()).override_failure_message(
@@ -372,7 +372,7 @@ func test_an_ai_turn_squares_the_camera_up() -> void:
 	# Dev call 2026-08-14: whatever angle the player left the camera at, the enemy phase
 	# plays out on an axis-aligned board.
 	_rig._target_yaw_degrees = 37.0
-	_cam().set_ai_locked(true)
+	_cam().set_playback_locked(true)
 	await _settle()
 	assert_float(_rig._target_yaw_degrees).override_failure_message(
 			"the AI turn did not square the camera up").is_equal_approx(0.0, 0.001)
@@ -386,13 +386,13 @@ func test_an_ai_turn_squares_the_camera_up() -> void:
 			"the realign re-fires every frame, not on entry").is_equal_approx(200.0, 0.001)
 
 	# And on the NEXT turn it takes the nearest detent, not zero.
-	_cam().set_ai_locked(false)
+	_cam().set_playback_locked(false)
 	await _settle()
-	_cam().set_ai_locked(true)
+	_cam().set_playback_locked(true)
 	await _settle()
 	assert_float(_rig._target_yaw_degrees).override_failure_message(
 			"it squared up to zero rather than to the nearest detent").is_equal_approx(180.0, 0.001)
-	_cam().set_ai_locked(false)
+	_cam().set_playback_locked(false)
 
 
 func test_space_recentres_the_diorama_on_the_pointer() -> void:
@@ -498,7 +498,7 @@ func test_the_ai_pan_aims_at_the_surface_too() -> void:
 	var unit := _player_unit()
 	assert_object(unit).is_not_null()
 	_game.game_state = _game.GameState.AI_TURN
-	_cam().set_ai_locked(true)
+	_cam().set_playback_locked(true)
 	await _cam().pan_to(unit)
 	_rig.position = Vector3(_rig.position.x, 12.0, _rig.position.z)
 	await _settle()
@@ -508,5 +508,5 @@ func test_the_ai_pan_aims_at_the_surface_too() -> void:
 			"the parked height IS the surface here; the case proves nothing").is_true()
 	assert_float(_rig.position.y).override_failure_message(
 			"the AI pan kept the rig's inherited aim height").is_equal_approx(wanted.y, 0.01)
-	_cam().set_ai_locked(false)
+	_cam().set_playback_locked(false)
 	_game.game_state = _game.GameState.IDLE

--- a/tests/presentation/test_camera_follow.gd
+++ b/tests/presentation/test_camera_follow.gd
@@ -72,6 +72,38 @@ func test_the_player_keeps_the_zoom_wheel_while_playback_owns_the_camera() -> vo
 	_game.game_state = _game.GameState.IDLE
 
 
+# A pass CLAIMS the camera and hands it back to whoever held it -- it does not simply unlock.
+# An AI turn owns the camera for its whole length and runs a pass inside it, so a blind release
+# would unlock the camera mid-turn and let the player drag the view out from under the enemy phase.
+func test_a_pass_inside_an_ai_turn_leaves_the_camera_still_owned() -> void:
+	var unit := _player_unit()
+	assert_object(unit).is_not_null()
+	_game.game_state = _game.GameState.AI_TURN
+	_cam().set_playback_locked(true)
+
+	await _game.order_executor.execute_orders(unit)   # empty queue: walks every phase, does nothing
+	await _settle()
+
+	assert_bool(_cam().playback_locked).override_failure_message(
+			"the pass released the camera it borrowed -- an AI turn is unlocked mid-turn").is_true()
+	_cam().set_playback_locked(false)
+	_game.game_state = _game.GameState.IDLE
+
+
+# ...and the mirror image: a pass on the PLAYER's own turn gives the camera back when it ends, or
+# the board would stay locked to clicks forever after one Execute.
+func test_a_pass_on_the_players_own_turn_gives_the_camera_back() -> void:
+	var unit := _player_unit()
+	assert_bool(_cam().playback_locked).override_failure_message(
+			"precondition: nothing should own the camera before the pass").is_false()
+
+	await _game.order_executor.execute_orders(unit)
+	await _settle()
+
+	assert_bool(_cam().playback_locked).override_failure_message(
+			"the pass kept the camera -- the board never unlocks after an Execute").is_false()
+
+
 # ...and a MENU takes it, because the surface on screen wants the wheel for itself. This is the
 # other half: a gate that never shuts is not a gate.
 func test_a_menu_takes_the_zoom_wheel_back() -> void:

--- a/tests/presentation/test_camera_follow.gd
+++ b/tests/presentation/test_camera_follow.gd
@@ -156,6 +156,43 @@ func test_the_move_phase_takes_the_camera_to_whoever_is_walking() -> void:
 	_cam().set_playback_locked(false)
 
 
+# ...and so does the side-channel tail. ADDED BY FALSIFICATION, not by reasoning: deleting the
+# subjects argument from execute_orders' side-channel call left 587 cases green across presentation
+# and squad, because everything about codas was pinned at its two ENDS (the sheet builds them, the
+# schedule reads them) and nothing drove the wire between. #103's shape exactly.
+#
+# The camera is parked on ANOTHER unit first, so "it ended up on the rallier" cannot pass by the
+# camera simply never having moved. A rally is the cheapest coda to stage: no target, no terrain,
+# and _queue_action is the raw door the beat sheet suite already uses.
+func test_a_side_channel_verb_takes_the_camera_too() -> void:
+	var unit := _player_unit()
+	var elsewhere := _any_unit_besides(unit)
+	assert_object(elsewhere).override_failure_message(
+			"fixture: this board has only one unit").is_not_null()
+
+	var rally := RallyAction.new()
+	rally.init(unit)
+	unit.squad._queue_action(rally)
+
+	_cam().set_playback_locked(true)
+	_cam().follow(elsewhere)
+	await _game.order_executor.execute_orders(unit)
+	await _settle()
+
+	assert_object(_cam().follow_unit).override_failure_message(
+			"the tail played with the camera still pointed at whatever it was watching before") \
+		.is_same(unit)
+	_cam().set_playback_locked(false)
+
+
+func _any_unit_besides(other: Unit) -> Unit:
+	for child in _game.units_root.get_children():
+		var unit := child as Unit
+		if unit != null and unit != other:
+			return unit
+	return null
+
+
 # A player unit that actually has somewhere to go -- a unit stranded on a terrace with no ramp off
 # it is a legal board and produces no move at all (the content razor's second hazard).
 func _mobile_player_unit() -> Unit:

--- a/tests/presentation/test_camera_follow.gd
+++ b/tests/presentation/test_camera_follow.gd
@@ -114,6 +114,61 @@ func test_a_menu_takes_the_zoom_wheel_back() -> void:
 	_game.game_state = _game.GameState.IDLE
 
 
+# The move phase gets a camera too (dev, 2026-08-26: "when I moved on my turn, the camera just
+# kinda stared off into space"). #520 diff 1 wired only the volley beats, and it had ALSO taken the
+# player's own scroll away for the length of a pass -- so the move phase went from unframed-but-
+# scrollable to unframed-and-frozen.
+#
+# Asserted on follow_unit rather than a position: pan_to ends by handing over to follow(), and a
+# position would depend on the 2D camera's clamp against the board's own extent, i.e. on authored
+# content. Run inside a claimed camera (what an AI turn does) because the restore at the end of a
+# PLAYER pass clears follow_unit -- here the claim is put back, so the last pan survives to be read.
+#
+# LIMIT, stated rather than implied: pan_to snaps headless, so this pins the WIRE, not the ordering.
+# That the pan precedes the walk is structural -- the await sits above the phase.
+func test_the_move_phase_takes_the_camera_to_whoever_is_walking() -> void:
+	var mover := _mobile_player_unit()
+	assert_object(mover).override_failure_message(
+			"fixture: no player unit on this board can move").is_not_null()
+
+	_cam().set_playback_locked(true)
+
+	# Control first: the same pass with nothing queued must move the camera nowhere, or the case
+	# below would pass on any pan at all rather than on the move's.
+	await _game.order_executor.execute_orders(mover)
+	await _settle()
+	assert_object(_cam().follow_unit).override_failure_message(
+			"an empty pass panned the camera somewhere").is_null()
+
+	var moverange = _game.compute_move_range(mover)
+	var destinations: Array[Vector2i] = _game.get_move_range(moverange, mover)
+	var path := RulesService.reconstruct_path(moverange.came_from, mover.movement.cell, destinations[0])
+	var move := MoveAction.new()
+	move.init(mover, path, null)
+	assert_bool(_game.squad_manager.queue_action(mover.squad, move)).override_failure_message(
+			"fixture: the move was refused, so the pass would concede instead of playing").is_true()
+
+	await _game.order_executor.execute_orders(mover)
+	await _settle()
+
+	assert_object(_cam().follow_unit).override_failure_message(
+			"the move phase played with the camera pointed wherever it was left").is_same(mover)
+	_cam().set_playback_locked(false)
+
+
+# A player unit that actually has somewhere to go -- a unit stranded on a terrace with no ramp off
+# it is a legal board and produces no move at all (the content razor's second hazard).
+func _mobile_player_unit() -> Unit:
+	for child in _game.units_root.get_children():
+		var unit := child as Unit
+		if unit == null or unit.get_faction() != Team.Faction.PLAYER:
+			continue
+		var reachable: Array[Vector2i] = _game.get_move_range(_game.compute_move_range(unit), unit)
+		if not reachable.is_empty():
+			return unit
+	return null
+
+
 func _cam() -> CameraController:
 	return _game.camera_controller
 

--- a/tests/presentation/test_camera_follow.gd
+++ b/tests/presentation/test_camera_follow.gd
@@ -41,6 +41,47 @@ func after_test() -> void:
 	_scene.free()
 
 
+# --- who owns the camera, and what the player keeps (#520) ------------------------------------
+
+# The #484 exclusion as a LAW over the flag rather than a scenario: whenever the mirror's gate is
+# open, _update_pointer's WRITE gate is shut. They read each other's target (the mirror READS the 2D
+# camera, the pointer WRITES it), so a frame running both marches the view to the pan limit. #520
+# widened the flag to cover a player's own pass, which is exactly when this could have broken.
+func test_the_mirror_gate_and_the_pointer_gate_are_never_open_together() -> void:
+	for locked in [false, true]:
+		_cam().set_playback_locked(locked)
+		await _settle()
+		assert_bool(_cam().playback_locked and not _game._board_locked_for_player()) \
+			.override_failure_message(
+				"the mirror may read the 2D camera while the pointer may still write it (#484)") \
+			.is_false()
+	_cam().set_playback_locked(false)
+
+
+# The dev's 2026-08-26 ruling: playback owns WHERE the camera looks, the player keeps HOW FAR OUT it
+# sits. Before #520 one flag killed orbit and wheel together for a whole AI turn.
+func test_the_player_keeps_the_zoom_wheel_while_playback_owns_the_camera() -> void:
+	_game.game_state = _game.GameState.AI_TURN
+	_cam().set_playback_locked(true)
+	await _settle()
+	assert_bool(_game._board_locked_for_player()).override_failure_message(
+			"precondition: playback should own the board here").is_true()
+	assert_bool(_rig.zoom_input_enabled).override_failure_message(
+			"the zoom wheel died with the rest of the rig -- the split did not take").is_true()
+	_cam().set_playback_locked(false)
+	_game.game_state = _game.GameState.IDLE
+
+
+# ...and a MENU takes it, because the surface on screen wants the wheel for itself. This is the
+# other half: a gate that never shuts is not a gate.
+func test_a_menu_takes_the_zoom_wheel_back() -> void:
+	_game.game_state = _game.GameState.MENU
+	await _settle()
+	assert_bool(_rig.zoom_input_enabled).override_failure_message(
+			"a menu is up and the wheel still zooms the board behind it").is_false()
+	_game.game_state = _game.GameState.IDLE
+
+
 func _cam() -> CameraController:
 	return _game.camera_controller
 

--- a/tests/presentation/test_predicted_health.gd
+++ b/tests/presentation/test_predicted_health.gd
@@ -39,6 +39,13 @@ func before_test() -> void:
 	_unit_mirror = _scene.get_node("UnitMirror") as UnitMirror
 	game.scenario_manager.clear_board()
 	game.game_state = game.GameState.IDLE
+	# The readout gate is `hovered or foretold or always_on` (#350/#354) and every case in this file
+	# is about the FORETOLD leg. Hover was silently absent before #520 only because nothing moved the
+	# camera during a player's own pass -- now the camera goes to the action, so where a stationary
+	# cursor points afterwards is a different cell, and one of them can hold a unit. Cutting the leg
+	# is what the file already says it wants ("the pointer is nowhere"); leaving it live made these
+	# cases pass or fail on whatever the PREVIOUS suite left the mouse doing.
+	_unit_mirror.hovered_unit_source = Callable()
 	await await_idle_frame()
 
 

--- a/tests/squad/test_beat_sheet.gd
+++ b/tests/squad/test_beat_sheet.gd
@@ -333,7 +333,156 @@ func _armor_granting(id: Abilities.Id) -> ArmorData:
 	return armor
 
 
+# --- the move phase (#520 follow-up) ----------------------------------------------------------
+
+# The MOVES beat is what the camera frames before anybody walks, and it opens on the LEADER when
+# the leader is walking -- a squad's move is read from the unit the rest are following. The mate's
+# move is queued FIRST here on purpose, so queue order alone would name the wrong unit.
+func test_the_move_beat_opens_on_the_leader_when_the_leader_walks() -> void:
+	var leader := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var mate := H.spawn_solo(self, _sm, PLAYER, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	_sm.join_squad(mate, leader.squad)
+
+	leader.squad._queue_action(_walk(mate, Vector2i(1, 1)))
+	leader.squad._queue_action(_walk(leader, Vector2i(0, 1)))
+
+	var sheet := BeatSheet.read(leader.squad, ResolvedPlan.new())
+	var beat := sheet.moves()
+	assert_object(beat).override_failure_message("two real moves produced no MOVES beat").is_not_null()
+	assert_int(beat.actions.size()).is_equal(2)
+	assert_object(beat.subject()) \
+		.override_failure_message("the walk framed queue order instead of the leader") \
+		.is_same(leader)
+
+
+# A hold-position filler is inserted by a game.gd signal handler for every member that is NOT
+# moving, so almost every real squad move carries some. They are not moves: nobody ordered one and
+# nothing travels, so framing one parks the camera on a unit standing still.
+func test_a_hold_position_filler_is_not_a_mover() -> void:
+	var leader := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var mate := H.spawn_solo(self, _sm, PLAYER, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	_sm.join_squad(mate, leader.squad)
+
+	leader.squad._queue_action(_hold(leader))
+	leader.squad._queue_action(_walk(mate, Vector2i(1, 1)))
+
+	var beat := BeatSheet.read(leader.squad, ResolvedPlan.new()).moves()
+	assert_object(beat).is_not_null()
+	assert_int(beat.actions.size()).override_failure_message(
+			"the leader's hold-position filler was counted as a move").is_equal(1)
+	assert_object(beat.subject()).is_same(mate)
+
+
+# ... and a queue of NOTHING but fillers is a phase in which the board does not change, so it earns
+# no beat at all -- which is what keeps the camera still instead of panning to a stationary unit.
+func test_a_queue_of_nothing_but_holds_has_no_move_beat() -> void:
+	var leader := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	leader.squad._queue_action(_hold(leader))
+
+	assert_object(BeatSheet.read(leader.squad, ResolvedPlan.new()).moves()) \
+		.override_failure_message("a hold-only queue produced a MOVES beat -- the camera would pan to nothing") \
+		.is_null()
+
+
+# --- the heal, as a fact (#519's table reads it) -----------------------------------------------
+
+# A heal is something that HAPPENED, and the sheet has to say so or #519's table cannot hold on it.
+# Read off the resolver's own heal_amount, never a re-read of fired_attack.heals -- same discipline
+# as every other fact here.
+func test_a_heal_is_a_beat_fact_and_a_damaging_hit_is_not() -> void:
+	assert_bool(_beat_of_a_hit_on_an_ally(true).has_heal) \
+		.override_failure_message("a heal landed and the beat did not know it").is_true()
+	assert_bool(_beat_of_a_hit_on_an_ally(false).has_heal) \
+		.override_failure_message("a damaging hit reads as a heal").is_false()
+
+
+# --- the side-channel tail --------------------------------------------------------------------
+
+# execute_orders plays the tail ONE ORDER AT A TIME, each awaiting its own completion, so two
+# rescues are two moments. A beat per TYPE (which is what #524 shipped) would leave the second
+# rescuer acting off-camera and unheld, since the schedule keys on each beat's first action.
+func test_two_rescues_are_two_coda_beats() -> void:
+	var leader := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var mate := H.spawn_solo(self, _sm, PLAYER, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	_sm.join_squad(mate, leader.squad)
+	var body_a := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 1), {Stats.Stat.LDR: 3})
+	var body_b := H.spawn_solo(self, _sm, PLAYER, Vector2i(1, 1), {Stats.Stat.LDR: 3})
+
+	leader.squad._queue_action(_rescue(leader, body_a))
+	leader.squad._queue_action(_rescue(mate, body_b))
+
+	var codas := BeatSheet.read(leader.squad, ResolvedPlan.new()).codas(BaseAction.ActionType.RESCUE)
+	assert_int(codas.size()).override_failure_message(
+			"two rescues collapsed into one beat -- the second plays off-camera").is_equal(2)
+	assert_object(codas[0].subject()).is_same(body_a)
+	assert_object(codas[1].subject()).is_same(body_b)
+
+
+# What a coda frames is what the verb is done TO, which is the same rule a volley follows -- and it
+# is the ORDER that answers, because only the order knows. A rescue has a body; a rally has nobody
+# but the unit doing it, and falls back to the actor.
+#
+# TWO actors, because rescue and rally are both MAIN actions: queued on one unit the second
+# displaces the first, which is the queue's own rule working rather than a fixture detail.
+func test_a_coda_frames_what_its_verb_is_done_to() -> void:
+	var rescuer := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var rallier := H.spawn_solo(self, _sm, PLAYER, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	_sm.join_squad(rallier, rescuer.squad)
+	var body := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 1), {Stats.Stat.LDR: 3})
+	rescuer.squad._queue_action(_rescue(rescuer, body))
+
+	var rally := RallyAction.new()
+	rally.init(rallier)
+	rescuer.squad._queue_action(rally)
+
+	var sheet := BeatSheet.read(rescuer.squad, ResolvedPlan.new())
+	assert_object(sheet.codas(BaseAction.ActionType.RESCUE)[0].subject()) \
+		.override_failure_message("a rescue framed the rescuer, not the body coming up").is_same(body)
+	assert_object(sheet.codas(BaseAction.ActionType.RALLY)[0].subject()) \
+		.override_failure_message("a rally has no target -- it must fall back to the unit rallying").is_same(rallier)
+
+
 # --- helpers ---------------------------------------------------------------------------------
+
+func _walk(unit: Unit, to: Vector2i) -> MoveAction:
+	var move := MoveAction.new()
+	var path: Array[Vector2i] = [to]
+	move.init(unit, path, null)
+	return move
+
+
+func _hold(unit: Unit) -> MoveAction:
+	var move := MoveAction.new()
+	move.init_hold_position(unit, null)
+	return move
+
+
+func _rescue(rescuer: Unit, body: Unit) -> RescueAction:
+	var action := RescueAction.new()
+	action.init(rescuer, body)
+	return action
+
+
+# One real resolve of a hit aimed at a SQUADMATE, healing or damaging, and the beat it produces.
+# The ally is the victim either way, so the only thing that differs is what the resolver did to it.
+func _beat_of_a_hit_on_an_ally(healing: bool) -> BeatSheet.Beat:
+	var actor := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var ally := H.spawn_solo(self, _sm, PLAYER, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	_sm.join_squad(ally, actor.squad)
+	var weapon := H.make_weapon(4)
+	weapon.template.main_attack.hits_allies = true
+	weapon.template.main_attack.heals = healing
+	actor.equipped_weapon = weapon
+	_sm.active_squad = actor.squad
+	actor.squad._queue_action(H.stamped_attack(actor, ally))
+
+	var plan := _sm.resolve_plan(actor.squad, _board_with([actor, ally]))
+	var beat: BeatSheet.Beat = BeatSheet.read(actor.squad, plan).volleys(false)[0]
+	assert_array(beat.victims).override_failure_message(
+			"fixture drifted: the aim at the ally found nobody").is_not_empty()
+	_break_volleys(plan)
+	return beat
+
 
 func _board_with(units_in: Array) -> BoardContext:
 	var units: Array[Unit] = []

--- a/tests/squad/test_beat_sheet.gd
+++ b/tests/squad/test_beat_sheet.gd
@@ -231,6 +231,37 @@ func _held_damage(attacker_stats: Dictionary, wears_iron_will: bool) -> bool:
 	return held
 
 
+# --- who the camera frames (#520) -------------------------------------------------------------
+
+# The VICTIM, not the attacker: what the player needs to read is what is being done to whom, and
+# reach is short enough that the attacker is usually in frame anyway.
+func test_a_beat_frames_its_victim() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var foe := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker, foe]))
+	var sheet := BeatSheet.read(attacker.squad, plan)
+	assert_object(sheet.volleys(false)[0].subject()).is_same(foe)
+	_break_volleys(plan)
+
+
+# #47's swing at open ground has NO victim, and the camera still has to go somewhere -- the actor.
+# Without the fallback a cell attack would play off-screen, which is the whole thing #520 fixes.
+func test_a_swing_at_open_ground_frames_the_actor_instead() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker]))
+	var beat: BeatSheet.Beat = BeatSheet.read(attacker.squad, plan).volleys(false)[0]
+	assert_array(beat.victims).override_failure_message(
+			"fixture drifted: this case needs the no-victim cell attack").is_empty()
+	assert_object(beat.subject()).is_same(attacker)
+	_break_volleys(plan)
+
+
 # --- the wire into the beat table (#519) ------------------------------------------------------
 
 # The sheet's whole point downstream is that a beat KNOWS what it was before anything plays. Both

--- a/tests/ui/test_report_flow.gd
+++ b/tests/ui/test_report_flow.gd
@@ -301,7 +301,7 @@ func test_the_camera_does_not_move_while_a_card_is_up() -> void:
 	# Isolate the pause as the only thing that could stop the poll -- the camera has two other
 	# locks of its own (a scripted pan, and an AI turn) and neither is what this test is about.
 	camera.lock_manual_input = false
-	camera.ai_locked = false
+	camera.playback_locked = false
 
 	game.game_state = game.GameState.IDLE
 	game.open_report_card(BugReporter.Kind.BUG)


### PR DESCRIPTION
Diff 1 of #520 (battle-zoom camera director), under umbrella #410. **The camera goes to the action, and the action waits for it** — in both profiles, per the ruling.

Diff 2 (the choreography: profile angles, the panning spin, tracking a volley, knockback and cliff follows, the lethality-aware dolly) is deliberately not here.

## What this is

**The enabling change is a rename, not a feature.** `CameraController.ai_locked` already meant *"something other than the player owns where the camera looks"* — it was only ever **named after its first caller**. It is `playback_locked` now, and `OrderExecutor.execute_orders` claims it too.

- **Saved and restored, never cleared.** An AI turn owns the camera for its whole length and a pass runs *inside* one, so a blind release would unlock the camera mid-turn.
- **`_board_locked_for_player()` is now composed of two named halves** — `playback_owns_board() or menu_is_up()`. Not a duplicate: the whole predicate is built *from* the halves, which finally have different readers.
- **The pan reuses the existing seam.** `CameraController.pan_to(unit, duration)` was already fixed-duration, headless-escaped, and awaited once per squad by `AIController`. `_execute_action_sequence` awaits the same call before a beat's opening action, so a volley pans once and then plays.
- **`BeatSheet.Beat.subject()`** answers who a beat frames: first victim, else the actor — because #47's swing at open ground has no victim and still has to be on screen.

**Why the camera never moved during your own Execute:** `battle3d._mirror_camera` returns early unless the flag is set, and the flag was set solely around AI turns. A `pan_to` moved the hidden 2D camera to no visible effect at all.

## The zoom, per the 2026-08-26 ruling

*"Let the player zoom in and out freely during AI turns and battle, but reset the camera zoom when they start."*

That reversed one of my four reader claims, and the cause was one line: `battle3d` set `_rig.manual_input_enabled` from the board lock, killing **orbit and wheel together** for a whole AI turn. Widening the flag as originally planned would have extended that to battle playback — backwards.

- The rig's wheel block moved **above** the manual gate, behind its own `zoom_input_enabled`, driven by the **menu half alone**. Zoom survives AI turns and playback; a menu still takes it.
- **Claiming the camera resets zoom** to `CameraRig3D.playback_distance` — hung off the edge-detect in `_mirror_camera` that already squared the view up for an enemy phase, so AI turns and battle passes both get it from one line. **Once on entry, never per frame**: a reset is a starting point, not a leash.

Knobs: **Camera travel to the action** (Playback) and **Playback zoom distance** (Camera handling).

## The one regression this caused, and how it was attributed

`tests/presentation/test_predicted_health.gd` → *readouts leave when the pass does* went red — **in its area, never alone**.

| run | result |
|---|---|
| the suite alone | 9/9 green |
| `presentation` on this branch | 1 failure |
| `presentation` on a clean `main` worktree | **386/386 green** |

Two separate facts, each needing its own run: it is **order-dependent**, and it is **mine**. The clean-main probe is what turned "probably mine" into "mine".

**Mechanism, confirmed by mutant rather than argued:** disabling the `pan_to` await took the reproducing pair (`test_input_bridge` + this suite, 53s) from 37-with-a-failure to 39 green. `test_input_bridge` synthesizes clicks, so it leaves the real mouse somewhere on the board; the camera now moves during a player's pass, so that stationary cursor points at a **different cell** when the pass ends — and one of them held a unit.

**The fix isolates the hover leg in that fixture, and that is narrower than it sounds.** The readout gate is `hovered or foretold or always_on`; every case in the file is about the **foretold** leg, and the file already says so (*"The pointer is nowhere — this readout is up because of the PLAN"*). Hover was absent only by accident, because nothing used to move the camera. It now sits beside the identical `PlayerSettings.reset_for_test()` isolation whose own comment calls it "NOT optional", for the same reason: without it these cases pass or fail on what the previous suite left behind.

(My first pass at this dismissed the hover hypothesis on the strength of that same comment — which belongs to a *different test* in the file. Re-reading it is what revived the right answer.)

## Verification

Areas: `presentation squad ui flow dev core` — **1446 cases / 132 suites, 0 failures, 0 orphans.** Full tree is CI's.

**Falsified — four mutants, each killed exactly the case it was aimed at:**

| mutant | case that reddened |
|---|---|
| zoom gate follows the board lock again (the pre-#520 bug) | `test_the_player_keeps_the_zoom_wheel_while_playback_owns_the_camera` |
| `subject()` frames the actor instead of the victim | `test_a_beat_frames_its_victim` |
| the board lock stops reading the flag (#484's exclusion) | `test_the_mirror_gate_and_the_pointer_gate_are_never_open_together` |
| blind release instead of save/restore | `test_a_pass_inside_an_ai_turn_leaves_the_camera_still_owned` |

The #484 exclusion was previously only prose in a comment plus a fixture line; it is a law over the flag now, which is what a rename most needed. And the save/restore turned out cheap to pin after all: **an empty queue still walks every phase**, so a pass can be driven for its ownership side-effect without staging combat.

**Embedded-content sweep:** not applicable. Nothing here adds a field to an embeddable content type — the rig's two new fields are `@export`s on a scene node, not on anything a scenario snapshot copies.

## One design question, for you rather than me

**After a pass, the camera stays parked on the last thing that happened.** That is what made the readout suite's old assumption false, and I think it is right: the camera followed the action and the action ended there.

But **#471 established a "camera return" idiom** elsewhere in this project, so returning the view to wherever you had put it is a coherent alternative. It is a feel call, so it is yours — and it is cheap either way, since the ownership edge that resets zoom is exactly where a return would hang.

## What is NOT verified

**The camera moving is not visible headless** — `pan_to` lands instantly there, deliberately, so nine suites that await `execute_orders` do not pay wall clock. The tests cover ownership, the gates, the subject choice and the schedule; **whether it reads well is yours, by playing.** Specifically worth judging: whether `Camera travel to the action` at 0.35s makes a pass feel deliberate or sluggish, and whether the playback zoom distance opens a fight at a sensible framing.
