### PR TITLE
#520 diff 2a: the camera takes an angle

### DIFF
--- a/Classes/actions/OrderExecutor.gd
+++ b/Classes/actions/OrderExecutor.gd
@@ -110,13 +110,13 @@ func execute_orders(unit):
 		await game.camera_controller.pan_to(walker, Pacing.PLAYBACK_PAN)
 	await _execute_action_phase_parallel(move_actions, _retire_move_markup)
 	await _execute_action_sequence(plan.attacks, beat, _beat_holds(sheet.volleys(false), profile, is_ai),
-			_beat_subjects(sheet.volleys(false)))
+			_beat_subjects(sheet.volleys(false)), _beat_lines(sheet.volleys(false)))
 	_apply_cell_effects(plan.cell_effects)
 	# The act break, held once between the two montages rather than folded into the first counter --
 	# a turnover the counters then pace on top of, not instead of.
 	await Pacing.beat(self, Pacing.duration_for(sheet.turnover(), profile, is_ai) if sheet.turnover() != null else 0.0)
 	await _execute_action_sequence(plan.counters, beat, _beat_holds(sheet.volleys(true), profile, is_ai),
-			_beat_subjects(sheet.volleys(true)))
+			_beat_subjects(sheet.volleys(true)), _beat_lines(sheet.volleys(true)))
 	# The tail gets the same treatment the volleys do (dev 2026-08-26): a CODA beat per ORDER, so
 	# each rescue pans to the body it lifts and holds for it instead of the whole batch sharing one
 	# flat beat and one camera position.
@@ -223,7 +223,8 @@ func _retire_move_markup(action: BaseAction) -> void:
 # (the parallel move phase, then each side-channel batch) with no separate between-phases pause, and
 # leaves no trailing pause before the squad's turn ends. An empty batch returns above, so a phase
 # with nothing in it costs nothing.
-func _execute_action_sequence(actions: Array, beat: float = 0.0, holds: Dictionary = {}, subjects: Dictionary = {}):
+func _execute_action_sequence(actions: Array, beat: float = 0.0, holds: Dictionary = {}, subjects: Dictionary = {},
+		lines: Dictionary = {}):
 	if actions.is_empty():
 		return
 
@@ -237,6 +238,11 @@ func _execute_action_sequence(actions: Array, beat: float = 0.0, holds: Dictiona
 		# the pan is one seam and one duration; headless it lands instantly like every other beat.
 		# Only a beat's OPENING action carries a subject, so a volley pans once and then plays.
 		if subjects.has(action):
+			# The ANGLE is published BEFORE the pan and never awaited (#520): the rig eases its yaw
+			# in _process while pan_to tweens the travel, so the spin and the approach are one
+			# movement rather than a turn followed by a walk.
+			if lines.has(action):
+				game.camera_controller.directed_line = lines[action]
 			await game.camera_controller.pan_to(subjects[action], Pacing.PLAYBACK_PAN)
 		await Pacing.beat(self, hold)
 		action.begin_execution()
@@ -267,6 +273,19 @@ func _beat_subjects(beats: Array[BeatSheet.Beat]) -> Dictionary:
 		if who != null and not beat.actions.is_empty():
 			subjects[beat.actions[0]] = who
 	return subjects
+
+
+# ...and from which SIDE, keyed identically (#520). A third schedule rather than one map to the Beat
+# itself, because what this hands the executor is plain data: three questions (how long, who, from
+# where), each answered before the pass starts. A beat with no direction is simply left out, the
+# same way a subjectless one is -- absence means the camera keeps the angle it has.
+func _beat_lines(beats: Array[BeatSheet.Beat]) -> Dictionary:
+	var lines: Dictionary = {}
+	for beat in beats:
+		var line := beat.aim_line()
+		if not line.is_empty() and not beat.actions.is_empty():
+			lines[beat.actions[0]] = line
+	return lines
 
 # Play the resolved terrain deposits into the live store, then redraw the board (#50). Runs after
 # the attack phase that produced them.

--- a/Classes/actions/resolution/BeatSheet.gd
+++ b/Classes/actions/resolution/BeatSheet.gd
@@ -71,6 +71,26 @@ class Beat:
 				return who
 		return actor if actor != null and is_instance_valid(actor) else null
 
+	# The line the camera frames this beat ACROSS (#520): [from, to] in sim cells, empty when the
+	# beat has no direction to be seen from. Only a VOLLEY has one -- the ticket's profile shot and
+	# "the next pair's natural profile angle" are both about an attacker and what they are aimed at,
+	# and moves, punctuation and the side-channel tail have no pair. Empty is the answer for those,
+	# which is already this sheet's idiom for "the camera does not move" (see subject()).
+	#
+	# The cells come off the ATTACK, not off the two units: origin_cell/target_cell are the
+	# resolver's own aim, so a swing at open ground (#47, target null) still has a direction, and a
+	# victim freed mid-pass cannot take the angle down with them. An aim at your own cell has no
+	# direction and is skipped rather than answered.
+	func aim_line() -> Array[Vector2i]:
+		for action in actions:
+			var attack := action as AttackAction
+			if attack == null:
+				continue
+			if attack.origin_cell == attack.target_cell:
+				continue
+			return [attack.origin_cell, attack.target_cell]
+		return []
+
 	# Drop this volley's no-op members and read the surviving facts off their outcomes. R7 skips a
 	# counter-er, not a volley, so this runs AFTER grouping -- dropping a skipped LEAD any earlier
 	# would orphan its own secondaries into a beat of their own.

--- a/Classes/board/CameraController.gd
+++ b/Classes/board/CameraController.gd
@@ -34,6 +34,11 @@ var was_moving := false
 # throughout (dev, 2026-08-26), which is why battle3d gates zoom on the menu half alone.
 var playback_locked := false
 var follow_unit: Unit = null  # while set, target_position tracks this unit every frame
+# The line the current beat is framed ACROSS, in sim cells (#520) -- [from, to], empty for a beat
+# with no direction. THIS camera never rotates and never will; it carries the value because it is
+# already what the 3D rig mirrors, and OrderExecutor has no path to the rig (the same reason the pan
+# goes through here). The rig turns it into a yaw, since only the rig knows what to measure from.
+var directed_line: Array[Vector2i] = []
 var _panning := false         # true while pan_to's tween owns global_position -- _process yields to it
 
 @export var move_speed := 14
@@ -163,6 +168,10 @@ func _input_delegated() -> bool:
 
 func set_playback_locked(locked: bool) -> void:
 	playback_locked = locked
+	# Cleared on BOTH edges, not just the release (#520). Claiming is a fresh pass, and the 3D rig
+	# re-solves this line against the detent it squares up to at that moment -- so a line left over
+	# from the previous squad would swing the camera off the new baseline before any beat ran.
+	directed_line = []
 	if not locked:
 		follow_unit = null
 

--- a/Classes/core/Pacing.gd
+++ b/Classes/core/Pacing.gd
@@ -80,6 +80,14 @@ static var HOLD_GUARD := 0.35
 static var BOARD_DRAMA := 0.0
 static var CINEMATIC_DRAMA := 0.95
 
+# How far the camera turns toward a beat's SIDE-ON angle, per profile (#520) -- 0 leaves the yaw
+# exactly where playback squared it up, 1 takes the full profile shot. DRAMA's shape applied to the
+# angle instead of the hold, and for the same reason: at 0.0 the BOARD profile is bit-for-bit the
+# square-on enemy phase it has always been, so wanting some angle on the plain board later is one
+# number rather than a restructure.
+static var BOARD_DIRECTION := 0.0
+static var CINEMATIC_DIRECTION := 1.0
+
 
 # Which profile playback is running under. ONE answer, so a caller never re-reads the setting.
 static func active_profile() -> Profile:
@@ -102,6 +110,10 @@ static func base_for(profile: Profile, is_ai: bool) -> float:
 
 static func drama_of(profile: Profile) -> float:
 	return CINEMATIC_DRAMA if profile == Profile.CINEMATIC else BOARD_DRAMA
+
+
+static func direction_of(profile: Profile) -> float:
+	return CINEMATIC_DIRECTION if profile == Profile.CINEMATIC else BOARD_DIRECTION
 
 
 # The loudest hold this beat earns, by VALUE rather than by rung order (see the holds above).

--- a/Classes/dev/GameKnobs.gd
+++ b/Classes/dev/GameKnobs.gd
@@ -383,6 +383,12 @@ const CLASS_KNOBS: Array[Dictionary] = [
 	{"group": "Playback", "label": "Drama: zoom on", "static": "CINEMATIC_DRAMA",
 		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
 		"tip": "The same multiplier with the zoom on. At 0 the zoom paces flat; above 1 every big moment stretches together, so this is the one dial for 'more dramatic' overall."},
+	{"group": "Playback", "label": "Camera angle: zoom off", "static": "BOARD_DIRECTION",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 1.0, "step": 0.05,
+		"tip": "How far the camera turns to see each blast side-on, zoom off. Ships at 0 -- square-on, exactly as the enemy phase has always played. At 1 it takes the full profile shot."},
+	{"group": "Playback", "label": "Camera angle: zoom on", "static": "CINEMATIC_DIRECTION",
+		"script": PACING_SCRIPT, "min": 0.0, "max": 1.0, "step": 0.05,
+		"tip": "The same turn with the zoom on. 1 puts the attacker and their target across the frame instead of one behind the other; part-way is a hint of the angle without leaving the square-on read."},
 	{"group": "Playback", "label": "Hold: a unit goes down", "static": "HOLD_DOWN",
 		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
 		"tip": "Extra time a blast earns for downing, killing, maiming or removing someone. Holds do NOT stack -- the largest single one wins -- so these numbers ARE the drama ranking. Set this under the shove hold and a shove outranks a death."},
@@ -572,6 +578,8 @@ static func read_static(name: String) -> Variant:
 		"CINEMATIC_ACTION": return Pacing.CINEMATIC_ACTION
 		"BOARD_DRAMA": return Pacing.BOARD_DRAMA
 		"CINEMATIC_DRAMA": return Pacing.CINEMATIC_DRAMA
+		"BOARD_DIRECTION": return Pacing.BOARD_DIRECTION
+		"CINEMATIC_DIRECTION": return Pacing.CINEMATIC_DIRECTION
 		"HOLD_DOWN": return Pacing.HOLD_DOWN
 		"HOLD_CRISIS": return Pacing.HOLD_CRISIS
 		"HOLD_IRON_WILL": return Pacing.HOLD_IRON_WILL
@@ -658,6 +666,12 @@ static func write_static(host: Node3D, name: String, value: Variant) -> void:
 			return
 		"CINEMATIC_DRAMA":
 			Pacing.CINEMATIC_DRAMA = value
+			return
+		"BOARD_DIRECTION":
+			Pacing.BOARD_DIRECTION = value
+			return
+		"CINEMATIC_DIRECTION":
+			Pacing.CINEMATIC_DIRECTION = value
 			return
 		"HOLD_DOWN":
 			Pacing.HOLD_DOWN = value

--- a/Classes/presentation/BoardSpace.gd
+++ b/Classes/presentation/BoardSpace.gd
@@ -239,3 +239,33 @@ static func of_cell(cell: Vector2i, row: int) -> Vector3i:
 static func of_pixels(px: Vector2, y: float) -> Vector3:
 	var per_cell := float(GridUtils.TILE_SIZE)
 	return Vector3(px.x / per_cell, y, px.y / per_cell)
+
+
+# The camera yaw that sees a cell pair SIDE-ON (#520): looking perpendicular to the line from
+# `from` to `to`, so an attacker and what they are swinging at both sit across the frame instead
+# of one hiding behind the other. Cells rather than units because the RESOLVER already owns the
+# aim (origin_cell -> target_cell) and re-deriving it off live node positions would be a second
+# answer to where the blow is pointed (Law #2).
+#
+# Yaw convention, and it is the whole of the arithmetic: CameraRig3D orbits about Y with the
+# camera parked at local +Z, so yaw t puts it at direction (sin t, cos t) from the aim. Side-on
+# means that direction is perpendicular to the pair's, which atan2(-dz, dx) solves directly.
+#
+# TWO yaws satisfy it, 180 apart -- the same shot from either side. Returning the one nearer
+# `baseline` is what makes it a SPIN rather than a lurch: the camera always takes the short way
+# round from where playback squared it up.
+#
+# NAN for a pair with no direction (a self-verb, an aim at your own cell). A float sentinel is
+# unavoidable here since every real angle is a legal yaw, and NAN is the one value that cannot be
+# mistaken for one; is_nan() at the single call site is what keeps it from travelling.
+static func side_on_yaw(from: Vector2i, to: Vector2i, baseline: float) -> float:
+	var dx := float(to.x - from.x)
+	var dz := float(to.y - from.y)   # a sim cell's y IS the world z -- see of_cell above
+	if is_zero_approx(dx) and is_zero_approx(dz):
+		return NAN
+	var side_on := rad_to_deg(atan2(-dz, dx))
+	var opposite := side_on + 180.0
+	if absf(angle_difference(deg_to_rad(baseline), deg_to_rad(opposite))) \
+			< absf(angle_difference(deg_to_rad(baseline), deg_to_rad(side_on))):
+		return opposite
+	return side_on

--- a/Classes/presentation/CameraRig3D.gd
+++ b/Classes/presentation/CameraRig3D.gd
@@ -113,6 +113,11 @@ var _borrowed_position := Vector3.ZERO
 var _borrowed_yaw_degrees := 0.0
 var _borrowed_distance := 0.0
 var _view_borrowed := false
+
+# What a DIRECTED shot is measured from (#520): the detent align_to_detent squared playback up to.
+# A third yaw beside the two above, and a third question -- _home_ is where the BOARD starts,
+# _borrowed_ where the PLAYER was standing, and this is where THIS PASS started.
+var _squared_up_yaw := 0.0
 # Empty = unbounded (the look-dev scene never frames, so it keeps free roam).
 var pan_limit := Rect2()
 
@@ -355,6 +360,31 @@ func _fit_distance(box: AABB) -> float:
 # its caller: an enemy phase reads square-on however the player left the camera.
 func align_to_detent() -> void:
 	_target_yaw_degrees = roundf(_target_yaw_degrees / yaw_step) * yaw_step
+	# ...and THAT is what a directed shot is measured from (#520). Captured here rather than read
+	# live at aim_along below, because a live read would compound: beat two would lerp from where
+	# beat one landed, so a partial strength would give the fifth beat more angle than the first.
+	_squared_up_yaw = _target_yaw_degrees
+
+
+# The camera DIRECTOR's door, and deliberately not pose() (#520): pose() snaps the yaw, adopts the
+# result as the OPENING SHOT, and drops the borrowed view -- all three wrong for a shot inside a
+# pass, the last of them fatal, since it is what the camera return is holding.
+#
+# So this writes the one thing a directed shot is: a yaw TARGET, eased by _process exactly as free
+# orbit and Q/E are eased. It re-solves rather than latching, so the per-frame mirror poll may call
+# it every frame with the same line and land on the same angle.
+#
+# An EMPTY line leaves the yaw alone rather than returning to square-on -- absence means "the camera
+# does not move", which is already the schedule's idiom for a beat with nobody to frame.
+func aim_along(line: Array[Vector2i]) -> void:
+	if line.size() != 2:
+		return
+	var side_on := BoardSpace.side_on_yaw(line[0], line[1], _squared_up_yaw)
+	if is_nan(side_on):
+		return
+	var strength := Pacing.direction_of(Pacing.active_profile())
+	_target_yaw_degrees = _squared_up_yaw + rad_to_deg(
+			angle_difference(deg_to_rad(_squared_up_yaw), deg_to_rad(side_on))) * strength
 
 
 # --- the view playback borrows (#520 follow-up) ------------------------------------------------

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -577,6 +577,11 @@ func _mirror_camera() -> void:
 	# would jolt the whole diorama mid-beat.
 	var flat := BoardSpace.of_pixels(cam.global_position, 0.0)
 	_rig.position = _aim_over(flat.x, flat.z)
+	# ...and the 2D camera answers WHERE, while the beat answers FROM WHICH SIDE (#520). Polled
+	# beside the position for the same reason it is: this is the one block that already runs every
+	# frame under playback. Below the early return deliberately -- the release edge above restores
+	# the player's own yaw, and re-aiming after it would undo the return in the same frame.
+	_rig.aim_along(cam.directed_line)
 
 
 func _unhandled_input(event: InputEvent) -> void:

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -7,7 +7,7 @@ its child [#49 Action Queue UX](https://github.com/Phaazoid/Godoiosis/issues/49)
 This is a *guidelines* doc, not a spec — it captures the principles we're holding the work to,
 plus the running order of the queue-UX checklist. Update it as items land.
 
-**Canon checked through #558 (2026-08-26).**
+**Canon checked through #564 (2026-08-26).**
 
 ## Principles
 
@@ -1280,6 +1280,64 @@ accessibility knob whose home is that same page. **Note the tuning-surface colli
 building:** those same layer colours are `GameKnobs.CLASS_KNOBS` rows (#373), i.e. dev-tunable
 game constants written back into their declarations — a player override is a *second* writer of the
 same value and needs a declared relationship with the authored default, not a second seam.
+
+## The camera takes an ANGLE ([#520](https://github.com/Phaazoid/Godoiosis/issues/520) diff 2a, BUILT 2026-08-26)
+
+Diff 1 made the camera *go to* the action and made the action wait for it. This is the first of
+#520's choreography: the camera also turns, so a blast is seen **side-on** — attacker and target
+across the frame instead of one behind the other — and the turn between beats reads as a spin.
+
+**Yaw is the only axis of this camera that was already authorable, which is why it went first.**
+`battle3d._mirror_camera` writes `_rig.position` from the 2D camera every frame, so the rig's
+position is a mirror and moving the node stages nothing — the `UnitMirror` reconcile trap one layer
+up. Yaw and distance are the rig's own and already eased in `_process`, and free orbit and Q/E
+already write `_target_yaw_degrees` directly with no bounds re-solve, so a director doing the same
+is doing exactly what the player does.
+
+**`pose()` is not the door.** It snaps the yaw, adopts the result as the OPENING SHOT, and calls
+`drop_stashed_view()` — which is what the camera return is holding. `CameraRig3D.aim_along()` is
+the director's own entry point and writes one thing: a yaw target.
+
+**Three yaws now live on the rig, named apart** (Law #4). `_home_*` is where the BOARD starts and
+is what R restores; `_borrowed_*` is where the PLAYER was standing, restored when playback gives
+the camera back; `_squared_up_yaw` is where THIS PASS started — the detent `align_to_detent()`
+snapped to. A directed shot is measured from the third. Captured on the edge rather than read live,
+because a live read compounds: beat two would lerp from where beat one landed, so a partial
+strength would give the fifth beat more angle than the first.
+
+**Strength is a per-profile multiplier, not a switch** — `Pacing.direction_of`, sitting beside
+`drama_of` and shaped the same way. `BOARD_DIRECTION` ships at **0.0**, which is bit-for-bit the
+square-on enemy phase the game has always played, so wanting some angle on the plain board later is
+one number rather than a restructure. Both are `GameKnobs` Playback rows.
+
+**Two of the three questions cross the seam as data, not as an angle.** `OrderExecutor` cannot see
+the rig — it talks to the 2D `CameraController`, which is what the 3D mirrors. So a beat publishes
+its **aim line** (`origin_cell → target_cell`, the resolver's own aim) and the rig turns that into a
+yaw, because only the rig knows what to measure from. The line comes off the ATTACK rather than off
+the two units, so #47's swing at open ground still has a direction and a victim freed mid-pass
+cannot take the angle down with it. `BoardSpace.side_on_yaw` is the arithmetic, and it returns the
+NEARER of the two perpendiculars — which is what makes the shot a spin instead of a lurch.
+
+`_beat_lines` is a third schedule beside `_beat_holds` and `_beat_subjects`, keyed identically by
+the beat's opening action, and inherits their rule: **a beat left out means the camera keeps the
+angle it has.** A MOVES beat, punctuation and the side-channel tail have no pair and so no line.
+
+**The consequence to know before touching this: every sprite on the board re-faces as the camera
+turns.** `UnitMirror._refresh_facing_on_camera_turn` re-judges `flip_h` against the live camera
+basis and the health cube grids `face()` it too, so a spin re-faces the whole board continuously.
+That is the effect, not a side effect — it is what makes 2D-in-3D read as dimensional.
+
+**The testing trap, and it is the claimed-camera one again.** A pass on the player's own turn
+releases at the end, and the release fires the view return — so the yaw an assertion reads after
+`execute_orders` is the camera coming home, not the shot. Claim the lock first (the AI-turn shape)
+so the pass's own save/restore lands on `true`. The other half is non-vacuity: **an aim along a
+board axis is already seen side-on from a detent**, so an axial fixture gives a case that passes
+whether the camera turns or not — the first draft of `test_a_pass_turns_the_camera_to_see_each_blast_side_on`
+did exactly that and survived every mutant. It aims diagonally now, and asserts the gap is real
+before asserting the camera closed it.
+
+Still open on #520: the pitch driver, the shake and micro-sway, the knockback and cliff follows
+(diff 2b), and lethality-aware direction (diff 2c).
 
 ## #44 board-side items (cross-referenced, not in this doc's running order)
 

--- a/tests/presentation/test_board_space.gd
+++ b/tests/presentation/test_board_space.gd
@@ -263,3 +263,50 @@ func test_a_corner_cell_gets_no_tilt_because_no_transform_could_carry_one() -> v
 		assert_that(BoardSpace.surface_transform(cell, heights).basis).override_failure_message(
 				"%s: a corner form was handed a tilt it cannot honour" % corners) \
 			.is_equal(Basis.IDENTITY)
+
+
+# --- the side-on camera yaw (#520 diff 2a) ----------------------------------------------------
+
+# The property, not the number: from the yaw the rig would be at, the camera's own offset direction
+# must be PERPENDICULAR to the pair's line -- that is what "side-on" means, and it is what stays
+# true if the rig's parking axis is ever re-authored. The rig orbits about Y with the camera at
+# local +Z, so yaw t puts it at (sin t, cos t).
+func test_the_side_on_yaw_looks_across_the_pair_not_along_it() -> void:
+	var pairs := [
+		[Vector2i(0, 0), Vector2i(3, 0)],    # along +x
+		[Vector2i(0, 0), Vector2i(0, 3)],    # along +z
+		[Vector2i(4, 1), Vector2i(1, 4)],    # a diagonal
+		[Vector2i(2, 5), Vector2i(7, 3)],    # something off both axes
+	]
+	for pair: Array in pairs:
+		var from: Vector2i = pair[0]
+		var to: Vector2i = pair[1]
+		var yaw := BoardSpace.side_on_yaw(from, to, 0.0)
+		var offset := Vector2(sin(deg_to_rad(yaw)), cos(deg_to_rad(yaw)))
+		var along := Vector2(to.x - from.x, to.y - from.y).normalized()
+		assert_float(offset.dot(along)).override_failure_message(
+				"%s -> %s: yaw %.2f looks along the pair, not across it" % [from, to, yaw]) \
+			.is_equal_approx(0.0, 0.001)
+
+
+# TWO yaws see a pair side-on, 180 apart. Which one is returned is what makes the shot a SPIN
+# rather than a lurch: from either baseline the answer is the near one, so the camera always takes
+# the short way round. Driven from both sides of the same pair, since one baseline could pass by
+# the function simply always returning the same yaw.
+func test_the_side_on_yaw_takes_the_near_side() -> void:
+	var from := Vector2i(0, 0)
+	var to := Vector2i(3, 0)
+	for baseline: float in [0.0, 90.0, 180.0, 270.0, -45.0, 400.0]:
+		var yaw := BoardSpace.side_on_yaw(from, to, baseline)
+		var near := absf(rad_to_deg(angle_difference(deg_to_rad(baseline), deg_to_rad(yaw))))
+		var far := absf(rad_to_deg(angle_difference(deg_to_rad(baseline), deg_to_rad(yaw + 180.0))))
+		assert_bool(near <= far).override_failure_message(
+				"baseline %.0f took the far side: %.1f away vs %.1f" % [baseline, near, far]) \
+			.is_true()
+
+
+# A pair with no direction cannot be seen side-on, and NAN is the one float that cannot be mistaken
+# for a legal yaw -- every real angle is one, so a numeric sentinel would be a shot the camera could
+# actually take.
+func test_a_pair_on_one_cell_has_no_side_to_be_seen_from() -> void:
+	assert_bool(is_nan(BoardSpace.side_on_yaw(Vector2i(2, 2), Vector2i(2, 2), 0.0))).is_true()

--- a/tests/presentation/test_camera_follow.gd
+++ b/tests/presentation/test_camera_follow.gd
@@ -179,6 +179,116 @@ func test_a_side_channel_verb_takes_the_camera_too() -> void:
 	_cam().set_playback_locked(false)
 
 
+# --- and from which SIDE it frames them (#520 diff 2a) ----------------------------------------
+
+# The whole wire, driven end to end: the executor publishes the beat's aim line, the mirror poll
+# reads it, and the rig turns. Written this way BECAUSE the diff-1 side-channel mutant survived 587
+# cases by having both ends pinned and nothing driving the middle (#103's shape) -- so this queues a
+# REAL attack through the real executor rather than poking directed_line.
+#
+# The expected yaw is re-derived from the beat's own line rather than written down, so the case
+# says "it went side-on to what it was framing", not "it went to 90 degrees" -- a fixture that
+# moves, or a rig parked on a different axis, must not red this.
+#
+# The STRENGTH is set rather than read: it is a feel value the dev tunes, so the case pins the fork
+# (full turn vs none) and never one side's number.
+func test_a_pass_turns_the_camera_to_see_each_blast_side_on() -> void:
+	var was := [Pacing.BOARD_DIRECTION, Pacing.CINEMATIC_DIRECTION]
+	Pacing.BOARD_DIRECTION = 1.0
+	Pacing.CINEMATIC_DIRECTION = 1.0
+
+	# Claimed FIRST, the AI-turn shape: a pass on the player's own turn RELEASES at the end, and the
+	# release fires the view return -- which puts the pre-pass yaw back, so an assertion taken after
+	# it is looking at the camera coming home rather than at the shot. Claiming first makes the
+	# pass's own save/restore land on `true`, so the angle it reached survives to be read.
+	_cam().set_playback_locked(true)
+	await _settle()
+	var attacker := _player_unit()
+	var line := _swing_at_open_ground(attacker)
+	var detent: float = _rig._target_yaw_degrees
+
+	await _game.order_executor.execute_orders(attacker)
+	await _settle()
+
+	var want := BoardSpace.side_on_yaw(line[0], line[1], detent)
+	assert_bool(is_nan(want)).override_failure_message(
+			"fixture drifted: the staged swing has no direction").is_false()
+	# THE NON-VACUITY GUARD, and it is the whole case: an aim along a board axis is already seen
+	# side-on from a detent, so a pass that turned nothing at all would satisfy the assertion below.
+	# The first draft of this case aimed along +x and passed against every mutant.
+	assert_float(_yaw_gap(want, detent)).override_failure_message(
+			"fixture drifted: this swing is already square-on, so the case cannot fail") \
+		.is_greater(10.0)
+	assert_float(_yaw_gap(_rig._target_yaw_degrees, want)).override_failure_message(
+			"the pass played square-on: yaw %.1f, side-on to the blast was %.1f" \
+			% [_rig._target_yaw_degrees, want]).is_equal_approx(0.0, 0.5)
+
+	Pacing.BOARD_DIRECTION = was[0]
+	Pacing.CINEMATIC_DIRECTION = was[1]
+	_cam().set_playback_locked(false)
+
+
+# ...and at strength 0 the identical pass does not move the camera a degree. That is what makes the
+# knob a DIAL rather than a switch, and it is what keeps the plain board bit-for-bit the square-on
+# enemy phase it has always been. Both profiles are zeroed, so this cannot pass by the fixture
+# happening to run under the other one.
+func test_at_zero_strength_the_same_pass_leaves_the_camera_square_on() -> void:
+	var was := [Pacing.BOARD_DIRECTION, Pacing.CINEMATIC_DIRECTION]
+	Pacing.BOARD_DIRECTION = 0.0
+	Pacing.CINEMATIC_DIRECTION = 0.0
+
+	_cam().set_playback_locked(true)   # same claimed-camera shape as the case above
+	await _settle()
+	var attacker := _player_unit()
+	_swing_at_open_ground(attacker)
+	var detent: float = _rig._target_yaw_degrees
+
+	await _game.order_executor.execute_orders(attacker)
+	await _settle()
+
+	assert_float(_yaw_gap(_rig._target_yaw_degrees, detent)).override_failure_message(
+			"a zeroed camera angle still turned the camera, to %.1f" % _rig._target_yaw_degrees) \
+		.is_equal_approx(0.0, 0.01)
+
+	Pacing.BOARD_DIRECTION = was[0]
+	Pacing.CINEMATIC_DIRECTION = was[1]
+	_cam().set_playback_locked(false)
+
+
+# A beat with nothing to frame must not swing the camera back to square-on -- absence means "keep
+# the angle you have", the same rule the subject schedule already follows. Driven at the rig, since
+# what is being pinned is how an EMPTY line is read.
+func test_a_beat_with_no_line_leaves_the_angle_where_it_was() -> void:
+	_cam().set_playback_locked(true)
+	await _settle()
+	_rig.aim_along([Vector2i(0, 0), Vector2i(3, 0)] as Array[Vector2i])
+	var turned: float = _rig._target_yaw_degrees
+
+	_rig.aim_along([] as Array[Vector2i])
+
+	assert_float(_rig._target_yaw_degrees).override_failure_message(
+			"an empty line snapped the camera back to square-on").is_equal_approx(turned, 0.01)
+	_cam().set_playback_locked(false)
+
+
+# #47's swing at open ground: a legal aim with no unit on the cell, which resolves and plays. It is
+# the one attack this suite can stage without asking what the board contains (the content razor) --
+# every alternative needs an enemy standing in reach. Returns the line the beat will carry.
+func _swing_at_open_ground(attacker: Unit) -> Array[Vector2i]:
+	var origin: Vector2i = attacker.movement.cell
+	# DIAGONAL, deliberately: a pair on a board axis is already side-on from a detent, so an axial
+	# aim gives a case that passes whether the camera turns or not.
+	var aim := origin + Vector2i(1, 1)
+	# _queue_action is the raw door -- the queue-time whiff gate would refuse an aim at nobody, and
+	# what is being staged here is a beat, not a player gesture.
+	attacker.squad._queue_action(AttackAction.declare(attacker, origin, aim))
+	return [origin, aim] as Array[Vector2i]
+
+
+func _yaw_gap(a: float, b: float) -> float:
+	return absf(rad_to_deg(angle_difference(deg_to_rad(a), deg_to_rad(b))))
+
+
 func _any_unit_besides(other: Unit) -> Unit:
 	for child in _game.units_root.get_children():
 		var unit := child as Unit

--- a/tests/presentation/test_camera_follow.gd
+++ b/tests/presentation/test_camera_follow.gd
@@ -255,6 +255,48 @@ func test_at_zero_strength_the_same_pass_leaves_the_camera_square_on() -> void:
 	_cam().set_playback_locked(false)
 
 
+# ADDED BY FALSIFICATION: measuring the turn from the LIVE yaw instead of from the detent the pass
+# squared up to passed all 27 cases. At strength 0 and 1 the two are identical -- 0 moves nothing
+# either way, 1 lands on the full angle either way -- so only a PARTIAL turn can tell them apart,
+# and no case had one.
+#
+# What breaks is idempotence, which matters because the mirror re-solves this EVERY FRAME: measured
+# from the live yaw, each frame closes half the remaining gap again, so a half-strength turn creeps
+# to the full angle over a few frames and the knob quietly stops meaning anything. Asserted as the
+# property (three calls, one answer) rather than as a frame count, so it does not depend on how
+# many frames an attack happens to take.
+func test_a_partial_turn_is_measured_from_where_the_pass_started() -> void:
+	var was := [Pacing.BOARD_DIRECTION, Pacing.CINEMATIC_DIRECTION]
+	Pacing.BOARD_DIRECTION = 0.5
+	Pacing.CINEMATIC_DIRECTION = 0.5
+
+	_cam().set_playback_locked(true)   # claiming is what captures the baseline
+	await _settle()
+	var detent: float = _rig._target_yaw_degrees
+	var line := [Vector2i(0, 0), Vector2i(3, 3)] as Array[Vector2i]
+
+	_rig.aim_along(line)
+	var once: float = _rig._target_yaw_degrees
+	# Non-vacuity: a partial turn that landed ON the detent, or all the way at the full angle, would
+	# satisfy the idempotence assertion for free.
+	var full := BoardSpace.side_on_yaw(line[0], line[1], detent)
+	assert_float(_yaw_gap(once, detent)).override_failure_message(
+			"the half turn did not leave the detent, so this case cannot fail").is_greater(5.0)
+	assert_float(_yaw_gap(once, full)).override_failure_message(
+			"the half turn went all the way, so this case cannot fail").is_greater(5.0)
+
+	_rig.aim_along(line)
+	_rig.aim_along(line)
+
+	assert_float(_rig._target_yaw_degrees).override_failure_message(
+			"the angle crept: one poll gave %.1f, three gave %.1f" % [once, _rig._target_yaw_degrees]) \
+		.is_equal_approx(once, 0.01)
+
+	Pacing.BOARD_DIRECTION = was[0]
+	Pacing.CINEMATIC_DIRECTION = was[1]
+	_cam().set_playback_locked(false)
+
+
 # A beat with nothing to frame must not swing the camera back to square-on -- absence means "keep
 # the angle you have", the same rule the subject schedule already follows. Driven at the rig, since
 # what is being pinned is how an EMPTY line is read.

--- a/tests/squad/test_beat_sheet.gd
+++ b/tests/squad/test_beat_sheet.gd
@@ -262,6 +262,52 @@ func test_a_swing_at_open_ground_frames_the_actor_instead() -> void:
 	_break_volleys(plan)
 
 
+# --- from which SIDE the camera frames it (#520 diff 2a) --------------------------------------
+
+# The line is the RESOLVER's aim, origin_cell -> target_cell, not the two units' live positions.
+# Asserted as the aim rather than as literal cells so the case survives the fixture moving.
+func test_a_volley_beat_names_the_line_it_is_framed_across() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	var foe := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker, foe]))
+	var beat: BeatSheet.Beat = BeatSheet.read(attacker.squad, plan).volleys(false)[0]
+	var opener: AttackAction = beat.actions[0]
+	assert_array(beat.aim_line()).is_equal([opener.origin_cell, opener.target_cell])
+	_break_volleys(plan)
+
+
+# A swing at open ground HAS a direction even with nobody to hit -- the aim points somewhere. That
+# is the whole reason the line comes off the attack rather than off actor-and-victim: the beat that
+# frames its actor by fallback (see above) is still a beat with a side to be seen from.
+func test_a_swing_at_open_ground_still_has_a_line() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker]))
+	var beat: BeatSheet.Beat = BeatSheet.read(attacker.squad, plan).volleys(false)[0]
+	assert_array(beat.victims).override_failure_message(
+			"fixture drifted: this case needs the no-victim cell attack").is_empty()
+	assert_array(beat.aim_line()).is_not_empty()
+	_break_volleys(plan)
+
+
+# A MOVES beat has no pair, so it has no line -- and absence is what the schedule reads as "leave
+# the camera's angle where it is". A walk framed side-on to nothing would be an angle invented from
+# whatever two cells happened to be reachable.
+func test_a_move_beat_has_no_line_to_be_framed_across() -> void:
+	var leader := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	leader.squad._queue_action(_walk(leader, Vector2i(0, 1)))
+
+	var moves := BeatSheet.read(leader.squad, ResolvedPlan.new()).moves()
+	assert_object(moves).override_failure_message(
+			"fixture drifted: this case needs a real move beat").is_not_null()
+	assert_array(moves.aim_line()).is_empty()
+
+
 # --- the wire into the beat table (#519) ------------------------------------------------------
 
 # The sheet's whole point downstream is that a beat KNOWS what it was before anything plays. Both


### PR DESCRIPTION
Closes part of #520 — diff 2a of the choreography, sliced yaw-first per your call.

The camera now **turns** as well as travels: a blast is framed side-on, attacker and target across the frame instead of one behind the other, and the turn between beats reads as a spin.

## Why yaw first

It is the only axis of this camera that was already authorable. `_mirror_camera` writes `_rig.position` from the 2D camera every frame, so the rig's position is a mirror and moving the node stages nothing — the `UnitMirror` reconcile trap one layer up. Yaw and distance are the rig's own and already eased in `_process`, and free orbit and Q/E already write `_target_yaw_degrees` directly with no bounds re-solve — so a director doing the same is doing exactly what you do with the mouse.

**`pose()` is not the door.** It snaps the yaw, adopts the result as the opening shot, and calls `drop_stashed_view()` — which is what the camera return we just shipped is holding. `CameraRig3D.aim_along()` is the director's own entry point and writes one thing.

## The seam

`OrderExecutor` cannot see the rig, so a beat publishes its **aim line** (`origin_cell -> target_cell`, the resolver's own aim) on the 2D camera and the rig turns that into a yaw — only the rig knows what to measure from. The line comes off the ATTACK rather than off the two units, so #47's swing at open ground still has a direction and a victim freed mid-pass cannot take the angle down with it.

`_beat_lines` is a third schedule beside `_beat_holds` and `_beat_subjects`, keyed identically, and inherits their rule: a beat left out means the camera keeps the angle it has.

Three yaws now live on the rig, named apart — `_home_*` is where the BOARD starts (what R restores), `_borrowed_*` is where YOU were standing, `_squared_up_yaw` is where THIS PASS started.

## The knobs

Two new Playback rows, `Camera angle: zoom off` / `Camera angle: zoom on`. Shaped like `drama_of`: **BOARD ships at 0.0**, which is bit-for-bit the square-on enemy phase the game has always played, so this cannot change the plain board unless you turn it up. Zoom-on ships at 1.0 — the full profile shot — and part-way is a hint of the angle without leaving the square-on read.

## Worth looking at when you play it

**Every sprite on the board re-faces as the camera turns.** `UnitMirror._refresh_facing_on_camera_turn` re-judges `flip_h` against the live camera basis, and the health cube grids `face()` it too — so a spin re-faces the whole board continuously. That is presumably the point, but it is the largest visible change here and you have not seen it.

**The spin is faster than the pan.** Yaw eases on `CameraRig3D.smoothing` (8.0, about 0.125s) while the travel takes `PLAYBACK_PAN` (0.5s), so the camera finishes turning before it finishes arriving. Slowing it is `smoothing`, an existing knob — but that knob also governs zoom, so if you want them decoupled that is a second number and I would rather you say than have me guess.

## Verification

`squad core dev` 633 cases / 0 failures / 0 orphans. `presentation` 404 / 0 / 0.

**Six mutants, five killed, one survived — and the survivor is the interesting one.** Measuring the turn from the LIVE yaw instead of from the detent the pass squared up to passed all 27 camera cases. At strength 0 and 1 the two formulations are identical, so only a PARTIAL turn can tell them apart and no case had one. What breaks is idempotence: the mirror re-solves every frame, so measured from the live yaw a half-strength turn creeps to the full angle over a few frames and the knob quietly stops meaning anything. `test_a_partial_turn_is_measured_from_where_the_pass_started` closes it.

The other five: dropping the yaw write, returning the far perpendicular, ignoring strength, deleting the publish (the #103-shaped wire mutant that survived on diff 1), and dropping the mirror poll.

**One test trap worth recording, because the first draft fell in it.** An aim along a board axis is already seen side-on from a detent, so an axial fixture gives a case that passes whether the camera turns or not — the first version of the headline case did exactly that. It aims diagonally now and asserts the gap is real before asserting the camera closed it. The second trap was the documented one: a pass on your own turn releases at the end and the release fires the view return, so a yaw read after `execute_orders` is the camera coming home rather than the shot.

## Still open on #520

Diff 2b (pitch driver, shake, micro-sway, the knockback and cliff follows) and diff 2c (lethality-aware direction).

Two findings that shape 2b, from tracing rather than guessing: **knockback-follow is nearly free** — `pan_to` ends in `follow(unit)` and a shove slides the unit's 2D position, so the camera already tracks a launched unit. **Cliff-follow is not** — the fall is 3D-only (`landing_fall_depth` / `void_fall_depth` are mirror-side offsets and the 2D position lands instantly), so following someone down needs a new 3D vertical authority. And the pitch driver is a second writer to `LookKnobs`' "Board pitch", a value you tune, so it has to offset and restore rather than assign.

Canon: `docs/design/visual-clarity.md` -> *The camera takes an ANGLE*, marker bumped to #564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
