### PR TITLE
The guard-link cases pinned the inset's value, not a relationship

### DIFF
--- a/Classes/board/OverlayManager.gd
+++ b/Classes/board/OverlayManager.gd
@@ -146,6 +146,10 @@ static var GUARD_LINK_MODULATE := Color.WHITE
 # the shield's thirteen columns. At half a cell that is three, and they are the shield's thinnest.
 # 0.5 is the geometric rule (the head stops at the edge the pair shares) rather than an art-derived
 # number; ~0.7 clears the shield entirely, which is what the range above 0.5 is for.
+#
+# TUNE IT WITH THE ALPHA ABOVE, not alone (found the first time the dev tuned this for real): both
+# buy the shield the same separation, so a translucent arrow needs less distance and an opaque one
+# needs more. Whichever you reach for, check the other still makes sense.
 static var GUARD_LINK_HEAD_INSET := 0.5
 
 # --- Squad markers (#325, settled 2026-08-19) ----------------------------------------------

--- a/tests/flow/test_guard_lifecycle_wires.gd
+++ b/tests/flow/test_guard_lifecycle_wires.gd
@@ -231,12 +231,15 @@ func test_queueing_a_move_drags_the_link_along_with_the_shield() -> void:
 		"the link vanished instead of following -- (2,1) is still adjacent to the ward").is_true()
 	assert_vector(_guard_link_tail_cell()).override_failure_message(
 		"the link still starts from the cell the blocker LEFT").is_equal(Vector2i(2, 1))
-	# The head lands HALF WAY between the two centres -- the shared edge -- which is both where the
-	# inset puts it and the one expression that says "it followed" without restating the inset.
+	# The head lands ON THE SEGMENT joining the moved pair, which is what "it followed" means without
+	# restating where along that segment the inset puts it -- a midpoint assertion here was a value
+	# pin, and the dev's own 0.3 would have reddened it (see the sibling case's note).
 	var from := GridUtils.cell_world(game.grid, Vector2i(2, 1))
 	var to := GridUtils.cell_world(game.grid, Vector2i(2, 0))
-	assert_vector(_guard_link_head_pos()).override_failure_message(
-		"the head is not on the edge the moved pair now shares").is_equal(from.lerp(to, 0.5))
+	var head := _guard_link_head_pos()
+	assert_float(head.distance_to(from) + head.distance_to(to)).override_failure_message(
+		"the head is off the line between the moved pair, so it did not follow them") \
+		.is_equal_approx(from.distance_to(to), 0.01)
 
 
 func test_the_link_head_stops_short_of_the_cell_the_shield_is_on() -> void:
@@ -244,9 +247,18 @@ func test_the_link_head_stops_short_of_the_cell_the_shield_is_on() -> void:
 	# arrowhead." The arrow tile's ink runs x=0..11 of 16 and the shield's x=1..13, so drawn on the
 	# ward's own cell the arrow covered eleven of the shield's thirteen columns.
 	#
-	# Pinned as a RELATIONSHIP against the ward's centre, never as the inset's number -- that value
-	# is a Game-tab knob and the tuning razor forbids a test that reddens when the dev turns it.
-	# What must stay true is only the direction: the head sits strictly BLOCKER-side of the shield.
+	# Pinned as a RELATIONSHIP, never as the inset's number -- that value is a Game-tab knob and the
+	# tuning razor forbids a test that reddens when the dev turns it. What must stay true is only
+	# that the head lands strictly BETWEEN the pair: off the shield at one end, not behind the
+	# blocker at the other.
+	#
+	# It carried a third assertion until the dev tuned this for real (2026-08-27), and that one
+	# pinned the value while claiming not to: `head-to-ward <= head-to-blocker` is only satisfiable
+	# at an inset of 0.5 or less, so the ~0.7 this ticket ADVERTISES as the way to clear the shield
+	# outright would have reddened the suite. Its failure message described the opposite case, which
+	# is the tell. **An assertion phrased as a comparison between two derived distances is a value
+	# pin wearing a relationship's clothes** -- ask which knob settings it admits, not whether it
+	# mentions a literal.
 	var blocker := _spawn(Team.Faction.PLAYER, Vector2i(1, 0))
 	var ward := _spawn(Team.Faction.PLAYER, Vector2i(2, 0))
 	await await_idle_frame()
@@ -263,9 +275,6 @@ func test_the_link_head_stops_short_of_the_cell_the_shield_is_on() -> void:
 	assert_float(head.distance_to(blocker_centre)).override_failure_message(
 		"the head was inset PAST the blocker -- it should stop between the pair, not behind it") \
 		.is_greater(0.0)
-	assert_float(head.distance_to(ward_centre)).override_failure_message(
-		"the head is closer to the ward than to the blocker, so it still crowds the shield") \
-		.is_less_equal(head.distance_to(blocker_centre))
 
 
 func test_a_spent_guard_stops_being_marked() -> void:


### PR DESCRIPTION
Follow-up to #566. **Land this before re-tuning `GUARD_LINK_HEAD_INSET`** — two of that PR's own
tests pin the knob's value, so turning it reddens the suite.

Found the first time the knob was actually tuned in play. Both cases would have reddened on the
dev's 0.3, and both would have reddened on the **~0.7 the comment advertises** as the way to clear
the shield outright. The knob's documented range was untestable, which is the tuning razor broken by
the very diff that invoked it.

## The two

**`test_the_link_head_stops_short_of_the_cell_the_shield_is_on`** carried a third assertion,
`head-to-ward <= head-to-blocker` — satisfiable only at an inset of **0.5 or less**. Its failure
message described the opposite case ("closer to the ward… still crowds the shield"), which is the
tell that it was never checking what it claimed. The two remaining assertions ARE the rule: strictly
off the shield at one end, strictly short of the blocker at the other, true for any inset in (0, 1).

**`test_queueing_a_move_drags_the_link_along_with_the_shield`** asserted the head sat at the exact
midpoint of the moved pair. What it *means* is "the link followed", now written as the head lying
**on the segment** joining them — which any inset satisfies.

## The lesson, since neither of these looked like a value pin

**An assertion phrased as a comparison between two DERIVED distances is a value pin wearing a
relationship's clothes.** Neither mentioned a literal. I wrote a comment in the first one explicitly
claiming it was a relationship "never the inset's number" — while writing the bug directly beneath
it. The question to ask is **which knob settings an assertion admits**, not whether it names a
number.

## Also

One comment at the inset noting it is tuned **with** the arrow's alpha rather than alone: both buy
the shield the same separation, so a translucent arrow needs less distance and an opaque one more.
That came out of the tuning session — turning one without checking the other is how the pair stops
making sense.

## Verified

`flow` 234/234, and the guard suite specifically. **`dev` and `presentation` were not re-run**: the
only production change in this diff is a comment, and the test change is confined to a `flow` suite.
CI runs the full tree.

Falsified in the previous session and re-confirmed here: with the old assertions restored against an
inset of 0.3, `test_queueing_a_move_drags_the_link_along_with_the_shield` reds — which is the
evidence for the claim above rather than an argument for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
