### PR TITLE
Write #111's attack files in Godot's own property order

### DIFF
--- a/Resources/WeaponAttacks/MainAttacks/ChainSword.tres
+++ b/Resources/WeaponAttacks/MainAttacks/ChainSword.tres
@@ -9,11 +9,11 @@ metadata/_custom_type_script = "uid://dsxc14gee2d01"
 
 [resource]
 script = ExtResource("2_wad")
-display_name = "Slash"
 scaling_blend = Dictionary[int, int]({
 1: 60,
 4: 40
 })
+display_name = "Slash"
 power = 3
 attack_pattern = SubResource("Resource_main")
 vertical_rule = 1

--- a/Resources/WeaponAttacks/MainAttacks/Drill.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Drill.tres
@@ -9,12 +9,12 @@ metadata/_custom_type_script = "uid://dsxc14gee2d01"
 
 [resource]
 script = ExtResource("2_wad")
-display_name = "Gouge"
-power = 3
-attack_pattern = SubResource("Resource_main")
-vertical_rule = 1
 scaling_blend = Dictionary[int, int]({
 1: 80,
 6: 20
 })
+display_name = "Gouge"
+power = 3
+attack_pattern = SubResource("Resource_main")
+vertical_rule = 1
 metadata/_custom_type_script = "uid://ddqeee7njjjq2"

--- a/Resources/WeaponAttacks/MainAttacks/Prosthetic.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prosthetic.tres
@@ -9,12 +9,12 @@ metadata/_custom_type_script = "uid://dsxc14gee2d01"
 
 [resource]
 script = ExtResource("2_wad")
-display_name = "Strike"
-power = 2
-attack_pattern = SubResource("Resource_main")
-vertical_rule = 1
 scaling_blend = Dictionary[int, int]({
 1: 50,
 4: 50
 })
+display_name = "Strike"
+power = 2
+attack_pattern = SubResource("Resource_main")
+vertical_rule = 1
 metadata/_custom_type_script = "uid://ddqeee7njjjq2"

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/Bow.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/Bow.tres
@@ -11,10 +11,10 @@ metadata/_custom_type_script = "uid://dsxc14gee2d01"
 
 [resource]
 script = ExtResource("2_4i624")
-display_name = "Loose"
-power = 3
-attack_pattern = SubResource("Resource_juf0b")
 scaling_blend = Dictionary[int, int]({
 4: 50,
 5: 50
 })
+display_name = "Loose"
+power = 3
+attack_pattern = SubResource("Resource_juf0b")

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/POINT.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/POINT.tres
@@ -10,11 +10,11 @@ metadata/_custom_type_script = "uid://bbbfksnb0tted"
 
 [resource]
 script = ExtResource("2_c5p18")
-display_name = "Lance"
-power = 5
-attack_pattern = SubResource("Resource_mrekx")
-hits_allies = true
 scaling_blend = Dictionary[int, int]({
 1: 70,
 4: 30
 })
+display_name = "Lance"
+power = 5
+attack_pattern = SubResource("Resource_mrekx")
+hits_allies = true

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/Shock Rod.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/Shock Rod.tres
@@ -7,7 +7,4 @@ script = ExtResource("1_o52ed")
 elemental_damage_type = 3
 display_name = "Jolt"
 power = 4
-scaling_blend = Dictionary[int, int]({
-1: 100
-})
 vertical_rule = 1

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/Sweeper.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/Sweeper.tres
@@ -8,10 +8,10 @@ script = ExtResource("1_qgxbu")
 
 [resource]
 script = ExtResource("2_ij5xu")
-display_name = "Cleave"
-power = 3
-attack_pattern = SubResource("Resource_5w2v2")
 scaling_blend = Dictionary[int, int]({
 1: 60,
 4: 40
 })
+display_name = "Cleave"
+power = 3
+attack_pattern = SubResource("Resource_5w2v2")

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/TheJaw.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/TheJaw.tres
@@ -9,12 +9,12 @@ metadata/_custom_type_script = "uid://dsxc14gee2d01"
 
 [resource]
 script = ExtResource("2_wad")
-display_name = "Bite"
-power = 5
-attack_pattern = SubResource("Resource_main")
-vertical_rule = 1
 scaling_blend = Dictionary[int, int]({
 1: 70,
 4: 30
 })
+display_name = "Bite"
+power = 5
+attack_pattern = SubResource("Resource_main")
+vertical_rule = 1
 metadata/_custom_type_script = "uid://ddqeee7njjjq2"

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/Water Staff.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/Water Staff.tres
@@ -7,7 +7,4 @@ script = ExtResource("1_bvk4r")
 elemental_damage_type = 2
 display_name = "Soak"
 power = 4
-scaling_blend = Dictionary[int, int]({
-1: 100
-})
 vertical_rule = 1


### PR DESCRIPTION
Follow-up to #111. Nine files it authored by hand were written in a property order Godot does not use, so the first editor save reorders them and you get a dirty file you never edited. That is how this was found -- `ChainSword.tres` came back modified after an editor session.

**`ChainSword.tres` in this branch is byte-for-byte identical to what your editor produced.** That is the check that matters: the committed bytes are now what the editor writes, so it has nothing left to change.

## What the order actually is

`WeaponAttackData`'s own fields (`elemental_damage_type`, `scaling_blend`) come **before** the ones inherited from `AttackData` (`display_name`, `power`, `attack_pattern`, …). My hand edits put `display_name` first or appended `scaling_blend` at the end, which is neither.

Round-tripped through `ResourceSaver` rather than reordered by hand, so this is Godot's answer and not my imitation of it.

## Two files change by more than order

`Prototypes/Shock Rod.tres` and `Prototypes/Water Staff.tres` **lose** their `scaling_blend` line. I had authored those as an explicit `STR 100` — which is exactly the `@export` default, so Godot drops them as redundant. Content is unchanged and it matches how `Kinetic_Mace.tres` (their family) already reads, but it does mean my claim on #111 that every promoted attack authors its blend explicitly is now false for those two. Flagging it rather than quietly letting it stand.

## The verification

Every write was gated on a content check: the resource is re-read from disk with the cache **bypassed** and every stored property compared, sub-resources included.

The gate proves itself before it authorises anything — it mutates a top-level field and a nested pattern field and refuses to run unless it sees both. That is not ceremony. The first version of the dump cast every property with `as Resource`, which **throws on a non-Object**, so it errored on nearly every field and then compared two equally damaged strings. It reported all seventeen files identical, for free. The files it had already written were reverted and redone.

A second measurement was wrong for a different reason and is worth recording: saving to a *probe* path makes Godot mint fresh `ext_resource` ids and can emit the ext_resource block in another order, so a text comparison flagged **every file in the repo**, including ones the serializer had just written. A same-path save reuses the existing ids and is the only trustworthy oracle here.

## uid loss

A headless `ResourceSaver.save()` strips `uid=` from ext_resource lines **and from the resource's own `gd_resource` header**. The editor keeps both. This is the regression `tests/law/test_resource_uid_references.gd` documents, and one its law cannot catch -- it flags a uid resolving to *nothing*, never the wholesale loss of every uid. Restored from `ResourceUID`, and for each file's own uid from the committed version. Audited: no file lost a uid it had.

## What I deliberately did NOT do

**14 of the 15 weapon files this ticket never touched reorder too** -- `Springspear.tres` by 10 property lines, `Spring.tres` by 12, `Super Gun.tres` by 9, and all seven `MainVarieties/` templates by 1. So the phantom-dirty-file problem is pre-existing across weapon content, not something #111 introduced (though `MainAttacks/ChainSword.tres` specifically **was** canonical before #111 and my edit is what broke it, which is why it surfaced first).

I built that wider normalization, measured it, and **threw it away**, because it is not cosmetic:

- Every `MainVarieties/*.tres` gains an explicit `mod_spaces = Array[int]([1, 2, 3])`. That property defaults to `SPACE_CAPACITIES.duplicate()`, so writing it out **pins each family to today's value** instead of following the constant. Same behaviour now, divergent the moment that constant is retuned.
- `Super Gun.tres` **loses** `min_range = 1`, since 1 is the class default.

Neither belongs in a commit labelled "reorder". Whether the editor writes `mod_spaces` the way a headless save does is **untested** -- I have no editor data point for a `WeaponData`, only for a `WeaponAttackData` -- so it may or may not be a live trap when you save a family template. Worth knowing either way.

Tests: `weapons dev flow` -- 782 cases, 0 failures, 0 orphans.

Note: GitHub Actions was in a major outage this afternoon, so CI may need a nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
