### PR TITLE
#521 slice A: the tear-out seam and a static diorama

### DIFF
--- a/Classes/actions/OrderExecutor.gd
+++ b/Classes/actions/OrderExecutor.gd
@@ -100,14 +100,6 @@ func execute_orders(unit):
 	var camera_was_locked: bool = game.camera_controller.playback_locked
 	game.camera_controller.set_playback_locked(true)
 
-	# THE TEAR-OUT (#521): the ground this fight happens on lifts off the board into a diorama, and
-	# thuds back at the end. The cell set is the sheet's own -- computed once from the plan, and
-	# already documented there as this ticket's -- so there is no second answer to what is on stage.
-	#
-	# Gated on the PROFILE, which is what makes "displacement is provably zero with the cinematic
-	# off" a property rather than a promise. A pass with nothing to tear out stages nothing.
-	_stage_the_fight(sheet, profile)
-
 	# The camera goes to the walk and the walk WAITS for it (#520, dev 2026-08-26). Moves are
 	# parallel, so one subject is framed -- the leader when the leader is walking -- and pan_to's
 	# closing follow() carries the camera along beside it for free. No hold here: the pan IS the
@@ -117,6 +109,20 @@ func execute_orders(unit):
 	if walker != null:
 		await game.camera_controller.pan_to(walker, Pacing.PLAYBACK_PAN)
 	await _execute_action_phase_parallel(move_actions, _retire_move_markup)
+
+	# THE TEAR-OUT (#521): the ground the FIGHT happens on lifts off the board into a diorama, and
+	# thuds back at the end. The cell set is the sheet's own -- computed once from the plan, so there
+	# is no second answer to what is on stage -- and it holds only what MAIN ACTIONS touch, which is
+	# the dev's rule: *"there have to be main actions at play. Movement by itself doesn't do it."*
+	#
+	# AFTER the walk, not before it, and that is forced by the same rule: an attacker's origin_cell
+	# IS its post-move cell, so tearing out at the top of the pass makes it walk toward a hole and
+	# pop into the sky on arrival. The board is where you move; the diorama is where you fight.
+	#
+	# Gated on the PROFILE too, which is what makes "displacement is provably zero with the cinematic
+	# off" a property rather than a promise.
+	_stage_the_fight(sheet, profile)
+
 	await _execute_action_sequence(plan.attacks, beat, _beat_holds(sheet.volleys(false), profile, is_ai),
 			_beat_subjects(sheet.volleys(false)), _beat_lines(sheet.volleys(false)))
 	_apply_cell_effects(plan.cell_effects)
@@ -270,7 +276,12 @@ func _execute_action_sequence(actions: Array, beat: float = 0.0, holds: Dictiona
 func _stage_the_fight(sheet: BeatSheet, profile: Pacing.Profile) -> void:
 	if profile != Pacing.Profile.CINEMATIC:
 		return
+	# THE GATE, and it is asked of the FIGHT's cells BEFORE any bystander is added -- an empty sheet
+	# means no main actions, which is the whole rule. Asking after would let the feels-test flag put
+	# a move-only pass back on stage, i.e. re-create the exact thing it is there to be judged next to.
 	var cells: Array[Vector2i] = sheet.cells.duplicate()
+	if cells.is_empty():
+		return
 	if Experiments.is_on(Experiments.Flag.DIORAMA_BYSTANDERS):
 		var on_stage: Dictionary[Vector2i, bool] = {}
 		for cell in cells:
@@ -283,8 +294,6 @@ func _stage_the_fight(sheet: BeatSheet, profile: Pacing.Profile) -> void:
 			if not on_stage.has(cell):
 				on_stage[cell] = true
 				cells.append(cell)
-	if cells.is_empty():
-		return
 	BoardSpace.stage(cells, BoardSpace.lift_offset())
 
 

--- a/Classes/actions/OrderExecutor.gd
+++ b/Classes/actions/OrderExecutor.gd
@@ -100,6 +100,14 @@ func execute_orders(unit):
 	var camera_was_locked: bool = game.camera_controller.playback_locked
 	game.camera_controller.set_playback_locked(true)
 
+	# THE TEAR-OUT (#521): the ground this fight happens on lifts off the board into a diorama, and
+	# thuds back at the end. The cell set is the sheet's own -- computed once from the plan, and
+	# already documented there as this ticket's -- so there is no second answer to what is on stage.
+	#
+	# Gated on the PROFILE, which is what makes "displacement is provably zero with the cinematic
+	# off" a property rather than a promise. A pass with nothing to tear out stages nothing.
+	_stage_the_fight(sheet, profile)
+
 	# The camera goes to the walk and the walk WAITS for it (#520, dev 2026-08-26). Moves are
 	# parallel, so one subject is framed -- the leader when the leader is walking -- and pan_to's
 	# closing follow() carries the camera along beside it for free. No hold here: the pan IS the
@@ -124,6 +132,7 @@ func execute_orders(unit):
 		var batch: Array = side_channel.get(type, [])
 		var codas := sheet.codas(type)
 		await _execute_action_sequence(batch, beat, _beat_holds(codas, profile, is_ai), _beat_subjects(codas))
+	BoardSpace.clear_staging()   # the tiles thud back into their sockets (#521)
 	game.camera_controller.set_playback_locked(camera_was_locked)
 	# The last await has returned, so the pass is played out: released HERE rather than beside
 	# _end_squad_turn because everything below is synchronous (no frame renders between them) and
@@ -250,6 +259,34 @@ func _execute_action_sequence(actions: Array, beat: float = 0.0, holds: Dictiona
 
 		while not action.execution_complete:
 			await get_tree().process_frame
+
+# Which ground goes on stage (#521). BOARD stages nothing at all -- the tear-out is the cinematic's,
+# and #410's ruling that the two profiles SHARE timings is about pacing, not about lifting the board
+# into the sky. An empty cell set stages nothing either, so a pass with no fight in it is untouched.
+#
+# BYSTANDERS is the feels-test fork the ticket asks for, and it is one bool because the sheet has
+# already decided who is in the fight: OFF stages the cells the fight touches, ON adds the ground
+# every OTHER unit is standing on, so the diorama keeps its spatial context.
+func _stage_the_fight(sheet: BeatSheet, profile: Pacing.Profile) -> void:
+	if profile != Pacing.Profile.CINEMATIC:
+		return
+	var cells: Array[Vector2i] = sheet.cells.duplicate()
+	if Experiments.is_on(Experiments.Flag.DIORAMA_BYSTANDERS):
+		var on_stage: Dictionary[Vector2i, bool] = {}
+		for cell in cells:
+			on_stage[cell] = true
+		for child in game.units_root.get_children():
+			var unit := child as Unit
+			if unit == null:
+				continue
+			var cell := unit.get_projected_destination()
+			if not on_stage.has(cell):
+				on_stage[cell] = true
+				cells.append(cell)
+	if cells.is_empty():
+		return
+	BoardSpace.stage(cells, BoardSpace.lift_offset())
+
 
 # Pause schedule for one phase: the action that OPENS each beat -> how long to hold before it.
 # Keyed by the beat's first SURVIVING member, so a volley whose lead was skipped (R7 downs the

--- a/Classes/actions/resolution/BeatSheet.gd
+++ b/Classes/actions/resolution/BeatSheet.gd
@@ -126,9 +126,18 @@ var beats: Array[Beat] = []
 # by construction, so they are never gathered separately.
 var cast: Array[Unit] = []
 
-# Every cell the fight touches: attacker origins, aimed cells, whole knockback flights and their
-# landings, terrain deposits, and the standing cell of any cast member none of that mentions.
-# Slice #521's tear-out set is exactly this, computed once here rather than again there.
+# Every cell a MAIN ACTION touches: attacker origins, aimed cells, whole knockback flights and their
+# landings, terrain deposits, and the actor and target of every side-channel verb. Slice #521's
+# tear-out set is exactly this, computed once here rather than again there.
+#
+# MOVEMENT CONTRIBUTES NOTHING, and that is the rule rather than an omission (dev, 2026-08-26):
+# *"there have to be main actions at play. Movement by itself doesn't do it."* This used to sweep
+# every cast member's standing cell, so a pass that only walked tore holes in the board with no
+# fight in it. An attacker's post-move cell is still here -- it IS origin_cell.
+#
+# The tear-out's GATE therefore falls out of the set rather than being a second rule: no main
+# actions means no cells means nothing lifts. Whether a NON-fighter's ground comes along for
+# context is #521's own feels-test flag, which the cast sweep was a second answer to.
 var cells: Array[Vector2i] = []
 
 
@@ -314,9 +323,22 @@ func _gather_cells(plan: ResolvedPlan) -> void:
 			_mark(out.knockback_to, seen)
 	for effect in plan.cell_effects:
 		_mark(effect.cell, seen)
-	# A squadmate who neither acts nor is hit is still on stage, so its ground is torn out too.
-	for unit in cast:
-		_mark(unit.get_projected_destination(), seen)
+	# ...and the side-channel verbs, which are main actions too: a rescue tears out the ground the
+	# body is lifted from as much as a swing tears out the ground it lands on.
+	#
+	# Asked of is_main_action() rather than of SIDE_CHANNEL_ORDER membership, which today is
+	# MAIN_ACTION_TYPES minus ATTACK and so would give the same answer -- nothing pins that the two
+	# lists must keep agreeing, and the rule is about MAIN ACTIONS.
+	for beat in beats:
+		if beat.kind != Kind.CODA:
+			continue
+		for action in beat.actions:
+			if not action.is_main_action():
+				continue
+			_mark(action.actor.get_projected_destination(), seen)
+			var target := action.aimed_at()
+			if target != null and is_instance_valid(target):
+				_mark(target.get_projected_destination(), seen)
 
 
 func _mark(cell: Vector2i, seen: Dictionary) -> void:

--- a/Classes/core/Pacing.gd
+++ b/Classes/core/Pacing.gd
@@ -54,19 +54,19 @@ static var CINEMATIC_ACTION := 0.4
 # What a beat earns for what it WAS. These do not stack -- the loudest single hold wins -- so the
 # drama ranking is whatever these NUMBERS say rather than an order written into code. Tune
 # HOLD_KNOCKBACK above HOLD_DOWN and a shove outranks a death, deliberately.
-static var HOLD_DOWN := 0.6        # a unit goes down, is killed, maimed, or removed from the board
+static var HOLD_DOWN := 0.9        # a unit goes down, is killed, maimed, or removed from the board
 static var HOLD_CRISIS := 0.85      # someone stands up surged instead of falling
 static var HOLD_IRON_WILL := 0.45  # the cap BIT: that should have killed them and did not
-static var HOLD_KNOCKBACK := 0.2   # the hit shoved its target
-static var HOLD_TURNOVER := 0.5    # the act break: the defending line raises weapons
-static var HOLD_HEAL := 0.35       # HP came back -- the quiet beat this table had no row for
+static var HOLD_KNOCKBACK := 0.6   # the hit shoved its target
+static var HOLD_TURNOVER := 0.7    # the act break: the defending line raises weapons
+static var HOLD_HEAL := 0.45       # HP came back -- the quiet beat this table had no row for
 
 # The side-channel tail (dev, 2026-08-26: "the side channel actions are going to need emphasis as
 # well"). PER VERB rather than one shared number, because a rescue and a reload are not the same
 # moment. coda_hold() below is the one lookup.
 static var HOLD_RESCUE := 0.2
 static var HOLD_RALLY := 0.4
-static var HOLD_INTIMIDATE := 0.4
+static var HOLD_INTIMIDATE := 0.35
 static var HOLD_RELOAD := 0.2
 static var HOLD_REV := 0.15
 static var HOLD_BURROW := 0.25

--- a/Classes/dev/Experiments.gd
+++ b/Classes/dev/Experiments.gd
@@ -15,6 +15,7 @@ class_name Experiments
 
 enum Flag {
 	EXAMPLE_FLAG,
+	DIORAMA_BYSTANDERS,
 }
 
 # Per-flag metadata. Literal-only, so it can be a compile-time const (like STAT_DEFAULTS).
@@ -25,6 +26,11 @@ const DEFS := {
 	Flag.EXAMPLE_FLAG: {
 		"title": "Example flag",
 		"desc": "Throwaway sample proving the harness end-to-end. Safe to delete.",
+		"default": false,
+	},
+	Flag.DIORAMA_BYSTANDERS: {
+		"title": "Diorama keeps its bystanders",
+		"desc": "Tear out the ground under every unit, not just the fight's, so the battle diorama keeps its spatial context. #521's feels test -- pick one and the loser gets deleted.",
 		"default": false,
 	},
 }

--- a/Classes/dev/GameKnobs.gd
+++ b/Classes/dev/GameKnobs.gd
@@ -268,6 +268,7 @@ const MOVEMENT_SCRIPT := "res://Classes/units/MovementComponent.gd"
 const ACTION_MENU_SCRIPT := "res://Classes/ui/ActionMenuController.gd"
 const PACING_SCRIPT := "res://Classes/core/Pacing.gd"
 const MISSION_STATUS_SCRIPT := "res://Classes/ui/MissionStatusPanel.gd"
+const BOARD_SPACE_SCRIPT := "res://Classes/presentation/BoardSpace.gd"
 
 const CLASS_KNOBS: Array[Dictionary] = [
 	{"group": "Board markup colours", "label": "Move fill", "layer": BoardOverlays.Layer.MOVE,
@@ -383,6 +384,9 @@ const CLASS_KNOBS: Array[Dictionary] = [
 	{"group": "Playback", "label": "Drama: zoom on", "static": "CINEMATIC_DRAMA",
 		"script": PACING_SCRIPT, "min": 0.0, "max": 3.0, "step": 0.05,
 		"tip": "The same multiplier with the zoom on. At 0 the zoom paces flat; above 1 every big moment stretches together, so this is the one dial for 'more dramatic' overall."},
+	{"group": "Playback", "label": "How high the fight lifts off the board", "static": "STAGE_LIFT",
+		"script": BOARD_SPACE_SCRIPT, "min": 0.0, "max": 60.0, "step": 0.5,
+		"tip": "How far above the board the torn-out diorama sits, in cells. The fight plays up there and the tiles thud back into their sockets when it ends. At 0 the diorama sits inside the board it came from."},
 	{"group": "Playback", "label": "Camera angle: zoom off", "static": "BOARD_DIRECTION",
 		"script": PACING_SCRIPT, "min": 0.0, "max": 1.0, "step": 0.05,
 		"tip": "How far the camera turns to see each blast side-on, zoom off. Ships at 0 -- square-on, exactly as the enemy phase has always played. At 1 it takes the full profile shot."},
@@ -576,6 +580,7 @@ static func read_static(name: String) -> Variant:
 		"PLAYER_ACTION": return Pacing.PLAYER_ACTION
 		"AI_ACTION": return Pacing.AI_ACTION
 		"CINEMATIC_ACTION": return Pacing.CINEMATIC_ACTION
+		"STAGE_LIFT": return BoardSpace.STAGE_LIFT
 		"BOARD_DRAMA": return Pacing.BOARD_DRAMA
 		"CINEMATIC_DRAMA": return Pacing.CINEMATIC_DRAMA
 		"BOARD_DIRECTION": return Pacing.BOARD_DIRECTION
@@ -660,6 +665,9 @@ static func write_static(host: Node3D, name: String, value: Variant) -> void:
 			return
 		"CINEMATIC_ACTION":
 			Pacing.CINEMATIC_ACTION = value
+			return
+		"STAGE_LIFT":
+			BoardSpace.STAGE_LIFT = value
 			return
 		"BOARD_DRAMA":
 			Pacing.BOARD_DRAMA = value

--- a/Classes/presentation/BoardMirror.gd
+++ b/Classes/presentation/BoardMirror.gd
@@ -1078,6 +1078,14 @@ func _reconcile_prop(grid: TileMapLayer, cell: Vector2i, heights: BoardHeights) 
 # cell changes, so there is no per-cell fact to compare and invalidating at the source is the only
 # honest answer. (#342 widened the key to the corners, which is the opposite case — a per-CELL input
 # the reconcile already holds, read off the same store the build reads, so it cannot go stale.)
+# One cell's prop, so the next reconcile rebuilds it where its ground now is (#521). Invalidation at
+# the SOURCE, drop_props' shape, rather than widening _reconcile_prop's diff key: a tear-out changes
+# where a cell renders without changing anything the key is made of, so a prop left standing keeps
+# the position it had when its ground was still in the board.
+func drop_prop_at(cell: Vector2i) -> void:
+	_free_prop_at(cell)
+
+
 func drop_props() -> void:
 	for cell: Vector2i in _props.keys():
 		_props[cell].queue_free()

--- a/Classes/presentation/BoardMirror.gd
+++ b/Classes/presentation/BoardMirror.gd
@@ -226,6 +226,11 @@ const FLAME_FRAMES := 8
 @export var cover_scale := 0.98: set = _set_cover_scale
 
 var board: GridMap
+# The tear-out's second lattice (#521): same mesh library, same cell_size, same cell coordinates,
+# and a NODE transform carrying the staged offset. A staged cell's column is written here and
+# cleared from `board`, leaving the socket the exit will thud back into. Null outside Battle3D --
+# the look-dev scene has one board and never stages.
+var staged_board: GridMap
 
 # How many terrain diffs have run. Read by the test that pins COALESCING — a drag
 # crossing N cells inside one frame must cost one pass, not N.
@@ -374,12 +379,18 @@ func _flicker_of(marker: Node3D) -> float:
 func rebuild(grid: TileMapLayer, heights: BoardHeights, burning: Array[Vector2i],
 		covered: Array[Vector2i]) -> void:
 	board.clear()
+	if staged_board != null:
+		staged_board.clear()
 	sync(grid, heights)
 	refresh_states(heights, burning, covered)
 
 
+# Where anything STANDING on this cell goes -- and it is the one seam every per-cell node in this
+# file is placed by (props, flames, cover clusters, state markers), which is why the tear-out's
+# offset needs exactly this one line rather than an edit per object kind (#521).
 func surface_point(cell: Vector2i, heights: BoardHeights) -> Vector3:
-	return BoardSpace.surface_point(cell, heights)   # the one answer lives with the convention
+	# the one answer lives with the convention; the offset is zero unless this cell is torn out
+	return BoardSpace.surface_point(cell, heights) + BoardSpace.staged_offset(cell)
 
 
 # The live terrain diff: write only what differs, erase what the 2D no longer paints.
@@ -398,10 +409,14 @@ func sync(grid: TileMapLayer, heights: BoardHeights) -> void:
 	# A prop on a cell that lost its ground entirely: reconcile_cell's own else-branch covers a cell
 	# repainted from prop to flat, but this walk only visits cells that still HAVE ground.
 	_free_props_except(live)
-	# get_used_cells returns a copy, so erasing inside the walk is safe.
-	for cell: Vector3i in board.get_used_cells():
-		if not live.has(BoardSpace.flat(cell)):
-			board.set_cell_item(cell, GridMap.INVALID_CELL_ITEM)
+	# get_used_cells returns a copy, so erasing inside the walk is safe. BOTH maps: a torn-out cell
+	# whose ground the 2D no longer paints is over on the staged lattice (#521).
+	for map: GridMap in [board, staged_board]:
+		if map == null:
+			continue
+		for cell: Vector3i in map.get_used_cells():
+			if not live.has(BoardSpace.flat(cell)):
+				map.set_cell_item(cell, GridMap.INVALID_CELL_ITEM)
 
 
 # The INCREMENTAL door (#319), and the whole reason sync() above was split. Same reconcile, over the
@@ -449,11 +464,36 @@ func reconcile_cell(grid: TileMapLayer, cell: Vector2i, heights: BoardHeights,
 # rather than approximate: _write_column fills floor..level contiguously (plus the ramp wedge one
 # above), so a column can never have a hole for this to stop early on. The same contiguity is what
 # _write_column's own walk-up cleanup already assumes.
+# BOTH maps, because a cell that loses its ground may have been torn out at the time (#521) -- and
+# because "clear this column" must mean the same thing wherever the column happens to live.
 func _clear_column(cell: Vector2i, floor_row: int) -> void:
+	_clear_column_on(board, cell, floor_row)
+	_clear_column_on(staged_board, cell, floor_row)
+
+
+func _clear_column_on(map: GridMap, cell: Vector2i, floor_row: int) -> void:
+	if map == null:
+		return
 	var y := floor_row
-	while board.get_cell_item(Vector3i(cell.x, y, cell.y)) != GridMap.INVALID_CELL_ITEM:
-		board.set_cell_item(Vector3i(cell.x, y, cell.y), GridMap.INVALID_CELL_ITEM)
+	while map.get_cell_item(Vector3i(cell.x, y, cell.y)) != GridMap.INVALID_CELL_ITEM:
+		map.set_cell_item(Vector3i(cell.x, y, cell.y), GridMap.INVALID_CELL_ITEM)
 		y += 1
+
+
+# Which GridMap a cell's column belongs in (#521). A GridMap cell CANNOT be offset individually --
+# it is a lattice -- so the tear-out moves the tiles by writing them into a second map whose NODE
+# transform is the displacement. Both share one lattice and one mesh library, which is what makes
+# the diorama an exact reconstruction rather than an arithmetic one.
+#
+# Null staged_board (the look-dev scene, a bare fixture) simply never stages.
+func _map_for(cell: Vector2i) -> GridMap:
+	if staged_board != null and BoardSpace.is_staged(cell):
+		return staged_board
+	return board
+
+
+func _other_map(map: GridMap) -> GridMap:
+	return board if map == staged_board else staged_board
 
 
 # The lowest ROW any column has to reach down to. A dip must have a bottom rather than a hole,
@@ -487,6 +527,10 @@ func floor_row_of(heights: BoardHeights) -> int:
 # cell -- almost every cell -- has no cap to pick art for.
 func _write_column(cell: Vector2i, grid: TileMapLayer, item: int, heights: BoardHeights,
 		floor_row: int) -> void:
+	# Routed, and the OTHER map's column cleared first (#521): a cell that just staged (or just came
+	# home) still holds its old column over there, and nothing else would ever come back for it.
+	var map := _map_for(cell)
+	_clear_column_on(_other_map(map), cell, floor_row)
 	var corners := heights.corners_at(cell)
 	var top_row := BoardSpace.top_row_of(Terrain.low_of_corners(corners))   # units -> drawn row
 	# The block at top_row is LOAD-BEARING under a cap, not just filler: its top face sits exactly at
@@ -496,8 +540,8 @@ func _write_column(cell: Vector2i, grid: TileMapLayer, item: int, heights: Board
 	# this block and that half becomes a hole; draw it AND the cap's floor triangle and they fight.
 	for y in range(floor_row, top_row + 1):
 		var at := Vector3i(cell.x, y, cell.y)
-		if board.get_cell_item(at) != item:
-			board.set_cell_item(at, item)
+		if map.get_cell_item(at) != item:
+			map.set_cell_item(at, item)
 	var top := top_row
 	var climb := Terrain.climb_of_corners(corners)
 	if climb > 0:
@@ -505,21 +549,21 @@ func _write_column(cell: Vector2i, grid: TileMapLayer, item: int, heights: Board
 		var mask := Terrain.corner_mask(corners)
 		var orientation := _form_orientation(mask)
 		var cap_item := form_item_for_cell(grid, cell, mask, climb)
-		if board.get_cell_item(cap) != cap_item \
-				or board.get_cell_item_orientation(cap) != orientation:
-			board.set_cell_item(cap, cap_item, orientation)
+		if map.get_cell_item(cap) != cap_item \
+				or map.get_cell_item_orientation(cap) != orientation:
+			map.set_cell_item(cap, cap_item, orientation)
 		# The cap's own upper rows, declared but not drawn -- see RAMP_FILL_ITEM_NAME.
 		var fill := ramp_fill_item()
 		for y in range(top_row + 2, top_row + climb + 1):
 			var above_cap := Vector3i(cell.x, y, cell.y)
-			if board.get_cell_item(above_cap) != fill:
-				board.set_cell_item(above_cap, fill)
+			if map.get_cell_item(above_cap) != fill:
+				map.set_cell_item(above_cap, fill)
 		top = top_row + climb
 	# LOWERING a cell strands everything the column used to hold above its new top. Walk up until
 	# the column is genuinely clear rather than assuming one stale cell — a 5-level cut leaves 5.
 	var above := top + 1
-	while board.get_cell_item(Vector3i(cell.x, above, cell.y)) != GridMap.INVALID_CELL_ITEM:
-		board.set_cell_item(Vector3i(cell.x, above, cell.y), GridMap.INVALID_CELL_ITEM)
+	while map.get_cell_item(Vector3i(cell.x, above, cell.y)) != GridMap.INVALID_CELL_ITEM:
+		map.set_cell_item(Vector3i(cell.x, above, cell.y), GridMap.INVALID_CELL_ITEM)
 		above += 1
 
 

--- a/Classes/presentation/BoardSpace.gd
+++ b/Classes/presentation/BoardSpace.gd
@@ -14,6 +14,12 @@ class_name BoardSpace
 # UNITS_PER_LEVEL rows, which is what keeps every world position exactly where it was.
 # Boundary rule: a position exactly on a face floors UPWARD (cell_of is a volume
 # query for interior points; round-trip through cell_center, not standing_point).
+#
+# STATEFUL SINCE #521, and that is a deliberate change of character -- everything above is pure
+# arithmetic. The tear-out asks one new question, "is this cell STAGED, and where", and the dev's
+# ruling on #410 puts it here: answered where BoardSpace is already consulted, never in a separate
+# diorama scene, which would be a second answer to where a thing renders. A Staging class this
+# delegated to would be two names for one fact. Pacing and PlayerSettings are the precedent.
 
 const CELL_SIZE := 1.0
 
@@ -269,3 +275,74 @@ static func side_on_yaw(from: Vector2i, to: Vector2i, baseline: float) -> float:
 			< absf(angle_difference(deg_to_rad(baseline), deg_to_rad(side_on))):
 		return opposite
 	return side_on
+
+
+# --- the tear-out: which cells are staged, and where (#521) ------------------------------------
+#
+# Zero displacement IS the board, so every reader below is safe on an unstaged board and on a board
+# that has never staged anything. One rigid offset for the whole set rather than one per cell: the
+# diorama is a TRUE reconstruction (dev, #410), so board-relative geometry is preserved by moving
+# the set as a body -- exact by construction, with no arithmetic to get wrong.
+#
+# A static outlives a suite (#449's lesson on PlayerSettings._state), which is what reset_for_test
+# is for. Nothing here reads the profile: WHETHER to stage is the caller's question, and
+# OrderExecutor asks it once per pass.
+static var _staged: Dictionary[Vector2i, bool] = {}
+static var _stage_offset := Vector3.ZERO
+# How far above the board the diorama sits, in CELLS. A feel value, so it is a GameKnobs row rather
+# than a constant -- and a `static var` because that is the only form a knob can write.
+static var STAGE_LIFT := 24.0
+# Monotonic, so a per-frame poll can tell "the staging moved" from "it did not" without diffing the
+# set. DirtyCells.version's shape, and for the same reason: any number of readers, none consuming.
+static var staging_version := 0
+
+
+static func stage(cells: Array[Vector2i], offset: Vector3) -> void:
+	_staged.clear()
+	for cell in cells:
+		_staged[cell] = true
+	_stage_offset = offset
+	staging_version += 1
+
+
+static func clear_staging() -> void:
+	if _staged.is_empty():
+		return
+	_staged.clear()
+	_stage_offset = Vector3.ZERO
+	staging_version += 1
+
+
+# Where this cell's contents render, relative to the board. THE placement question -- every mirror
+# adds it at its own placement site, and the ground GridMap honours it as a node transform because
+# a GridMap cell cannot be offset individually.
+static func staged_offset(cell: Vector2i) -> Vector3:
+	return _stage_offset if _staged.has(cell) else Vector3.ZERO
+
+
+static func is_staged(cell: Vector2i) -> bool:
+	return _staged.has(cell)
+
+
+# The set itself, for the one reader that must walk it: the mirror re-routing whole columns between
+# the board and the staged GridMap when the staging changes.
+static func staged_cells() -> Array[Vector2i]:
+	var cells: Array[Vector2i] = []
+	cells.assign(_staged.keys())
+	return cells
+
+
+static func stage_offset() -> Vector3:
+	return _stage_offset
+
+
+# Where the diorama sits for a tear-out starting now. Straight up: the tiles rise OUT of the board
+# (#521), and the exit drops them back into the sockets they left.
+static func lift_offset() -> Vector3:
+	return Vector3(0.0, STAGE_LIFT * CELL_SIZE, 0.0)
+
+
+static func reset_for_test() -> void:
+	_staged.clear()
+	_stage_offset = Vector3.ZERO
+	staging_version = 0

--- a/Classes/presentation/OverlayMirror.gd
+++ b/Classes/presentation/OverlayMirror.gd
@@ -46,6 +46,13 @@ var _pick_texture: Texture2D   # the (1,0) "pick this unit" tile art, cut lazily
 var _last_heights_version := -1
 var _heights_moved := false
 
+# ...and blind to the TEAR-OUT the same way (#521): a flame stands on its cell's surface, and the
+# whole cell can lift off the board while the burning set stays byte-identical. #308's rule applied
+# to the second store this poll now draws through -- gate on that store having moved, never on a
+# copy of what it holds.
+var _last_staging_version := -1
+var _staging_moved := false
+
 var _last_trace_version := -1   # OverlayManager.sight_trace_version -- the store's own signal (#308)
 
 # How far the drop pointer stands off the cliff face it hangs on (#431), in cells. A depth-buffer
@@ -68,6 +75,7 @@ func _process(_delta: float) -> void:
 		return
 	var om: OverlayManager = game.overlay_manager
 	_heights_moved = _poll_heights()   # once per frame, ahead of every diff that reads it
+	_staging_moved = _poll_staging()
 
 	_fill(BoardOverlays.Layer.MOVE, om.move_overlay.get_used_cells())
 	_fill(BoardOverlays.Layer.INVALID_MOVE, om.invalidmove_overlay.get_used_cells())
@@ -112,6 +120,16 @@ func _poll_heights() -> bool:
 	return true
 
 
+# Has the tear-out moved since the last frame (#521)? BoardSpace.staging_version is monotonic and
+# non-consuming -- DirtyCells.version's shape -- so battle3d's own staging poll and this one can
+# both read it without either taking it away from the other.
+func _poll_staging() -> bool:
+	if BoardSpace.staging_version == _last_staging_version:
+		return false
+	_last_staging_version = BoardSpace.staging_version
+	return true
+
+
 # Which cells are alight and which are dug in, each straight off its ONE enumeration form. Polled
 # rather than wired because a states_changed signal would fire inside the resolver's per-effect
 # loop and churn markers many times within a single pass; the poll coalesces a frame into one
@@ -125,7 +143,7 @@ func _standing_states() -> void:
 	covered.sort()
 	# A marker STANDS on its cell's surface, so raising that cell moves it while the burning set
 	# stays byte-identical (#308).
-	if not _heights_moved and _last_fire == burning and _last_cover == covered:
+	if not _heights_moved and not _staging_moved and _last_fire == burning and _last_cover == covered:
 		return
 	_last_fire = burning
 	_last_cover = covered

--- a/Classes/presentation/OverlayMirror.gd
+++ b/Classes/presentation/OverlayMirror.gd
@@ -422,8 +422,12 @@ func _ribbon_point(cell: Vector2i, at: Vector3) -> Vector3:
 # Flat CORNERS for the same reason and it is the literal truth: it lies on nothing, so it takes the
 # flat quad however folded the ground beneath it happens to be.
 func _air_anchor(px: Vector2, from_cell: Vector2i) -> Dictionary:
-	var flight_y := BoardSpace.surface_transform(from_cell, _heights()).origin.y
-	return {"surface": Transform3D(Basis.IDENTITY, BoardSpace.of_pixels(px, flight_y)),
+	# The flight hangs over the cell it was LAUNCHED from, so it is that cell's tear-out it follows
+	# (#521) -- the whole offset, since this builds its origin rather than inheriting one.
+	var staged := BoardSpace.staged_offset(from_cell)
+	var flight_y := BoardSpace.surface_transform(from_cell, _heights()).origin.y + staged.y
+	return {"surface": Transform3D(Basis.IDENTITY,
+			BoardSpace.of_pixels(px, flight_y) + Vector3(staged.x, 0.0, staged.z)),
 			"corners": Vector4i.ZERO}
 
 
@@ -541,16 +545,25 @@ func _marker(anchor: Dictionary, texture: Texture2D, tint: Color) -> Dictionary:
 # lies flat against the slope. BoardSpace.surface_transform is the one answer.
 func _anchor(cell: Vector2i) -> Dictionary:
 	var heights := _heights()
-	return {"surface": BoardSpace.surface_transform(cell, heights),
+	# The tear-out rides here too (#521): markup belongs to the cell it marks, so it goes wherever
+	# that cell went. One line, because this is the one answer for every marker in the file.
+	var surface := BoardSpace.surface_transform(cell, heights)
+	surface.origin += BoardSpace.staged_offset(cell)
+	return {"surface": surface,
 			"corners": Vector4i.ZERO if heights == null else heights.corners_at(cell)}
 
 
 # The same, for a 2D world position (sprites sit at cell centers). The LEVEL and the SLOPE both come
 # from the cell those pixels fall in, so a ghost or arrow over a terrace lifts and tilts with it.
 func _anchor_px(px: Vector2) -> Dictionary:
-	var anchor := _anchor(_cell_of_px(px))
+	var cell := _cell_of_px(px)
+	var anchor := _anchor(cell)
 	var surface: Transform3D = anchor["surface"]
-	anchor["surface"] = Transform3D(surface.basis, BoardSpace.of_pixels(px, surface.origin.y))
+	# Only the HORIZONTAL half of the tear-out offset (#521): the vertical already arrived through
+	# _anchor's surface origin, and of_pixels is what replaces x and z.
+	var staged := BoardSpace.staged_offset(cell)
+	anchor["surface"] = Transform3D(surface.basis,
+			BoardSpace.of_pixels(px, surface.origin.y) + Vector3(staged.x, 0.0, staged.z))
 	return anchor
 
 

--- a/Classes/presentation/UnitMirror.gd
+++ b/Classes/presentation/UnitMirror.gd
@@ -404,7 +404,14 @@ func _sync(unit: Unit, sprite: UnitSprite3D) -> void:
 	# Half a ROW down, not half a cell (#427 slice 2): the standing point sits exactly on a row
 	# boundary, and the cell wanted is the one BELOW it — dropping a whole row would name the one
 	# under that.
+	#
+	# Taken BEFORE the tear-out offset (#521): a sprite's CELL is a board fact, and the diorama is
+	# the same board somewhere else. Reading it off the displaced point would name a cell in the sky.
 	sprite.cell = BoardSpace.cell_of(stand - Vector3(0.0, BoardSpace.ROW_HEIGHT * 0.5, 0.0))
+	# ...and the sprite goes wherever the ground it is standing on went. The horizontal half comes
+	# from PIXELS above rather than from BoardSpace, which is why the offset is added to the whole
+	# placement here instead of hiding inside surface_point.
+	stand += BoardSpace.staged_offset(over)
 	# The attack lunge and the invalid-order shake (#321) tween $MapSprite's LOCAL position, which
 	# unit.position never sees — the one fact UnitVisuals expresses that the reads above cannot
 	# reach. Mapped through the same metric and the same axes as the stand point: a 2D y is board
@@ -552,7 +559,10 @@ func _bar_anchor(unit: Unit, sprite: UnitSprite3D) -> Vector3:
 	var lift := Vector3(0.0, sprite.art_top_height() + hud_lift, 0.0)
 	if not unit.visuals.projected:
 		return sprite.position + lift
-	return BoardSpace.surface_point(unit.get_projected_destination(), heights) + lift
+	# The ghost's cell, so the readout rides the diorama with the ground it is over (#521). The
+	# branch above needs no offset: sprite.position already carries it.
+	var ghost_cell := unit.get_projected_destination()
+	return BoardSpace.surface_point(ghost_cell, heights) + BoardSpace.staged_offset(ghost_cell) + lift
 
 
 # HP moving, and what the readout does about it (#314). The BASELINE is written before anything

--- a/Scenes/Battle3D/Battle3D.tscn
+++ b/Scenes/Battle3D/Battle3D.tscn
@@ -62,6 +62,10 @@ shadow_enabled = true
 mesh_library = ExtResource("6")
 cell_size = Vector3(1, 0.5, 1)
 
+[node name="StagedBoard" type="GridMap" parent="." unique_id=1466093521]
+mesh_library = ExtResource("6")
+cell_size = Vector3(1, 0.5, 1)
+
 [node name="BoardOverlays" type="Node3D" parent="." unique_id=1690625544]
 script = ExtResource("5")
 

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -113,6 +113,9 @@ var _floor_row := 0
 # would walk every column of the board each time the mouse moves.
 var _board_rect := Rect2i()
 var _pointer_cell: Vector3i = BoardSpace.NO_CELL
+# The staging this poll last drew (#521) -- its own last-drawn key, the _help_* fields' shape.
+var _staged_version := 0
+var _staged_drawn: Array[Vector2i] = []
 # Which grid VERTEX the pointer is nearest (#427 slice 4). Stored beside the cell rather than derived
 # from it: it changes as the cursor crosses the MIDDLE of a cell, so the cell early-out below would
 # freeze it for the whole tile.
@@ -157,6 +160,7 @@ func _ready() -> void:
 		get_viewport().size_changed.connect(_position_pip)
 		_update_help()
 	_board_mirror.board = $Board
+	_board_mirror.staged_board = $StagedBoard
 	_unit_mirror.units_root = game.units_root
 	_unit_mirror.heights = game.board_heights
 	_unit_mirror.hovered_unit_source = _hovered_unit
@@ -258,6 +262,33 @@ func _refresh_tops() -> void:
 # and panning stops at the old edge. Bounds only, never a re-frame: the 2D twin
 # (CameraController.refresh_bounds) moves limits and never re-aims, and yanking the
 # camera mid-stroke is not what painting a tile should do.
+# The tear-out's reconcile (#521): when the staged set changes, the cells that CROSSED between the
+# board and the diorama have to be re-routed, and the staged lattice moved to its offset.
+#
+# The UNION of what was staged and what is staged now, because a cell coming HOME is as much a
+# change as one going up and neither set alone names it. Gated on a monotonic version rather than a
+# diff, DirtyCells.version's shape -- and the previously-staged set is remembered here rather than
+# on BoardSpace, because it is this poll's own last-drawn key, not a fact about the board.
+func _sync_staging() -> void:
+	if BoardSpace.staging_version == _staged_version:
+		return
+	_staged_version = BoardSpace.staging_version
+	var now := BoardSpace.staged_cells()
+	var touched: Dictionary[Vector2i, bool] = {}
+	for cell in _staged_drawn:
+		touched[cell] = true
+	for cell in now:
+		touched[cell] = true
+	_staged_drawn = now
+	$StagedBoard.position = BoardSpace.stage_offset()
+	if touched.is_empty():
+		return
+	var cells: Array[Vector2i] = []
+	cells.assign(touched.keys())
+	_board_mirror.sync_cells(game.grid, cells, game.board_heights,
+			_board_mirror.floor_row_of(game.board_heights))
+
+
 func _sync_terrain_while_authoring() -> void:
 	if game.game_state != game.GameState.DEV_MODE:
 		return
@@ -518,6 +549,7 @@ func _process(_delta: float) -> void:
 	_rig.set_process(live)
 	_rig.set_process_unhandled_input(live)
 	_sync_terrain_while_authoring()
+	_sync_staging()
 	# Separate from `live`, and deliberately so: while the AI acts or a menu is up the
 	# rig must keep SMOOTHING (the mirror below drives it) while refusing the player.
 	# Same predicate that refuses their clicks — one question, one answer.

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -285,6 +285,11 @@ func _sync_staging() -> void:
 		return
 	var cells: Array[Vector2i] = []
 	cells.assign(touched.keys())
+	# The props go FIRST: _reconcile_prop leaves a standing one alone when its tile and corners are
+	# unchanged, which a tear-out does not touch -- so without this a crate stays on the board its
+	# ground just left. The flames re-seat through OverlayMirror's own staging poll.
+	for cell in cells:
+		_board_mirror.drop_prop_at(cell)
 	_board_mirror.sync_cells(game.grid, cells, game.board_heights,
 			_board_mirror.floor_row_of(game.board_heights))
 

--- a/docs/SCRATCHPAD.md
+++ b/docs/SCRATCHPAD.md
@@ -38,6 +38,11 @@ Then report a short per-idea summary: where each went, and anything that needs t
 
 - Hover-until-appear time should maybe be a dev-mode toggle *(dev, 2026-08-22, filed at his request during #467 round 3 — "maybe hover until appear time should be a dev mode toggle, file that away")*. Context so the sweep does not have to re-derive it: the action ring's readout now waits out `gui/timers/tooltip_delay_sec`, the **project** setting the inspect panel's own tooltips already read, so there is exactly one number and no second seam. A dev toggle would be a *second writer* of that number, which is [#422](https://github.com/Phaazoid/Godoiosis/issues/422)'s question (dev defaults vs player settings) rather than a knob-table line — and note the same value is arguably a **player** setting, not a dev one, since a slow reader and a fast one want different waits.
 
+
+Currently, the camera still has a few cases where it teleports - this should never happen, it should always be a pan.  Plus, on the AIs turn, when the camera is showing their movement, instead of just centering on the unit, it should try to show both their start and end position in the initial shot (should be doable unless super zoomed in)
+
+I don't see a dev tuning tool for wait on unit death - currently the camera leaves while the health blocks are still exploding, no drama there.  
+
 ## 🗂 Dispersed (log)
 
 *Swept 2026-08-20 — twelve entries. Four were issue-shaped and are now **filed**: [#417](https://github.com/Phaazoid/Godoiosis/issues/417) move re-entry, [#418](https://github.com/Phaazoid/Godoiosis/issues/418) the health-bar third option, [#419](https://github.com/Phaazoid/Godoiosis/issues/419) the hazard warning, [#420](https://github.com/Phaazoid/Godoiosis/issues/420) the composed-view question behind the glow ask. The last two are filed `agent/human` because each waits on a design fork this sweep deliberately left unpicked.*

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -1374,10 +1374,29 @@ cannot be offset individually** — it is a lattice — so:
 **A sprite's CELL is still a board fact.** `UnitMirror` reads it *before* adding the offset —
 reading it off the displaced point would name a cell in the sky.
 
-**Staged on the profile, so the law is a property rather than a promise.** `OrderExecutor` stages
-`BeatSheet.cells` — already computed once from the plan, and already documented there as this
-ticket's set — and stages nothing at all under `BOARD`. `tests/presentation/test_staging.gd` asserts
-zero displacement for **every painted cell** after a plain-board pass, read off the seam directly.
+**A MAIN ACTION is what tears the board open — movement never does** (dev, on playing it:
+*"there have to be main actions at play. Movement by itself doesn't do it."*). `BeatSheet.cells` is
+therefore what main actions touch: an attack's origin, aim, knockback flight and terrain deposits,
+plus the actor and target of every side-channel verb. Asked of `BaseAction.is_main_action()` rather
+than of `SIDE_CHANNEL_ORDER` membership — the two lists agree today and nothing pins that they must.
+
+**The GATE falls out of the SET rather than sitting beside it**: no main actions means no cells
+means nothing lifts. That is one rule, not two, and it is why `_stage_the_fight` asks whether the
+fight's cells are empty **before** the bystanders flag adds anything — asking after would let the
+feels-test put move-only passes back in the sky, which is the exact thing it exists to be judged
+against.
+
+What this replaced was a sweep over every cast member's standing cell, and the symptom was a hole
+in the board at the end of every move. It was also a Law #4 duplicate: whether a *non-fighter's*
+ground comes along is the feels-test flag's question, and the cast sweep was a second answer to it.
+
+**The tear-out waits for the walk.** An attacker's `origin_cell` is its *post-move* cell, so staging
+before the move phase makes it walk toward a hole and pop into the sky on arrival. The board is
+where you move; the diorama is where you fight.
+
+**Staged on the profile too, so #521's law is a property rather than a promise** — nothing stages
+under `BOARD`, and `tests/presentation/test_staging.gd` asserts zero displacement for **every
+painted cell** after a plain-board pass, read off the seam directly.
 
 **The feels-test fork is one bool**, `Experiments.Flag.DIORAMA_BYSTANDERS`: off stages the cells the
 fight touches, on adds the ground every other unit stands on so the diorama keeps its spatial

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -7,7 +7,7 @@ its child [#49 Action Queue UX](https://github.com/Phaazoid/Godoiosis/issues/49)
 This is a *guidelines* doc, not a spec — it captures the principles we're holding the work to,
 plus the running order of the queue-UX checklist. Update it as items land.
 
-**Canon checked through #564 (2026-08-26).**
+**Canon checked through #565 (2026-08-26).**
 
 ## Principles
 
@@ -1338,6 +1338,53 @@ before asserting the camera closed it.
 
 Still open on #520: the pitch driver, the shake and micro-sway, the knockback and cliff follows
 (diff 2b), and lethality-aware direction (diff 2c).
+
+## The fight TEARS OUT of the board ([#521](https://github.com/Phaazoid/Godoiosis/issues/521) slice A, BUILT 2026-08-26)
+
+The ground a fight happens on lifts off the board into a diorama and thuds back when the pass ends.
+This slice is the **seam and a static tear-out** — no rise off the top of frame, no white-out, no
+one-by-one slam. What it buys is the question every later slice depends on: does the reconstruction
+read right?
+
+**One question, one answer: `BoardSpace.staged_offset(cell)`.** The dev's ruling on #410 puts it
+here — *answered where `BoardSpace` is already consulted*, never in a separate diorama scene, which
+would be a second answer to where a thing renders. `Vector3.ZERO` is the board, so every reader is
+inert on a board that has never staged.
+
+**It makes `BoardSpace` stateful for the first time**, and that is declared in its own header: the
+file was pure arithmetic. A `Staging` class it delegated to would be two names for one fact.
+`Pacing` and `PlayerSettings` are the precedent, and #449's hazard comes with it — a static outlives
+a suite, hence `reset_for_test()`.
+
+**Two mechanisms honour that one answer, and the split is forced by the engine.** A **GridMap cell
+cannot be offset individually** — it is a lattice — so:
+
+- **The ground routes to a second `GridMap`** (`$StagedBoard`), same mesh library, same `cell_size`,
+  same cell coordinates, with the displacement as its **node transform**. A staged cell's column is
+  written there and cleared from `$Board`, leaving the socket the exit thuds back into. Because both
+  share one lattice, **the reconstruction is exact by construction** — board-relative geometry,
+  horizontal and vertical, with no arithmetic to get wrong.
+- **Everything else adds the offset at its own placement site** — and there are far fewer than there
+  look to be. `BoardMirror.surface_point` is the one seam every prop, flame, cover cluster and state
+  marker in that file is placed by; `OverlayMirror._anchor` is the one seam every marker gets its
+  transform from. Units are the exception that proves why the offset is its own question:
+  **`UnitMirror` places horizontally from PIXELS, not from `BoardSpace`**, so an offset hidden
+  inside `surface_point` would have lifted a unit vertically and left it behind horizontally.
+
+**A sprite's CELL is still a board fact.** `UnitMirror` reads it *before* adding the offset —
+reading it off the displaced point would name a cell in the sky.
+
+**Staged on the profile, so the law is a property rather than a promise.** `OrderExecutor` stages
+`BeatSheet.cells` — already computed once from the plan, and already documented there as this
+ticket's set — and stages nothing at all under `BOARD`. `tests/presentation/test_staging.gd` asserts
+zero displacement for **every painted cell** after a plain-board pass, read off the seam directly.
+
+**The feels-test fork is one bool**, `Experiments.Flag.DIORAMA_BYSTANDERS`: off stages the cells the
+fight touches, on adds the ground every other unit stands on so the diorama keeps its spatial
+context. A session-scoped dev toggle — one of the two gets deleted once it has been played.
+
+Still open on #521: the transition both ways (rise, white-out, the one-by-one slam in queue order,
+the exit thud and its dust shockwave), and strata on the cut edges, which is art-pass work.
 
 ## #44 board-side items (cross-referenced, not in this doc's running order)
 

--- a/tests/presentation/test_staging.gd
+++ b/tests/presentation/test_staging.gd
@@ -1,0 +1,231 @@
+# The TEAR-OUT seam (#521 slice A, umbrella #410): one question -- "is this cell STAGED, and
+# where" -- and whether every surface that draws a cell honours the answer.
+#
+# Two mechanisms carry one answer, because a GridMap cell CANNOT be offset individually: the ground
+# routes to a second lattice whose node transform is the displacement, and everything else (units,
+# health readouts, props, markup) adds the offset at its own placement site. Both read
+# BoardSpace.staged_offset, so a case that pins one does not pin the other -- hence cases for each.
+#
+# The offset is READ back rather than written down anywhere below (BoardSpace.stage_offset), so the
+# lift stays a knob the dev can move without reddening a line here.
+extends GdUnitTestSuite
+
+const SCENE_PATH := "res://Scenes/Battle3D/Battle3D.tscn"
+const PROLOG := "res://Scenarios/missions/Prolog.tres"
+
+var _scene: Node3D
+var _game: Node2D
+var _board: GridMap
+var _staged: GridMap
+var _unit_mirror: UnitMirror
+
+
+func before_test() -> void:
+	# A static outlives a suite (#449). Cleared at BOTH ends: a case that leaves the board in the
+	# sky poisons every case after it, and the poll that draws it is per-frame.
+	BoardSpace.reset_for_test()
+	get_tree().root.size = Vector2i(1280, 720)
+	var packed := load(SCENE_PATH) as PackedScene
+	_scene = packed.instantiate() as Node3D
+	_scene.auto_play = false
+	get_tree().root.add_child(_scene)
+	await await_idle_frame()
+	_game = _scene.game
+	_board = _scene.get_node("Board") as GridMap
+	_staged = _scene.get_node("StagedBoard") as GridMap
+	_unit_mirror = _scene.get_node("UnitMirror") as UnitMirror
+	_scene.load_mission(PROLOG)
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	BoardSpace.reset_for_test()
+	PlayerSettings.reset_for_test()
+	await DialogFixtures.end_all_dialog(self)   # the mission door arms #182 dialog; end it or it leaks
+	get_tree().root.remove_child(_scene)
+	_scene.free()
+
+
+# --- the question itself -----------------------------------------------------------------------
+
+# ZERO displacement IS the board, and that is what makes every reader safe on a board that has
+# never staged. Asked of every painted cell rather than a sample: the seam has to be inert
+# everywhere, not on average.
+func test_an_unstaged_board_displaces_nothing() -> void:
+	var painted: Array[Vector2i] = _painted_cells()
+	assert_array(painted).override_failure_message(
+			"fixture drifted: the mission painted no cells").is_not_empty()
+	for cell in painted:
+		assert_vector(BoardSpace.staged_offset(cell)).override_failure_message(
+				"%s was displaced on a board nothing staged" % cell).is_equal(Vector3.ZERO)
+
+
+func test_a_staged_cell_answers_the_offset_and_the_rest_of_the_board_does_not() -> void:
+	var painted := _painted_cells()
+	var on_stage: Vector2i = painted[0]
+	BoardSpace.stage([on_stage] as Array[Vector2i], BoardSpace.lift_offset())
+
+	assert_vector(BoardSpace.staged_offset(on_stage)).is_equal(BoardSpace.stage_offset())
+	assert_bool(BoardSpace.is_staged(on_stage)).is_true()
+	var off_stage := _a_cell_other_than(on_stage)
+	assert_vector(BoardSpace.staged_offset(off_stage)).override_failure_message(
+			"a cell nobody staged came up with the diorama").is_equal(Vector3.ZERO)
+
+
+# --- the ground: two lattices, one set of coordinates -------------------------------------------
+
+# The tiles LEAVE the board and arrive on the staged lattice at the SAME cell coordinates -- which
+# is what makes the diorama an exact reconstruction rather than an arithmetic one -- and the hole
+# they leave is the socket the exit will thud them back into.
+func test_a_torn_out_column_moves_to_the_staged_lattice_and_comes_home() -> void:
+	var cell := _painted_cells()[0]
+	var column := _column_of(_board, cell)
+	assert_array(column).override_failure_message(
+			"fixture drifted: this cell has no column on the board").is_not_empty()
+
+	BoardSpace.stage([cell] as Array[Vector2i], BoardSpace.lift_offset())
+	await _settle()
+
+	assert_array(_column_of(_board, cell)).override_failure_message(
+			"the ground stayed in the board it was torn out of").is_empty()
+	assert_array(_column_of(_staged, cell)).override_failure_message(
+			"the torn-out column did not arrive on the staged lattice").is_equal(column)
+
+	BoardSpace.clear_staging()
+	await _settle()
+
+	assert_array(_column_of(_staged, cell)).override_failure_message(
+			"the column stayed in the sky after the staging cleared").is_empty()
+	assert_array(_column_of(_board, cell)).override_failure_message(
+			"the column did not thud back into its socket").is_equal(column)
+
+
+# The staged lattice carries the displacement as its NODE transform -- the whole reason a second
+# GridMap exists, since a cell inside one cannot be offset at all.
+func test_the_staged_lattice_carries_the_displacement_as_its_own_transform() -> void:
+	BoardSpace.stage([_painted_cells()[0]] as Array[Vector2i], BoardSpace.lift_offset())
+	await _settle()
+	assert_vector(_staged.position).is_equal(BoardSpace.stage_offset())
+
+	BoardSpace.clear_staging()
+	await _settle()
+	assert_vector(_staged.position).override_failure_message(
+			"the staged lattice stayed in the sky with nothing on it").is_equal(Vector3.ZERO)
+
+
+# --- everything that is not a tile --------------------------------------------------------------
+
+# A unit rides the ground it is standing on. Its sprite is placed from PIXELS, not from BoardSpace,
+# which is exactly why the offset has to be added to the whole placement rather than hidden inside
+# surface_point -- an offset applied only to the surface query would move it vertically and leave it
+# behind horizontally.
+func test_a_unit_on_torn_out_ground_rides_up_with_it() -> void:
+	var unit := _a_unit()
+	assert_object(unit).override_failure_message("fixture drifted: no unit on this board").is_not_null()
+	var sprite := _unit_mirror.sprite_for(unit)
+	await _settle()
+	var home: Vector3 = sprite.position
+
+	var cell: Vector2i = unit.movement.cell
+	BoardSpace.stage([cell] as Array[Vector2i], BoardSpace.lift_offset())
+	await _settle()
+
+	var offset := BoardSpace.stage_offset()
+	# Non-vacuity: at a zero lift the assertion below is true whether anything moved or not.
+	assert_float(offset.length()).override_failure_message(
+			"the lift is zero, so this case cannot fail").is_greater(0.1)
+	assert_vector(sprite.position).override_failure_message(
+			"the unit stayed on the board its ground left").is_equal_approx(home + offset, Vector3.ONE * 0.01)
+
+
+# --- the wire into a real pass ------------------------------------------------------------------
+
+# The executor tears out and puts back, and BOTH ends are pinned by one case -- the version moves
+# (so it staged at all) and the board is flat again afterwards (so it cleared). Written against the
+# VERSION rather than by watching mid-pass, because clear_staging runs before execute_orders
+# returns and there is no frame in between to look at.
+func test_a_pass_tears_the_fight_out_and_puts_the_board_back() -> void:
+	PlayerSettings.set_on(PlayerSettings.Setting.BATTLE_ZOOM, true)
+	var unit := _a_unit()
+	_queue_a_move(unit)
+	var before := BoardSpace.staging_version
+
+	await _game.order_executor.execute_orders(unit)
+	await _settle()
+
+	assert_int(BoardSpace.staging_version).override_failure_message(
+			"the pass never staged anything").is_greater(before)
+	for cell in _painted_cells():
+		assert_vector(BoardSpace.staged_offset(cell)).override_failure_message(
+				"%s was left in the sky after the pass" % cell).is_equal(Vector3.ZERO)
+
+
+# THE LAW #521 asks for: with the cinematic off, displacement is provably zero EVERYWHERE. Read off
+# the seam directly -- never off a mirror, which something rebuilds every frame and would report
+# zero for a reason of its own. The version is asserted too, so "nothing was displaced" cannot pass
+# by having staged and cleared within the pass.
+func test_with_the_cinematic_off_a_pass_displaces_nothing_at_all() -> void:
+	PlayerSettings.set_on(PlayerSettings.Setting.BATTLE_ZOOM, false)
+	var unit := _a_unit()
+	_queue_a_move(unit)
+	var before := BoardSpace.staging_version
+
+	await _game.order_executor.execute_orders(unit)
+	await _settle()
+
+	assert_int(BoardSpace.staging_version).override_failure_message(
+			"the plain board staged something and put it back").is_equal(before)
+	for cell in _painted_cells():
+		assert_vector(BoardSpace.staged_offset(cell)).override_failure_message(
+				"%s was displaced with the cinematic off" % cell).is_equal(Vector3.ZERO)
+
+
+# --- helpers ------------------------------------------------------------------------------------
+
+func _painted_cells() -> Array[Vector2i]:
+	var cells: Array[Vector2i] = []
+	cells.assign(_game.grid.get_used_cells())
+	return cells
+
+
+func _a_cell_other_than(cell: Vector2i) -> Vector2i:
+	for other in _painted_cells():
+		if other != cell:
+			return other
+	return cell
+
+
+# The rows of a cell's column, top to bottom, as meshlib item ids -- what the tear-out has to move
+# without changing. Read off the lattice rather than re-derived, so the case compares the SAME
+# question on both sides.
+func _column_of(map: GridMap, cell: Vector2i) -> Array[int]:
+	var items: Array[int] = []
+	for at: Vector3i in map.get_used_cells():
+		if at.x == cell.x and at.z == cell.y:
+			items.append(map.get_cell_item(at))
+	return items
+
+
+func _a_unit() -> Unit:
+	for child in _game.units_root.get_children():
+		var unit := child as Unit
+		if unit != null:
+			return unit
+	return null
+
+
+# The production door game._click_choosing_move uses, minus the click.
+func _queue_a_move(unit: Unit) -> void:
+	var moverange = _game.compute_move_range(unit)
+	var destinations: Array[Vector2i] = _game.get_move_range(moverange, unit)
+	if destinations.is_empty():
+		return
+	_game.enter_move_mode(unit)
+	_game.selected_unit = unit
+	_game._on_left_click(destinations[0])
+
+
+# The rig's own settle: process_frame resumes coroutines BEFORE node _process, so one frame is stale.
+func _settle() -> void:
+	await await_idle_frame()
+	await await_idle_frame()

--- a/tests/presentation/test_staging.gd
+++ b/tests/presentation/test_staging.gd
@@ -138,6 +138,58 @@ func test_a_unit_on_torn_out_ground_rides_up_with_it() -> void:
 			"the unit stayed on the board its ground left").is_equal_approx(home + offset, Vector3.ONE * 0.01)
 
 
+# Anything STANDING on a torn-out cell goes up with it -- props, cover, and the flames here, all of
+# which BoardMirror places through its own surface_point. Driven end to end (deposit real fire, let
+# the poll stand it up, tear the cell out) because that offset is a wire and #103's law applies:
+# ADDED AFTER a mutant deleting it survived every case in this file.
+func test_what_stands_on_torn_out_ground_goes_up_with_it() -> void:
+	var cell := _painted_cells()[0]
+	var effect := ResolvedCellEffect.new()
+	effect.cell = cell
+	effect.states_added.assign([Terrain.TileState.BLAZE])
+	_game.terrain_states.apply(effect)
+	await _settle()
+
+	var mirror := _scene.get_node("BoardMirror") as BoardMirror
+	var flame := mirror.fire_marker_at(cell)
+	assert_object(flame).override_failure_message(
+			"no flame was ever stood up -- this case cannot see the offset").is_not_null()
+	var home: Vector3 = flame.position
+
+	BoardSpace.stage([cell] as Array[Vector2i], BoardSpace.lift_offset())
+	await _settle()
+
+	var offset := BoardSpace.stage_offset()
+	assert_float(offset.length()).override_failure_message(
+			"the lift is zero, so this case cannot fail").is_greater(0.1)
+	assert_vector(mirror.fire_marker_at(cell).position).override_failure_message(
+			"the fire stayed burning on the board its ground left") \
+		.is_equal_approx(home + offset, Vector3.ONE * 0.01)
+
+
+# ...and so does the MARKUP on it. Asked of OverlayMirror._anchor directly rather than of a drawn
+# marker: every channel that reads it is torn down by the time a pass ends, so there is nothing left
+# on screen to look at -- and this is the decision, one answer for every marker in that file.
+# ADDED AFTER the same mutant survived.
+func test_markup_on_torn_out_ground_goes_up_with_it() -> void:
+	var cell := _painted_cells()[0]
+	var mirror := _scene.get_node("OverlayMirror") as OverlayMirror
+	var home: Transform3D = mirror._anchor(cell)["surface"]
+
+	BoardSpace.stage([cell] as Array[Vector2i], BoardSpace.lift_offset())
+
+	var offset := BoardSpace.stage_offset()
+	assert_float(offset.length()).override_failure_message(
+			"the lift is zero, so this case cannot fail").is_greater(0.1)
+	var staged: Transform3D = mirror._anchor(cell)["surface"]
+	assert_vector(staged.origin).override_failure_message(
+			"markup stayed on the board the cell it marks left").is_equal_approx(
+			home.origin + offset, Vector3.ONE * 0.01)
+	assert_that(staged.basis).override_failure_message(
+			"the tear-out changed how markup LIES on the cell, which is not its business") \
+		.is_equal(home.basis)
+
+
 # --- the wire into a real pass ------------------------------------------------------------------
 
 # The executor tears out and puts back, and BOTH ends are pinned by one case -- the version moves

--- a/tests/presentation/test_staging.gd
+++ b/tests/presentation/test_staging.gd
@@ -160,6 +160,38 @@ func test_a_pass_tears_the_fight_out_and_puts_the_board_back() -> void:
 				"%s was left in the sky after the pass" % cell).is_equal(Vector3.ZERO)
 
 
+# WHICH ground goes up, asked of the decision itself. The pass cases above cannot see this: the
+# staging is cleared before execute_orders returns, so a version that staged the WHOLE BOARD and put
+# it back would satisfy every one of them. Driven at _stage_the_fight because that is the decision,
+# and the expected set is BeatSheet's own -- computed the same way the executor computes it, so the
+# case says "the fight's ground, nobody else's" rather than naming cells.
+func test_the_tear_out_set_is_the_fights_ground_and_not_the_whole_board() -> void:
+	var unit := _a_unit()
+	_queue_a_move(unit)
+	var plan: ResolvedPlan = _game.squad_manager.resolve_plan(unit.squad, _game._board())
+	var sheet := BeatSheet.read(unit.squad, plan)
+	assert_array(sheet.cells).override_failure_message(
+			"fixture drifted: this pass touches no cells").is_not_empty()
+	# Non-vacuity: if the fight already covered the board, "not the whole board" proves nothing.
+	assert_int(sheet.cells.size()).override_failure_message(
+			"the fight covers the whole board, so this case cannot fail") \
+		.is_less(_painted_cells().size())
+
+	_game.order_executor._stage_the_fight(sheet, Pacing.Profile.CINEMATIC)
+
+	var staged := BoardSpace.staged_cells()
+	staged.sort()
+	var want: Array[Vector2i] = sheet.cells.duplicate()
+	want.sort()
+	assert_array(staged).is_equal(want)
+
+	# ...and the plain board tears out nothing at all, asked of the same door.
+	BoardSpace.clear_staging()
+	_game.order_executor._stage_the_fight(sheet, Pacing.Profile.BOARD)
+	assert_array(BoardSpace.staged_cells()).override_failure_message(
+			"the plain board tore the fight out anyway").is_empty()
+
+
 # THE LAW #521 asks for: with the cinematic off, displacement is provably zero EVERYWHERE. Read off
 # the seam directly -- never off a mirror, which something rebuilds every frame and would report
 # zero for a reason of its own. The version is asserted too, so "nothing was displaced" cannot pass

--- a/tests/presentation/test_staging.gd
+++ b/tests/presentation/test_staging.gd
@@ -41,6 +41,7 @@ func before_test() -> void:
 func after_test() -> void:
 	BoardSpace.reset_for_test()
 	PlayerSettings.reset_for_test()
+	Experiments.reset_for_test()   # a flag a case SET is a static that outlives it (#449)
 	await DialogFixtures.end_all_dialog(self)   # the mission door arms #182 dialog; end it or it leaks
 	get_tree().root.remove_child(_scene)
 	_scene.free()
@@ -199,7 +200,7 @@ func test_markup_on_torn_out_ground_goes_up_with_it() -> void:
 func test_a_pass_tears_the_fight_out_and_puts_the_board_back() -> void:
 	PlayerSettings.set_on(PlayerSettings.Setting.BATTLE_ZOOM, true)
 	var unit := _a_unit()
-	_queue_a_move(unit)
+	_swing_at_open_ground(unit)
 	var before := BoardSpace.staging_version
 
 	await _game.order_executor.execute_orders(unit)
@@ -219,7 +220,7 @@ func test_a_pass_tears_the_fight_out_and_puts_the_board_back() -> void:
 # case says "the fight's ground, nobody else's" rather than naming cells.
 func test_the_tear_out_set_is_the_fights_ground_and_not_the_whole_board() -> void:
 	var unit := _a_unit()
-	_queue_a_move(unit)
+	_swing_at_open_ground(unit)
 	var plan: ResolvedPlan = _game.squad_manager.resolve_plan(unit.squad, _game._board())
 	var sheet := BeatSheet.read(unit.squad, plan)
 	assert_array(sheet.cells).override_failure_message(
@@ -244,6 +245,81 @@ func test_the_tear_out_set_is_the_fights_ground_and_not_the_whole_board() -> voi
 			"the plain board tore the fight out anyway").is_empty()
 
 
+# WALKING TEARS OUT NOTHING (dev, 2026-08-26: *"there have to be main actions at play. Movement by
+# itself doesn't do it."*). Driven end to end through the real executor, since the rule is about
+# what a PASS does -- and reported in play, not reasoned about: the version that shipped tore a hole
+# in the board at the end of every move.
+#
+# The cinematic is deliberately ON, so this cannot pass for the profile gate's reason.
+func test_walking_tears_out_nothing() -> void:
+	PlayerSettings.set_on(PlayerSettings.Setting.BATTLE_ZOOM, true)
+	var unit := _a_unit()
+	_queue_a_move(unit)
+	assert_int(unit.squad.action_queue.size()).override_failure_message(
+			"fixture drifted: no move was queued, so this case cannot fail").is_greater(0)
+	var before := BoardSpace.staging_version
+
+	await _game.order_executor.execute_orders(unit)
+	await _settle()
+
+	assert_int(BoardSpace.staging_version).override_failure_message(
+			"a pass with nothing but movement in it tore out the board").is_equal(before)
+
+
+# THE WALK HAPPENS ON THE BOARD; the fight is what tears out. An attacker's origin_cell IS its
+# post-move cell, so staging before the move phase makes it walk toward a hole and pop into the sky
+# on arrival -- which is why the tear-out sits AFTER _execute_action_phase_parallel.
+#
+# Sampled every frame rather than asserted at the end, because the ordering is only observable
+# WHILE the pass runs: execute_orders is started without awaiting, and executing_plan is the
+# published "a pass is running" fact that bounds the loop. Both are read, never driven.
+func test_the_tear_out_waits_for_the_walk_to_finish() -> void:
+	PlayerSettings.set_on(PlayerSettings.Setting.BATTLE_ZOOM, true)
+	var mover := _a_mobile_unit()
+	assert_object(mover).override_failure_message(
+			"fixture: no unit on this board can move").is_not_null()
+	_queue_a_move(mover)
+	_swing_at_open_ground(mover)     # a MAIN action, or nothing would tear out at all
+	var before := BoardSpace.staging_version
+
+	var saw_walking := false
+	var staged_mid_walk := false
+	_game.order_executor.execute_orders(mover)   # deliberately NOT awaited
+	while _game.order_executor.executing_plan != null:
+		if mover.movement.moving:
+			saw_walking = true
+			if BoardSpace.staging_version != before:
+				staged_mid_walk = true
+		await await_idle_frame()
+	await _settle()
+
+	# Non-vacuity: a walk that never spanned a frame would make the assertion below free.
+	assert_bool(saw_walking).override_failure_message(
+			"the mover was never observed walking, so this case cannot fail").is_true()
+	assert_bool(staged_mid_walk).override_failure_message(
+			"the ground tore out from under a unit that was still walking to it").is_false()
+	assert_int(BoardSpace.staging_version).override_failure_message(
+			"the pass never staged at all, so the ordering was not exercised").is_greater(before)
+
+
+# ...and the bystanders flag does NOT get to reopen that. It widens WHAT comes along once a fight
+# is on stage; it is not a second answer to WHETHER one is, which is why _stage_the_fight asks the
+# gate before adding anything. Written because the first draft asked it after, so switching the
+# feels-test on would have put move-only passes back in the sky.
+func test_the_bystanders_flag_does_not_put_a_walk_on_stage() -> void:
+	PlayerSettings.set_on(PlayerSettings.Setting.BATTLE_ZOOM, true)
+	Experiments.set_on(Experiments.Flag.DIORAMA_BYSTANDERS, true)
+	var unit := _a_unit()
+	_queue_a_move(unit)
+	var before := BoardSpace.staging_version
+
+	await _game.order_executor.execute_orders(unit)
+	await _settle()
+
+	assert_int(BoardSpace.staging_version).override_failure_message(
+			"the feels-test flag tore out a pass with no main action in it").is_equal(before)
+
+
 # THE LAW #521 asks for: with the cinematic off, displacement is provably zero EVERYWHERE. Read off
 # the seam directly -- never off a mirror, which something rebuilds every frame and would report
 # zero for a reason of its own. The version is asserted too, so "nothing was displaced" cannot pass
@@ -251,7 +327,7 @@ func test_the_tear_out_set_is_the_fights_ground_and_not_the_whole_board() -> voi
 func test_with_the_cinematic_off_a_pass_displaces_nothing_at_all() -> void:
 	PlayerSettings.set_on(PlayerSettings.Setting.BATTLE_ZOOM, false)
 	var unit := _a_unit()
-	_queue_a_move(unit)
+	_swing_at_open_ground(unit)
 	var before := BoardSpace.staging_version
 
 	await _game.order_executor.execute_orders(unit)
@@ -290,12 +366,34 @@ func _column_of(map: GridMap, cell: Vector2i) -> Array[int]:
 	return items
 
 
+func _a_mobile_unit() -> Unit:
+	for child in _game.units_root.get_children():
+		var unit := child as Unit
+		if unit == null:
+			continue
+		var reachable: Array[Vector2i] = _game.get_move_range(_game.compute_move_range(unit), unit)
+		if not reachable.is_empty():
+			return unit
+	return null
+
+
 func _a_unit() -> Unit:
 	for child in _game.units_root.get_children():
 		var unit := child as Unit
 		if unit != null:
 			return unit
 	return null
+
+
+# #47's swing at open ground: a legal aim with no unit on the cell, which resolves and PLAYS. The
+# cheapest MAIN ACTION this suite can stage without asking what the board contains (the content
+# razor) -- every alternative needs an enemy standing in reach. _queue_action is the raw door,
+# since the queue-time whiff gate would refuse an aim at nobody and what is staged here is a pass.
+func _swing_at_open_ground(attacker: Unit) -> void:
+	# The PROJECTED cell, so this is still a legal aim when a move is queued ahead of it -- an aim
+	# stamped from the pre-move cell would be refused and the whole pass with it.
+	var origin: Vector2i = attacker.get_projected_destination()
+	attacker.squad._queue_action(AttackAction.declare(attacker, origin, origin + Vector2i(1, 1)))
 
 
 # The production door game._click_choosing_move uses, minus the click.

--- a/tests/presentation/test_staging.gd.uid
+++ b/tests/presentation/test_staging.gd.uid
@@ -1,0 +1,1 @@
+uid://b8susus7rc4nc

--- a/tests/squad/test_beat_sheet.gd
+++ b/tests/squad/test_beat_sheet.gd
@@ -104,9 +104,12 @@ func test_the_cast_holds_every_member_of_every_participating_squad() -> void:
 	for unit in [attacker, mate, foe, foe_mate]:
 		assert_bool(sheet.cast.has(unit)).override_failure_message(
 				"cast is missing %s" % unit).is_true()
-	# The bystander squadmate never acts and is never hit, so only the cast sweep puts its ground
-	# in the tear-out set.
-	assert_bool(sheet.cells.has(Vector2i(0, 1))).is_true()
+	# The CAST is who is in the scene; the tear-out set is what a MAIN ACTION touches, and those are
+	# different questions (dev, 2026-08-26). The bystander squadmate never acts and is never hit, so
+	# it is cast and its ground stays on the board -- bringing it along for context is #521's own
+	# feels-test flag, deliberately not a fact of the sheet.
+	assert_bool(sheet.cells.has(mate.movement.cell)).override_failure_message(
+			"a bystander's ground is in the tear-out set").is_false()
 	_break_volleys(plan)
 
 
@@ -114,6 +117,37 @@ func test_the_cast_holds_every_member_of_every_participating_squad() -> void:
 
 # One blast is one shot however many it hits -- #410 rules an AoE striking three victims a single
 # sweep, not three cuts. Grouping follows is_secondary_hit, the same read the resolver makes.
+# THE TEAR-OUT'S GATE, and it lives in the SET rather than beside it (dev, 2026-08-26): *"there
+# have to be main actions at play. Movement by itself doesn't do it."* A pass that only walks
+# touches no main-action cell, so there is nothing to lift and no second predicate to keep in step.
+#
+# Found in play: the cast sweep this replaced tore a hole in the board at the end of every move.
+func test_a_pass_that_only_walks_touches_no_ground() -> void:
+	var leader := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	leader.squad._queue_action(_walk(leader, Vector2i(0, 1)))
+
+	var sheet := BeatSheet.read(leader.squad, ResolvedPlan.new())
+	assert_object(sheet.moves()).override_failure_message(
+			"fixture drifted: this case needs a real move beat").is_not_null()
+	assert_array(sheet.cells).override_failure_message(
+			"walking tore out ground: %s" % [sheet.cells]).is_empty()
+
+
+# ...and a MAIN ACTION does, whichever one it is. A rally is the cheapest to stage -- no target, no
+# terrain -- and it is a side-channel verb, so this is the half an attack-shaped rule would miss.
+func test_a_side_channel_main_action_puts_its_ground_on_stage() -> void:
+	var unit := H.spawn_solo(self, _sm, PLAYER, Vector2i(2, 3), {Stats.Stat.LDR: 3})
+	var rally := RallyAction.new()
+	rally.init(unit)
+	assert_bool(rally.is_main_action()).override_failure_message(
+			"fixture drifted: this case needs a MAIN action").is_true()
+	unit.squad._queue_action(rally)
+
+	var sheet := BeatSheet.read(unit.squad, ResolvedPlan.new())
+	assert_array(sheet.cells).override_failure_message(
+			"a main action tore out nothing").contains([unit.movement.cell])
+
+
 func test_a_three_victim_volley_is_one_beat_in_strike_order() -> void:
 	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
 	var a := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})


### PR DESCRIPTION
Closes part of #521 — slice A, per your call: the seam and a static tear-out, transition after.

The ground a fight happens on **lifts off the board into a diorama** and thuds back when the pass ends. No rise off the top of frame, no white-out, no one-by-one slam — what this buys is the question everything else in #521 depends on: **does the reconstruction read right?**

**Your `47d3517 "tuning"` commit is the first commit on this branch.** It never made it into #565 (that merged one commit earlier, and GitHub deleted the remote branch), so it was living only on your local checkout.

## The seam

`BoardSpace.staged_offset(cell)` — your #410 ruling, answered where `BoardSpace` is already consulted. `Vector3.ZERO` is the board, so every reader is inert on a board that has never staged. **It makes `BoardSpace` stateful for the first time**, which its header now says out loud; a `Staging` class it delegated to would be two names for one fact.

## Two mechanisms, one answer — and the split is forced by the engine

**A GridMap cell cannot be offset individually.** It's a lattice. So:

- **The ground routes to a second `GridMap`** (`$StagedBoard`) — same mesh library, same `cell_size`, same cell coordinates, with the displacement as its **node transform**. A staged column is written there and cleared from `$Board`, leaving the socket the exit thuds back into. Because both share one lattice, **the reconstruction is exact by construction** rather than arithmetic.
- **Everything else adds the offset at its placement site** — and that's two seams, not ten: `BoardMirror.surface_point` is the one door every prop, flame, cover cluster and state marker in that file is placed by, and `OverlayMirror._anchor` is the one every marker's transform comes from.

Units are the exception that shows why the offset is its own question: **`UnitMirror` places horizontally from PIXELS**, not from `BoardSpace`, so an offset hidden inside `surface_point` would have lifted a unit vertically and left it behind horizontally.

## Knobs

`How high the fight lifts off the board` (Playback, in cells) and `Experiments → Diorama keeps its bystanders` — the feels-test fork, off = the fight's ground only, on = every unit's ground so the diorama keeps spatial context. One of those two gets deleted once you've played both.

## Verification

`presentation` 414 cases / 0 failures / 0 orphans. `squad core dev` 633 / 0 / 0.

**Eight mutants, seven killed — and the survivor found a real bug rather than a test gap.** Deleting the markup offset broke nothing, because nothing drove either wire. Writing the cases to kill it surfaced this: **a flame or a prop is only re-placed when its OWN diff key moves, and a tear-out changes where a cell renders without changing anything that key is made of.** So the fire went on burning on the board its ground had left. That's #308's shape in a new store, and it's fixed the same way #308 was — `OverlayMirror` gates its standing-state poll on `BoardSpace.staging_version` beside the heights version, and the staging sync drops the touched cells' props so the next reconcile rebuilds them where their ground now is.

The generalizable half, worth keeping: **adding a new input to where something renders means auditing every diff key that decides whether to re-render it.**

The other seven: dropping the stage, dropping the release, ignoring the profile gate, never routing to the staged lattice, answering the offset for unstaged cells, dropping the unit offset, dropping the prop/flame offset.

**One observability trap, the twin of #520's:** staging is cleared before `execute_orders` returns, so no case can watch the staged *set* during a pass — a version that tore out the whole board and put it back would satisfy every end-of-pass assertion. The set is pinned at the decision (`_stage_the_fight` against `BeatSheet.cells`) and the wire at the monotonic version.

**The law #521 asks for** is `test_with_the_cinematic_off_a_pass_displaces_nothing_at_all`: after a plain-board pass, `staged_offset` is zero for **every painted cell**, read off the seam directly rather than off a mirror that rebuilds itself. Falsified independently — it reds on its own when the profile gate is removed, not just behind an earlier case.

## Worth looking at when you play it

**A torn-out cell leaves a hole in the board.** That's correct — it's the socket the exit thuds back into — but with no white-out yet you'll see straight through the board where the fight was. If that reads as broken rather than as a tear-out, the answer is the transition, not a patch here.

**Bystander units on staged ground come along even with the flag off.** `BeatSheet._gather_cells` marks every cast member's standing cell, so a squadmate who neither acts nor is hit is on stage by design — "participants only" is already broader than the phrase suggests.

**The lift ships at 24 cells**, which is a guess, not a judgement. It's the first knob to reach for.

Canon: `docs/design/visual-clarity.md` -> *The fight TEARS OUT of the board*, marker bumped to #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
