### PR TITLE
The tile brush slopes a TUFT (#342)

### DIFF
--- a/Classes/core/GridUtils.gd
+++ b/Classes/core/GridUtils.gd
@@ -144,6 +144,12 @@ enum PropShape { FLAT, BILLBOARD, CUBE, FACETED, ROUND, PLANE, TUFT }
 const SOLID_SHAPES: Array[PropShape] = [PropShape.CUBE, PropShape.FACETED, PropShape.ROUND,
 		PropShape.PLANE]
 
+# Which shapes ARE the ground rather than something sitting on it (#342). NOT the inverse of
+# stands_up_of, and that is the whole point: a TUFT stands up AND is ground -- its plants are
+# billboards, so it stands, while the cell itself is walkable ground with things growing out of it
+# (#280). Those are two questions that happened to agree until TUFT existed.
+const GROUND_SHAPES: Array[PropShape] = [PropShape.FLAT, PropShape.TUFT]
+
 # Which cell EDGES a PLANE's wall runs out to (#263). A FLAG SET rather than a yaw, because a corner
 # piece reaches TWO -- fence_tl runs east and south -- and one angle cannot say that. Each authored
 # edge becomes a half-length slab from the cell centre out to it, so a straight run is two collinear
@@ -265,6 +271,13 @@ static func stands_up_of(data: TileData) -> bool:
 
 static func stands_up_at_cell(grid: TileMapLayer, cell: Vector2i) -> bool:
 	return stands_up_of(grid.get_cell_tile_data(cell))
+
+
+# Is this tile's own surface the GROUND? Asked by anything deciding what may be shaped like terrain
+# -- the tile brush's rise gate is the first (#342). An unauthored tile reads FLAT, so it is ground,
+# the same permissive default prop_shape_of gives everywhere else.
+static func is_ground_shape(data: TileData) -> bool:
+	return GROUND_SHAPES.has(prop_shape_of(data))
 
 
 static func get_terrain_icon_at_cell(grid: TileMapLayer, cell: Vector2i) -> Texture2D:

--- a/Classes/dev/TileBrushTool.gd
+++ b/Classes/dev/TileBrushTool.gd
@@ -14,7 +14,8 @@ class_name TileBrushTool
 # reason #260 gave — a per-tile elevation would need one grass tile per level — but "how high" was
 # never a different QUESTION from "which tile", only a different store, and a mode per store made
 # authoring a raised cell two gestures. Raising a cell is now repainting it at a new level.
-# The rise is refused for a tile that stands up (see selected_rise): a rock has no face to tilt.
+# The rise is refused for a tile that is not GROUND (see selected_rise): a rock has no face to tilt,
+# while a tuft is ground with plants growing out of it and slopes like any other (#342).
 # CORNER mode (#427 slice 4) is the second tool the reframe asked for and does NOT replace any of
 # that ("keep the version of the tool we have now, but also have a corner mode" — dev, 2026-08-23):
 # it drags the POINT four cells share to the level picker's height, welding them, where the cell
@@ -234,11 +235,11 @@ func _on_tile_dropdown_item_selected(index: int):
 # Grey the rise picker for a tile that cannot slope, so selected_rise's refusal is VISIBLE rather
 # than a setting that silently does nothing.
 func _sync_rise_availability() -> void:
-	var flat := selected_tile_is_flat()
+	var ground := selected_tile_is_ground()
 	if _rise_option != null:
-		_rise_option.disabled = not flat
+		_rise_option.disabled = not ground
 	if _climb_option != null:
-		_climb_option.disabled = not flat
+		_climb_option.disabled = not ground
 
 func deactivate():
 	$Panel/TileBrushRow/TileBoxCheck.button_pressed = false
@@ -425,15 +426,15 @@ func _build_extra_controls() -> void:
 func selected_elevation() -> int:
 	return _elevation
 
-# What the next click would actually SLOPE — not simply the picker's value (#340). A standing tile
-# has no top face to tilt, so a rock or a lantern paints flat however the picker is set.
+# What the next click would actually SLOPE — not simply the picker's value (#340). A tile that is
+# not ground has no top face to tilt, so a rock or a lantern paints flat however the picker is set.
 #
 # The gate lives HERE rather than at the paint site because the GHOST reads this too: gated one level
 # down, the preview would show a sloping rock that the paint then refuses, which is #285's rule that
 # a preview must answer "what would this click PRODUCE". `_rise` itself is untouched, so picking a
 # prop and coming back to grass restores the direction you had.
 func selected_rise() -> Terrain.RampRise:
-	return _rise if selected_tile_is_flat() else Terrain.RampRise.NONE
+	return _rise if selected_tile_is_ground() else Terrain.RampRise.NONE
 
 # How far that slope climbs. NOT gated on the flat tile the way selected_rise is: a refused rise is
 # already NONE, and corners_of_ramp ignores the climb entirely then — gating both would be two
@@ -441,16 +442,21 @@ func selected_rise() -> Terrain.RampRise:
 func selected_climb() -> int:
 	return _climb
 
-# Whether the PICKED tile is ground rather than something standing on it. GridUtils.stands_up_of is
-# the one answer (derived from prop_shape); an unresolvable pick reads flat, the same permissive
+# Whether the PICKED tile is ground rather than something standing on it. GridUtils.is_ground_shape
+# is the one answer (derived from prop_shape); an unresolvable pick reads ground, the same permissive
 # default an unauthored tile gets there.
-func selected_tile_is_flat() -> bool:
+#
+# It asked stands_up_of until #342, which is a DIFFERENT question -- "does this stand ON the ground"
+# -- and the two agreed only until TUFT, which is both. A flowery-grass tuft is walkable ground with
+# plants growing out of it, so it belongs on the sloping side of the dev's own rule (*"only tiles
+# that are flat, not things like rocks, lanterns, etc. grass, mud, etc."*); rocks and fences stay out.
+func selected_tile_is_ground() -> bool:
 	if game == null or game.grid == null or game.grid.tile_set == null:
 		return true
 	var source := game.grid.tile_set.get_source(selected_source) as TileSetAtlasSource
 	if source == null or not source.has_tile(selected_tile):
 		return true
-	return not GridUtils.stands_up_of(source.get_tile_data(selected_tile, 0))
+	return GridUtils.is_ground_shape(source.get_tile_data(selected_tile, 0))
 
 # The ONE writer of the brush level: the wheel, the SpinBox and Reset all land here, so the widget
 # and the value the brush paints with cannot drift. set_value_no_signal, or the SpinBox's own

--- a/docs/design/verticality.md
+++ b/docs/design/verticality.md
@@ -6,7 +6,7 @@ grill-style. Every ruling below is his; the rationale is recorded because almost
 re-derivable from the code. Numbers (tolerances, drop damage, the 2D offset) are deliberately absent —
 they are feel values and get knobs, not guesses (`CLAUDE.md` → the tuning rule).
 
-**Canon checked through #498 (2026-08-25).**
+**Canon checked through #546 (2026-08-26).**
 
 The one-line version: **a cell has a height, height changes only via ramps, ramps are chokepoints
 rather than tolls, and what height buys you is REACH — not damage, not to-hit.**
@@ -989,12 +989,13 @@ Measured cost: 293 variants, meshlib 325 → 618 items and 1.35 → 1.85 MB. Two
 > (`Terrain.gradient_of_corners`) rather than a twelve-entry table, so the mesh and the rules cannot
 > drift about which way a cell climbs.
 
-- **Only flat tiles may SLOPE — but every tile gets a variant (amended by
-  [#342](https://github.com/Phaazoid/Godoiosis/issues/342), 2026-08-25).** The dev's rule is about
+- **Only GROUND may SLOPE — but every tile gets a variant (amended by
+  [#342](https://github.com/Phaazoid/Godoiosis/issues/342), 2026-08-25/26).** The dev's rule is about
   authoring: *"only tiles that are flat, not things like rocks, lanterns, etc. grass, mud, etc."*
-  The gate is `GridUtils.stands_up_of` — the existing `prop_shape` derivation, not a new predicate —
-  and it lives in `TileBrushTool.selected_rise()` so the GHOST reads it too; gated at the paint site
-  instead, the preview would show a sloping rock the click then refuses.
+  The gate is `GridUtils.is_ground_shape` — a `prop_shape` derivation, not a stored flag — and it
+  lives in `TileBrushTool.selected_rise()` so the GHOST reads it too; gated at the paint site
+  instead, the preview would show a sloping rock the click then refuses. It read `stands_up_of` until
+  #342 round 2; see *"is this GROUND?" is not the inverse of "does this STAND UP?"* below.
 
   **The meshlib generator used to share that gate, and that was the bug.** What a cap draws is not
   the tile's ART, it is the GROUND the tile stands on — which the generator's atlas pass has already
@@ -1011,16 +1012,24 @@ Measured cost: 293 variants, meshlib 325 → 618 items and 1.35 → 1.85 MB. Two
   documents still reach it — an empty cell, a rotated alternative, and **multi-cell art**, whose
   tiles the generator skips outright and which therefore have no block either. A standing prop no
   longer does. Without the fallback those cells render as a hole.
-- **A TUFT slopes, and its plants are planted per PLANT (#342).** `stands_up_of` reads a flowery
-  grass tuft as standing, so the tile brush still refuses it a rise — but a tuft is walkable ground,
-  and the corner tool slopes one whenever a neighbouring vertex is dragged, so the question this
-  entry used to defer (*"should a tuft slope at all?"*) was answered by #427 slice 4 shipping. A tuft
-  is the one prop whose parts are SPREAD ACROSS the square, so one surface point for the whole
-  assembly is only right while the square is level; each cluster now reads
-  `BoardSpace.surface_height_at` at **its own** point. It stays upright rather than tilting with the
-  ground — these are Y-billboards, and a plant grows up whatever the hill does, which is why
-  `surface_transform` (the answer this entry predicted) is the wrong seam for it. Widening the
-  brush's own gate to admit TUFT is still open on #342.
+- **A TUFT slopes, and its plants are planted per PLANT (#342).** The question this entry used to
+  defer (*"should a tuft slope at all?"*) was answered by #427 slice 4 shipping: the corner tool
+  slopes one whenever a neighbouring vertex is dragged, because it gates on GROUND. A tuft is the one
+  prop whose parts are SPREAD ACROSS the square, so one surface point for the whole assembly is only
+  right while the square is level; each cluster now reads `BoardSpace.surface_height_at` at **its
+  own** point. It stays upright rather than tilting with the ground — these are Y-billboards, and a
+  plant grows up whatever the hill does, which is why `surface_transform` (the answer this entry
+  predicted) is the wrong seam for it.
+- **"Is this GROUND?" is not the inverse of "does this STAND UP?" — #342 round 2 closed the brush's
+  half on that.** `GridUtils.stands_up_of` asks whether a tile stands ON the ground, which is right
+  for rendering: a tuft's plants really are billboards. The tile brush's rise gate borrowed it as a
+  proxy for *may this tile be shaped like terrain*, and the two agreed **only until TUFT existed**,
+  which answers yes to both. So a flowery-grass tile could be sloped by the corner tool and refused
+  by the brush — one board, two answers. `GridUtils.GROUND_SHAPES` / `is_ground_shape` is the second
+  question named once (`FLAT`, `TUFT`), and `TileBrushTool.selected_tile_is_ground` is its one
+  caller; rocks, fences and lanterns still paint flat however the picker is set. The brush stays the
+  CONSERVATIVE tool on purpose — the corner tool gates only on `has_ground`, so it will slope a rock,
+  and *"different tools for different situations"* is the standing ruling that keeps them apart.
 - **A prop follows its ground.** `BoardMirror._reconcile_prop` early-outs on identity, and until #342
   that identity was the TILE alone — so moving the ground under any prop left it sown at the old
   height. That is #471's law (*a poll compares every input its answer depends on*) one store along:

--- a/tests/dev/test_height_brush.gd
+++ b/tests/dev/test_height_brush.gd
@@ -324,29 +324,44 @@ func test_shrinking_the_map_prunes_stranded_elevation() -> void:
 	assert_int(game.board_heights.elevation_at(inside)).is_equal(2)   # still has ground
 
 
-# ---- only flat ground can slope (#340) ----
+# ---- only GROUND can slope (#340, widened by #342) ----
 
-# Which tile stands up is ASKED of the tileset, never named by coords: authored content is not
+# Which tile is ground is ASKED of the tileset, never named by coords: authored content is not
 # pinnable (the content razor), and prop_shape is the same fact the gate itself reads.
-func _find_tile(standing: bool) -> Vector2i:
+#
+# It asked stands_up_of until #342 -- a DIFFERENT question, and a TUFT answers yes to both. Left
+# alone, this helper would have started handing the "standing" case a tile the gate now ALLOWS, so
+# whether the case below reddened would have come down to tileset ordering.
+func _first_tile_where(matches: Callable) -> Vector2i:
 	var source := game.grid.tile_set.get_source(_brush.selected_source) as TileSetAtlasSource
 	for i in source.get_tiles_count():
 		var coords := source.get_tile_id(i)
 		if source.get_tile_size_in_atlas(coords) != Vector2i.ONE:
 			continue
-		if GridUtils.stands_up_of(source.get_tile_data(coords, 0)) == standing:
+		var hit: bool = matches.call(source.get_tile_data(coords, 0))   # .call() erases to Variant
+		if hit:
 			return coords
 	return Vector2i(-1, -1)
 
 
+func _find_tile(ground: bool) -> Vector2i:
+	return _first_tile_where(func(data: TileData) -> bool:
+			return GridUtils.is_ground_shape(data) == ground)
+
+
+func _find_shape(shape: GridUtils.PropShape) -> Vector2i:
+	return _first_tile_where(func(data: TileData) -> bool:
+			return GridUtils.prop_shape_of(data) == shape)
+
+
 func test_a_tile_that_stands_up_paints_flat_however_the_rise_is_set() -> void:
 	# The dev's rule: "only tiles that are flat, not things like rocks, lanterns". A rock has no top
-	# face to tilt. The FLAT half is the control -- without it this case also passes against a gate
+	# face to tilt. The GROUND half is the control -- without it this case also passes against a gate
 	# that simply refused every rise.
-	var prop := _find_tile(true)
-	var ground := _find_tile(false)
+	var prop := _find_tile(false)
+	var ground := _find_tile(true)
 	assert_bool(prop != Vector2i(-1, -1) and ground != Vector2i(-1, -1)).override_failure_message(
-			"fixture: this source needs both a standing and a flat tile to tell the two apart"
+			"fixture: this source needs both a standing prop and a ground tile to tell them apart"
 			).is_true()
 	var cell := _hover_cell()
 	_brush._rise_option.item_selected.emit(TileBrushTool.RISE_CYCLE.find(NORTH))
@@ -360,6 +375,31 @@ func test_a_tile_that_stands_up_paints_flat_however_the_rise_is_set() -> void:
 	_dc.handle_tile_brush(_press(MOUSE_BUTTON_LEFT, true))
 	assert_int(game.board_heights.ramp_rise_at(cell)).override_failure_message(
 			"the gate refused a rise to flat ground too, so it is not a gate").is_equal(NORTH)
+
+
+func test_a_TUFT_takes_a_rise_even_though_its_plants_stand_up() -> void:
+	# #342. A flowery-grass tuft is walkable GROUND with plants growing out of it, and the corner
+	# tool had been sloping one freely all along -- only the brush refused.
+	var tuft := _find_shape(GridUtils.PropShape.TUFT)
+	assert_bool(tuft != Vector2i(-1, -1)).override_failure_message(
+			"fixture: this source has no TUFT tile, so this case checks nothing"
+			).is_true()
+
+	# The two questions really do disagree about this tile, which is what makes the case a test of
+	# the WIDENING rather than of a tile that was already FLAT and would have passed before #342.
+	var source := game.grid.tile_set.get_source(_brush.selected_source) as TileSetAtlasSource
+	var data := source.get_tile_data(tuft, 0)
+	assert_bool(GridUtils.stands_up_of(data)).override_failure_message(
+			"fixture: a TUFT must read as STANDING, or this case is testing a flat tile"
+			).is_true()
+
+	var cell := _hover_cell()
+	_brush._rise_option.item_selected.emit(TileBrushTool.RISE_CYCLE.find(NORTH))
+	_brush.selected_tile = tuft
+	_dc.handle_tile_brush(_press(MOUSE_BUTTON_LEFT, true))
+	assert_int(game.board_heights.ramp_rise_at(cell)).override_failure_message(
+			"a tuft was refused a rise, though it is ground with plants standing on it"
+			).is_equal(NORTH)
 
 
 # ---- the readout ----


### PR DESCRIPTION
Closes #342.

## The bug is a question, not a predicate

`GridUtils.stands_up_of` answers *"does this tile stand ON the ground?"* — and it answers it
correctly. A tuft's plants really are billboards.

The tile brush's rise gate borrowed it as a proxy for a different question: *"may this tile be shaped
like terrain?"* The two agreed **only until TUFT existed**, which answers yes to both — walkable
ground with plants growing out of it. So a flowery-grass tile could be sloped freely by the corner
tool (which gates on `has_ground`) and refused by the brush. One board, two answers.

`GridUtils.GROUND_SHAPES` / `is_ground_shape` names the second question once — `FLAT`, `TUFT` —
beside `SOLID_SHAPES` and `stands_up_of`. A named set rather than `FLAT or TUFT` at the caller,
because that inline enumeration is what #527 called a second answer to a question something else
already owns.

**`stands_up_of` is untouched.** Its five other readers ask its own, unchanged question. The gate is
renamed `selected_tile_is_ground`, since *is flat* stops being true the moment a tuft passes it.

## Where the line stays

Rocks, fences and lanterns still paint flat however the picker is set — your rule (*"only tiles that
are flat, not things like rocks, lanterns, etc. grass, mud, etc."*) reads as *flat ground yes, props
no*, with grass as the example of yes.

**The brush stays the conservative tool on purpose.** The corner tool gates only on `has_ground`, so
it will slope a rock, and #527 made that render correctly. Deleting the brush's gate to match was the
alternative and I did not take it: *"different tools for different situations"* is the standing
ruling that keeps them apart, and the brush being the careful one is a defensible guard-rail. If it
feels wrong in authoring, deleting the gate is a one-line change from here.

## One thing that had to move with it

`test_height_brush._find_tile(standing)` picked by `stands_up_of`, so a TUFT satisfied
`standing == true`. Left alone, `test_a_tile_that_stands_up_paints_flat_however_the_rise_is_set`
would have started picking a tile the gate now **allows** — and whether it reddened would have come
down to tileset ordering. It asks the new question now, and the tuft case asserts
`stands_up_of` is still true of its tile, so the case is a test of the *widening* rather than of a
tile that was already FLAT and would have passed before this diff.

## Verification

`dev` **372/372** (371 + the new case).

**Falsified, committed first, two mutants:**

| mutant | what reddened |
| --- | --- |
| `GROUND_SHAPES` narrowed back to `[FLAT]` | *a tuft was refused a rise, though it is ground with plants standing on it* — the new case, by name |
| `is_ground_shape` always true, i.e. no gate at all | *a tile that stands up was painted as a ramp* — the rock case, the only case marked FAILED |

Each reddened the case it was aimed at, so neither half of the pair is vacuous.

## What you should see

Pick flowery grass, set a rise, paint — it slopes, and the rise/climb pickers stop greying out for
it. Pick a rock and they still grey, and it still paints flat. The 3D side of this shipped in #527,
so a sloped flowerbed should already wear its own mint ground with its flowers standing on the tilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
