### PR TITLE
Give the 3D top bar a background (#498)

### DIFF
--- a/Classes/dev/GameKnobs.gd
+++ b/Classes/dev/GameKnobs.gd
@@ -67,6 +67,10 @@ const KNOBS: Array[Dictionary] = [
 	# tab a player never sees.
 	{"group": "Dev chrome", "node": "BoardMirror", "prop": "brush_ghost_alpha", "label": "Brush ghost alpha", "min": 0.0, "max": 1.0, "step": 0.01,
 		"tip": "Opacity of the dev tile brush's preview block -- the ghost showing what you are about to paint. Dev-only; players never see it."},
+	# "." is the HOST itself (LookKnobs.target_of) — the first row to use it, because the plate is a
+	# child of Battle3D's own UI layer and there is no sub-node that owns it.
+	{"group": "Dev chrome", "node": ".", "prop": "help_plate_alpha", "label": "Top bar plate", "min": 0.0, "max": 1.0, "step": 0.01,
+		"tip": "Opacity of the dark plate behind the help line, the checkout stamp and the DEV MODE badge (#498). Zero removes it and the text goes back to washing out over pale terrain; past about 0.7 the plate stops reading as chrome and starts covering the board. The plate is fitted to the text, so this changes how hard it reads, never how much screen it takes. Dev-only."},
 	{"group": "Dev chrome", "node": "BoardMirror", "prop": "brush_vertex_ghost_size", "label": "Corner marker size", "min": 0.05, "max": 0.6, "step": 0.01,
 		"tip": "Edge of the corner tool's marker cube, as a fraction of a cell. It marks the POINT a drag has hold of, so it wants to be grabbable by eye without growing large enough to read as a tile -- past about a third of a cell it starts covering the corner it is pointing at. Dev-only."},
 

--- a/Scenes/Battle3D/Battle3D.tscn
+++ b/Scenes/Battle3D/Battle3D.tscn
@@ -39,6 +39,13 @@ dof_blur_near_distance = 9.0
 dof_blur_near_transition = 4.0
 dof_blur_amount = 0.08
 
+[sub_resource type="StyleBoxFlat" id="help_plate"]
+bg_color = Color(0, 0, 0, 0.45)
+corner_radius_top_left = 3
+corner_radius_top_right = 3
+corner_radius_bottom_right = 3
+corner_radius_bottom_left = 3
+
 [node name="Battle3D" type="Node3D" unique_id=222815813]
 script = ExtResource("1")
 
@@ -81,6 +88,10 @@ current = true
 fov = 30.0
 
 [node name="UI" type="CanvasLayer" parent="." unique_id=1085063773]
+
+[node name="Plate" type="Panel" parent="UI" unique_id=242989360]
+visible = false
+theme_override_styles/panel = SubResource("help_plate")
 
 [node name="Help" type="Label" parent="UI" unique_id=242989368]
 modulate = Color(1, 1, 1, 0.85)

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -50,6 +50,18 @@ enum View {
 # The corner debug view's knobs (aesthetics get a knob, not a guess):
 @export var pip_scale := 0.35
 @export var pip_margin := Vector2(12.0, 12.0)
+# How opaque the plate behind the top-left readouts is (#498). A KNOB rather than a constant
+# because "difficult to read" is a contrast complaint and the answer is taste -- but only the
+# ALPHA is one: the colour is black because the text is light, and the padding is not a value
+# anyone will argue about. Its setter re-applies immediately, or it is a slider that moves
+# nothing until the help line happens to be rebuilt (#264's born-dead knob).
+#
+# PLAIN `@export`, never `@export_range`: KnobSource.DECLARATION_LINE matches `^@export<space>var`,
+# so an annotated form has no declaration line to write back and Save would silently find nothing.
+# The row's own min/max/step is what builds the panel's slider anyway.
+@export var help_plate_alpha := 0.45: set = _set_help_plate_alpha
+# Breathing room around the widest line, in pixels. Constant: see above.
+const HELP_PLATE_PAD := Vector2(7.0, 5.0)
 
 @onready var _main: Node = $Main
 @onready var _board_mirror: BoardMirror = $BoardMirror
@@ -83,6 +95,10 @@ var _help_can_spawn := false
 @onready var _help: Label = $UI/Help
 @onready var _checkout: Label = $UI/Checkout
 @onready var _dev_badge: Label = $UI/DevMode
+# ONE plate behind all three, not one each (#498). They are read together and sit in one corner,
+# so three plates would give three ragged edges; and the CanvasLayer draws its children in tree
+# order, which is the whole reason this is the FIRST child rather than a z_index.
+@onready var _plate: Panel = $UI/Plate
 
 var game: Node2D
 var _game_container: SubViewportContainer
@@ -125,12 +141,14 @@ func _ready() -> void:
 	# subtree keeps no path to this scene, and a flat Main.tscn launch simply never gets a host.
 	if dev_overlay is DevOverlay:
 		(dev_overlay as DevOverlay).attach_3d_host(self)
+	_set_help_plate_alpha(help_plate_alpha)
 	_show_checkout()
 	game.dev_mode_changed.connect(_show_dev_badge)
 	_show_dev_badge(game.dev_mode_enabled)
 	if demo_mode:
 		_game_container.visible = false
 		_help.text = "Battle3D mirror (demo mode, read-only)  |  Q/E orbit  |  wheel zoom  |  WASD pan  |  R reset"
+		_fit_help_plate()
 	else:
 		# _apply_hosting also assigns input ownership: the 3D pick becomes the pointer
 		# source HoverPresenter reads (so hover reaches every cell, not just the ones
@@ -745,6 +763,7 @@ func _update_help() -> void:
 	var space := "SPACE spawn" if game.dev_controller.spawn_armed() else "SPACE centre"
 	var wheel := "wheel level  |  Ctrl+wheel zoom" if game.dev_controller.elevation_brush_live() else "wheel zoom"
 	_help.text = "Battle3D  |  LMB act  |  %s  |  %s-drag orbit  |  Q/E realign  |  %s  |  WASD pan  |  %s  |  R reset  |  F4 flat 2D  |  Shift+F4 corner" % [right, orbit, wheel, space]
+	_fit_help_plate()
 
 
 # WHICH CHECKOUT is on screen (#295) — several agents move the dev's working tree, so the build he
@@ -760,6 +779,7 @@ func _show_checkout() -> void:
 	var stamp := Checkout.describe()
 	_checkout.visible = stamp != ""
 	_checkout.text = stamp
+	_fit_help_plate()
 
 
 # IS DEV MODE ON — the badge is PRESENT or it is not, so there is no off-state to misread. Reads
@@ -772,6 +792,47 @@ func _show_checkout() -> void:
 # problem this is fixing rather than a shape to copy.
 func _show_dev_badge(active: bool) -> void:
 	_dev_badge.visible = active
+	_fit_help_plate()
+
+
+# The plate is fitted to the TEXT, not to the labels (#498). Each label is authored 900px wide so a
+# rebuilt help line never reflows, which means their rects say nothing about where the words end --
+# a plate sized to them would be a bar across most of the screen. So the width comes from the font
+# measuring each live string, and the height from the authored rows, which is what keeps their
+# spacing. Hidden when nothing is showing, since an empty plate is a smudge in the corner.
+#
+# Called from all three writers rather than polled: every one of them can change what is on screen
+# (the help line rebuilds as the brush arms, the checkout hides outside a dev build, the badge
+# toggles with dev mode), and a plate sized on a stale set is the artifact this is fixing.
+func _fit_help_plate() -> void:
+	var bounds := Rect2()
+	var found := false
+	for label: Label in [_help, _checkout, _dev_badge]:
+		if not label.visible or label.text.is_empty():
+			continue
+		var font := label.get_theme_font(&"font")
+		var width: float = font.get_string_size(label.text, HORIZONTAL_ALIGNMENT_LEFT, -1,
+				label.get_theme_font_size(&"font_size")).x
+		var line := Rect2(label.position, Vector2(width, label.size.y))
+		bounds = line if not found else bounds.merge(line)
+		found = true
+	_plate.visible = found
+	if not found:
+		return
+	_plate.position = bounds.position - HELP_PLATE_PAD
+	_plate.size = bounds.size + HELP_PLATE_PAD * 2.0
+
+
+# Writes THROUGH to the stylebox rather than storing and hoping: a knob whose value is only read
+# where the plate is built moves nothing until the next rebuild. Guarded because an @export setter
+# runs at instantiation, before @onready assigns the node -- _ready re-applies it for that case.
+func _set_help_plate_alpha(value: float) -> void:
+	help_plate_alpha = value
+	if _plate == null:
+		return
+	var box := _plate.get_theme_stylebox(&"panel") as StyleBoxFlat
+	if box != null:
+		box.bg_color.a = value
 
 
 # SPACE means two things, and dev mode wins — exactly how game.gd's own SPACE arm resolves

--- a/tests/dev/test_game_knobs.gd
+++ b/tests/dev/test_game_knobs.gd
@@ -436,7 +436,18 @@ func test_the_scene_overrides_no_game_knob_property() -> void:
 
 
 # The lines belonging to one [node ...] block, up to the next one.
+#
+# "." is the ROOT, matching LookKnobs.target_of -- a knob's `node` has two readers and they have to
+# spell the same vocabulary, or a legal value silently reads as "no such node" here and the law
+# reports a missing node instead of the override it exists to find (#498, the first row to use it).
+# The root has no name this can search for, but a .tscn always writes it as the FIRST [node block.
 func _node_section(scene: String, node_name: String) -> String:
+	if node_name == ".":
+		var root := scene.find("[node name=\"")
+		if root < 0:
+			return ""
+		var after_root := scene.find("\n[", root + 1)
+		return scene.substr(root, -1 if after_root < 0 else after_root - root)
 	var start := scene.find("[node name=\"%s\"" % node_name)
 	if start < 0:
 		return ""


### PR DESCRIPTION
Closes #498.

## What it does

**One plate behind all three top-left readouts** — the help line, the checkout stamp and the `DEV MODE` badge. They are read together and sit in one corner, so three plates would be three ragged edges.

**Fitted to the TEXT, not to the labels.** Each label is authored 900px wide so a rebuilt help line never reflows, which means their rects say nothing about where the words end — a plate sized to them would be a bar across most of the screen whatever it said. The width comes from the font measuring each live string, the height from the authored rows, which is what keeps their spacing.

It refits from all three writers rather than polling, because each can change what is on screen independently: the help line rebuilds as the brush arms, the checkout hides outside a dev build, the badge toggles with dev mode.

**Alpha is a `GameKnobs` row under *Dev chrome*** (`Top bar plate`), beside `brush_ghost_alpha`. "Difficult to read" is a contrast complaint, so opacity is the taste value; the colour is black because the text is light, and the padding is not something anyone will argue about. Its setter writes through to the stylebox, or it is #264's born-dead slider.

## Two things the existing laws caught

Both are worth keeping, and neither would have been visible by looking at the game.

- **`@export_range` has no declaration line `KnobSource` can write back.** `DECLARATION_LINE` matches `^@export<space>var`, so the annotated form would have worked in the panel and then **silently saved nothing** — precisely the failure that rewriter's return-`""`-on-miss design exists to make loud. Plain `@export` now, commented at the source.
- **This is the first row to use `"node": "."`** (the host itself). `LookKnobs.target_of` has always supported it and nothing had needed it — but `test_game_knobs.gd`'s own `_node_section` could not spell it, so it reported *"no node '.'"* instead of the override it exists to find. **Taught rather than exempted**: a knob's `node` has two readers and they have to share one vocabulary. That also makes the law able to check the ROOT node at all, which it never could before.

## Verification

No new tests — small visual change, per the ask. Verified instead by measurement, since this project never launches the game to check UI:

| | |
| --- | --- |
| plate rect | `(1, 3)` size `1021×46` — fitted, not 0×0 |
| child index | `0 of 4`, so it draws **behind** the labels |
| text union | `(8, 8)` size `1007×36`, **plate encloses it** |
| padding | exactly 7×5 on every side |
| `DEV MODE` hidden | correctly excluded — union stops at y=44, not 70 |
| knob write 0.45 → 0.8 | reaches the stylebox |

Taken with a throwaway suite case, deleted before commit. A bare `--script` probe cannot do this: no `Dialogic` autoload, so `game.gd` will not compile and `battle3d._ready` never reaches the code.

`dev` + `presentation` = 746 cases, and `tests/dev/test_game_knobs.gd` 29/29 alone after the helper fix.

**Falsified, committed first:** authoring `help_plate_alpha = 0.9` on the scene root reds `test_the_scene_overrides_no_game_knob_property` with *"Battle3D.tscn overrides .:help_plate_alpha"* — so the widened helper has teeth on the path this PR added, rather than merely not crashing on it.

## One honest note

The help line measures **1007px** at font 13, so on a 1280-wide window the plate spans ~1022 of it — close to full width. That is the text genuinely being that long, not the plate over-reaching. If it reads too heavy, the lever is the help line's length, not this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
