### PR TITLE
#520 diff 2b slice 1: the camera moves as one thing

### DIFF
--- a/Classes/actions/OrderExecutor.gd
+++ b/Classes/actions/OrderExecutor.gd
@@ -111,13 +111,30 @@ func execute_orders(unit):
 	game.camera_controller.set_playback_locked(true)
 
 	# The camera goes to the walk and the walk WAITS for it (#520, dev 2026-08-26). Moves are
-	# parallel, so one subject is framed -- the leader when the leader is walking -- and pan_to's
-	# closing follow() carries the camera along beside it for free. No hold here: the pan IS the
-	# beat, and a pause would be dead air between pressing Execute and anything happening.
+	# parallel, so one subject is framed -- the leader when the leader is walking. No hold here: the
+	# pan IS the beat, and a pause would be dead air between pressing Execute and anything happening.
+	#
+	# Framed across BOTH ENDS of that walk rather than centred on the walker (dev, scratchpad
+	# 2026-08-26: "instead of just centering on the unit, it should try to show both their start and
+	# end position in the initial shot"). Two halves, both already-eased channels: the 2D camera
+	# travels to the MIDPOINT, and the span is published for the 3D rig to widen its distance to.
+	# The span goes out BEFORE the travel and is never awaited, exactly as a beat's angle is -- the
+	# rig widens on its own edge while the pan tweens, so the two are one movement.
 	var walk := sheet.moves()
 	var walker: Unit = walk.subject() if walk != null else null
 	if walker != null:
-		await game.camera_controller.pan_to(walker, Pacing.PLAYBACK_PAN)
+		var from: Vector2i = walker.movement.cell
+		var to: Vector2i = walker.get_projected_destination()
+		# A hold-position order has no span to frame; the midpoint below is then the walker's own
+		# cell, i.e. exactly the shot this always took. Absence means "the camera keeps its zoom",
+		# which is already the idiom every other schedule here uses.
+		if to != from:
+			var span: Array[Vector2i] = [from, to]
+			game.camera_controller.framed_span = span
+		var grid: TileMapLayer = game.grid
+		await game.camera_controller.pan_to_position(
+				(GridUtils.cell_world(grid, from) + GridUtils.cell_world(grid, to)) * 0.5,
+				Pacing.PLAYBACK_PAN)
 	await _execute_action_phase_parallel(move_actions, _retire_move_markup)
 	# The shots the walk walked into (#413), in trigger order, and BEFORE the tear-out below: a
 	# watch fires at a crossing CELL, which the diorama's stage set does not hold (it holds what MAIN

--- a/Classes/board/CameraController.gd
+++ b/Classes/board/CameraController.gd
@@ -39,6 +39,15 @@ var follow_unit: Unit = null  # while set, target_position tracks this unit ever
 # already what the 3D rig mirrors, and OrderExecutor has no path to the rig (the same reason the pan
 # goes through here). The rig turns it into a yaw, since only the rig knows what to measure from.
 var directed_line: Array[Vector2i] = []
+# The two ends the shot must take IN, in sim cells (#520) -- a walk's start and its destination, so
+# the opening shot of a move shows where it begins and where it is going instead of just centring on
+# the walker (dev, scratchpad 2026-08-26). Empty for a beat that frames one thing.
+#
+# Carried here for the reason directed_line is: this is what the 3D rig already mirrors and
+# OrderExecutor has no path to the rig. A DIFFERENT question from that one, though, and the two must
+# never be folded together -- directed_line is an ANGLE and this is a FIT, so one field answering
+# both would spin the camera side-on to every walk.
+var framed_span: Array[Vector2i] = []
 var _panning := false         # true while pan_to's tween owns global_position -- _process yields to it
 
 @export var move_speed := 14
@@ -172,6 +181,10 @@ func set_playback_locked(locked: bool) -> void:
 	# re-solves this line against the detent it squares up to at that moment -- so a line left over
 	# from the previous squad would swing the camera off the new baseline before any beat ran.
 	directed_line = []
+	# The span goes with it, and needs the both-edges clear even more than the line does: the rig
+	# widens on the CHANGE, so a span surviving a claim would be the same value the mirror already
+	# has and the next squad's walk would open at whatever zoom the last one left.
+	framed_span = []
 	if not locked:
 		follow_unit = null
 
@@ -184,22 +197,26 @@ func follow(unit: Unit) -> void:
 # continuous follow() once the pan lands. The duration is Pacing's (#118); fixed-vs-speed is
 # the design, the number is a knob.
 func pan_to(unit: Unit, duration: float = Pacing.AI_SQUAD_PAN) -> void:
+	await pan_to_position(unit.global_position, duration)
+	follow(unit)
+
+# pan_to's POSITION-taking half, and the tween both share (#520): a point that is not a unit -- the
+# MIDPOINT of a walk, so the shot opens on both its ends. No closing follow(), and that is the whole
+# difference: framing both ends only means anything if the camera HOLDS while the walk crosses it,
+# where following would drag the far end straight back out of frame.
+func pan_to_position(world_pos: Vector2, duration: float = Pacing.AI_SQUAD_PAN) -> void:
 	follow_unit = null
 	# Nobody is watching a headless run, and the glide is awaited once per AI squad -- tweening it
-	# there is pure suite wall clock. Land on the destination and hand over to follow() exactly as
-	# the tweened path does.
+	# there is pure suite wall clock. Land on the destination exactly as the tweened path does.
 	if DisplayServer.get_name() == "headless":
-		_apply_pan_position(unit.global_position)
-		follow(unit)
+		_apply_pan_position(world_pos)
 		return
 	_panning = true
 	var start := global_position
-	var dest: Vector2 = unit.global_position
 	var tween := create_tween()
-	tween.tween_method(_apply_pan_position, start, dest, duration).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
+	tween.tween_method(_apply_pan_position, start, world_pos, duration).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
 	await tween.finished
 	_panning = false
-	follow(unit)
 
 func _apply_pan_position(pos: Vector2) -> void:
 	global_position = pos

--- a/Classes/dev/GameKnobs.gd
+++ b/Classes/dev/GameKnobs.gd
@@ -165,6 +165,8 @@ const KNOBS: Array[Dictionary] = [
 		"tip": "How far one notch of the mouse wheel moves the camera."},
 	{"group": "Camera handling", "node": "CameraRig", "prop": "smoothing", "label": "Camera smoothing", "min": 1.0, "max": 24.0, "step": 0.1,
 		"tip": "How fast the camera catches up to where it has been told to go. Higher is snappier and more responsive; lower glides, which reads as cinematic until you are trying to play."},
+	{"group": "Camera handling", "node": "CameraRig", "prop": "glide_smoothing", "label": "Pan glide speed", "min": 1.0, "max": 24.0, "step": 0.1,
+		"tip": "How fast the camera TRAVELS when something other than your hand moves it -- the flight back to your own view after a pass, the return to a unit you just gave an order to, R, and the rise into the torn-out diorama. Higher lands sooner, lower drifts. This is where to look if the end of every Execute reads as slow: the return is the most visible of them by far. Separate from Camera smoothing above, which is how the yaw and the zoom catch up under your own input."},
 	{"group": "Camera handling", "node": "CameraRig", "prop": "pan_speed", "label": "Pan speed", "min": 1.0, "max": 30.0, "step": 0.5,
 		"tip": "How fast WASD slides the camera across the board, in world units per second."},
 	{"group": "Camera handling", "node": "CameraRig", "prop": "orbit_sensitivity", "label": "Orbit sensitivity", "min": 0.02, "max": 1.0, "step": 0.01,

--- a/Classes/flow/ScenarioManager.gd
+++ b/Classes/flow/ScenarioManager.gd
@@ -380,6 +380,12 @@ func clear_board():
 	# reload mid-enemy-phase rests game_state on _base_state() through exit_current_mode below, so an
 	# playback_locked left standing by an interrupted turn would lock the fresh board for good.
 	game.camera_controller.set_playback_locked(false)
+	# ...and the TEAR-OUT the same pass may have left in the sky (#521, wired to the camera in #520
+	# diff 2b). Same shape as the line above and the same trigger: only execute_orders clears the
+	# staging, so a board swapped mid-pass (F2, Mission Select) hands the fresh board a lifted set of
+	# cells nothing will ever put down -- and since the rig now RIDES that lift, the camera goes with
+	# it. `BoardSpace` is a static, so it outlives the board exactly the way that flag does.
+	BoardSpace.clear_staging()
 	game.zone_manager.load_dict({})   # zones are board content; load_scenario refills them after
 	overlay_manager.redraw_zones(game.zone_manager)
 	game.terrain_states.clear()   # tile states are board content too -- a sandbox spawn inherits no fire (#174)

--- a/Classes/presentation/CameraRig3D.gd
+++ b/Classes/presentation/CameraRig3D.gd
@@ -42,6 +42,19 @@ class_name CameraRig3D
 # align_to_detent() exists for the AI turn: an enemy phase plays out square-on however
 # the player left the camera. It is the only realign the rig does not owe to a keypress.
 #
+# WHERE IT LOOKS is two channels summed, and `position` is DERIVED from them every frame (#520):
+# _aim is the point on the board the rig sits over, _lift how far the torn-out diorama has risen
+# under it (#521). Kept apart because they ease on different clocks -- board tracking under playback
+# is HELD, since the 2D camera it mirrors already tweens its own travel and easing on top of an ease
+# is lag, while the lift is the map-to-battle transition and is the one thing that pans. Nothing may
+# write `position` directly; hold_at (the snap) and glide_to (the pan) are the doors, and a stray
+# assignment is simply overwritten on the next frame rather than half-honoured.
+#
+# glide_to exists because the dev's rule is that the camera never teleports (scratchpad, 2026-08-26:
+# "the camera still has a few cases where it teleports - this should never happen, it should always
+# be a pan"). Its scope is the BOARD -- his own narrowing, 2026-08-27: "that only applies while we're
+# on the map", with the map-to-battle transition a declared exception that starts as a pan.
+#
 # DoF focus TRACKS the zoom (dev note, 2026-08-12: static distances made the blur
 # swallow the board at close zoom): every frame the near/far focus distances are
 # re-derived as offsets around the camera's live distance to the rig, so the focus
@@ -62,6 +75,12 @@ class_name CameraRig3D
 @export var zoom_step := 1.5
 @export var pan_speed := 8.0
 @export var smoothing := 8.0
+# How fast a GLIDE closes, in the same units as `smoothing` above -- which stays the YAW and ZOOM
+# rate. Its own number because the two answer different questions: that one is how snappy the camera
+# feels under your hand, this is how a shot TRAVELS when playback moves it. Shared by every pan (the
+# view return, both recentres, R) AND by the tear-out lift, so the map-to-battle transition paces
+# with them; the day the transition wants its own rate, this is the line that forks.
+@export var glide_smoothing := 6.0
 @export var orbit_button: MouseButton = MOUSE_BUTTON_RIGHT: set = _set_orbit_button
 # Stood down by a host that needs the wheel for something else (#285: the elevation brush paints
 # at the wheel's level). Declarative, exactly like orbit_button above -- and it has to be a knob
@@ -101,6 +120,12 @@ class_name CameraRig3D
 
 var _target_yaw_degrees := 0.0
 var _target_distance := 14.0
+# The two position channels (see the header): where the rig looks NOW and where it is heading, plus
+# the same pair for the diorama's rise. `position` is their sum and nothing else.
+var _aim := Vector3.ZERO
+var _target_aim := Vector3.ZERO
+var _lift := Vector3.ZERO
+var _target_lift := Vector3.ZERO
 var _home_position := Vector3.ZERO
 var _home_yaw_degrees := 0.0
 var _home_distance := 14.0
@@ -128,6 +153,10 @@ var _orbit_travel_px := 0.0
 func _ready() -> void:
 	_target_yaw_degrees = rotation_degrees.y
 	_target_distance = _camera.position.z
+	# Whatever the scene authored is where the rig already IS, so both channels start there rather
+	# than gliding in from the origin on the first frame.
+	_aim = position
+	_target_aim = position
 	_home_position = position
 	_home_yaw_degrees = _target_yaw_degrees
 	_home_distance = _target_distance
@@ -171,7 +200,10 @@ func _unhandled_input(event: InputEvent) -> void:
 			KEY_E:
 				_target_yaw_degrees = _next_detent(-1)
 			KEY_R:
-				position = _home_position
+				# A PAN since #520, like the other three that used to cut. Yaw and distance were
+				# already eased, so this is what makes all three axes of "back to the opening
+				# shot" one movement instead of a jump with a lerp bolted to it.
+				glide_to(_home_position)
 				_target_yaw_degrees = _home_yaw_degrees
 				_target_distance = _home_distance
 
@@ -237,6 +269,55 @@ func set_zoom(distance: float) -> void:
 	_target_distance = minf(distance, max_distance)
 
 
+# Widen the DISTANCE alone until `volume` fits, leaving the aim, the yaw and the opening shot exactly
+# where they are (#520). frame() cannot serve this: it re-aims, adopts _home_* and drops the borrowed
+# view -- all three wrong inside a pass, the last of them fatal, which is the same reason a directed
+# shot is aim_along rather than pose().
+#
+# WIDENS ONLY, never narrows. The ask is "show both their start and end position in the initial shot"
+# (dev, scratchpad 2026-08-26), and a short hop already has both ends in frame at the playback
+# distance -- pulling IN to fit one would answer a question nobody asked. set_zoom is the door, so the
+# board's own ceiling still clamps it and a span too big to fit simply frames as much as it can,
+# which is the ticket's own "should be doable unless super zoomed in".
+func widen_to_fit(volume: AABB) -> void:
+	var distance := _fit_distance(volume.grow(fit_margin_cells))
+	if distance <= 0.0:
+		return   # no valid projection yet -- the caller keeps what it has, as everywhere else here
+	set_zoom(maxf(_target_distance, distance))
+
+
+# --- Where the rig looks (#520) ---------------------------------------------------------------
+
+# Move the aim OUTRIGHT: the snap. Every writer that already has the camera where it wants it comes
+# through here -- WASD (a held key is already continuous, so easing it would only put lag between the
+# press and the board moving), frame()/pose() (a rig still lerping unprojects at one distance and
+# picks at another, desyncing every screen-space read on the way in), and the playback mirror, whose
+# 2D twin is already tweening the travel it reports.
+func hold_at(aim: Vector3) -> void:
+	_target_aim = aim
+	_aim = aim
+	_apply_position()
+
+
+# ...and the PAN: the target moves and _process closes the gap. The four places the camera used to
+# teleport are its whole caller list -- the pass-end view return, both recentres (SPACE and #471's
+# return to the acting unit), and R.
+func glide_to(aim: Vector3) -> void:
+	_target_aim = aim
+
+
+# How far the ground under the rig has been torn out of the board (#521). POLLED rather than latched,
+# with the staging's own offset, so the camera rides the diorama up and settles back down with it and
+# a tear-out that clears mid-pass needs nobody to remember to undo this.
+func lift_to(lift: Vector3) -> void:
+	_target_lift = lift
+
+
+# The ONE place the node's position is written. Both channels, summed -- see the header.
+func _apply_position() -> void:
+	position = _aim + _lift
+
+
 # Frame `volume` (in cells/world units): aim at it, sit far enough back that all of it
 # is inside THIS camera's frustum, adopt that as home, and bound panning. Callers supply
 # the volume; the trigonometry is the rig's because only it knows fov, aspect and pitch.
@@ -251,15 +332,18 @@ func frame(volume: AABB, bounds := AABB()) -> void:
 	if not rebound(limits):
 		return   # no valid projection yet (a viewport with no size); keep the current framing
 
-	position = _aim_at(box)
+	# Snap, never ease -- hold_at, not glide_to: a camera still lerping toward the fit unprojects at
+	# one distance and picks at another, which desyncs every screen-space read taken on the way.
+	hold_at(_aim_at(box))
 	set_zoom(_fit_distance(box))
-	# Snap, never ease: a camera still lerping toward the fit unprojects at one distance
-	# and picks at another, which desyncs every screen-space read taken on the way.
 	_camera.position.z = _target_distance
 
 	# R means "back to the opening shot". Position and distance are board facts and come
 	# from the fit; yaw is a scene fact and stays whatever the scene authored.
-	_home_position = position
+	#
+	# The AIM rather than `position`, which also carries the tear-out lift: home is a place on the
+	# board, and flying back to one taken mid-diorama would put the opening shot in the sky.
+	_home_position = _aim
 	_home_distance = _target_distance
 	drop_stashed_view()
 
@@ -293,13 +377,13 @@ func pose(aim: Vector3, yaw_degrees: float, distance: float, bounds: AABB) -> vo
 		_target_yaw_degrees = previous_target_yaw
 		return
 
-	position = aim
+	hold_at(aim)
 	set_zoom(distance)
 	_camera.position.z = _target_distance
 
 	# R means "back to the opening shot", and an authored opening shot INCLUDES its yaw -- so unlike
 	# frame(), which leaves yaw to the scene, this adopts all three.
-	_home_position = position
+	_home_position = _aim
 	_home_yaw_degrees = _target_yaw_degrees
 	_home_distance = _target_distance
 	drop_stashed_view()
@@ -391,8 +475,12 @@ func aim_along(line: Array[Vector2i]) -> void:
 #
 # Called on the EDGE into playback, BEFORE the detent/zoom reset -- after it would stash the reset
 # rather than the player's own framing.
+#
+# The AIM rather than `position`, and the TARGET rather than the live value: what is being put back
+# is where the player was heading on the board, so a claim landing while a previous pass's lift is
+# still settling must not bake that lift into the view it hands back.
 func stash_view() -> void:
-	_borrowed_position = position
+	_borrowed_position = _target_aim
 	_borrowed_yaw_degrees = _target_yaw_degrees
 	_borrowed_distance = _target_distance
 	_view_borrowed = true
@@ -401,15 +489,15 @@ func stash_view() -> void:
 # ...and on the edge back out. A no-op unless something is actually borrowed, so a release with no
 # claim behind it (a board clear, a fixture poking the flag) moves nothing.
 #
-# Restores exactly the way R does: position ASSIGNED, because the mirror writes it directly every
-# frame and there is no target to ease toward; yaw and distance set as TARGETS so _process eases
-# them. Distance goes through set_zoom rather than a raw assign so it lands in the same clamp every
-# other writer uses -- the board may have been repainted while playback held the camera.
+# Restores exactly the way R does, and since #520 that means all three axes are TARGETS the smoothing
+# closes: this is the most visible of the four pans, firing at the end of every Execute and every
+# enemy turn. Distance goes through set_zoom rather than a raw assign so it lands in the same clamp
+# every other writer uses -- the board may have been repainted while playback held the camera.
 func restore_view() -> void:
 	if not _view_borrowed:
 		return
 	_view_borrowed = false
-	position = _borrowed_position
+	glide_to(_borrowed_position)
 	_target_yaw_degrees = _borrowed_yaw_degrees
 	set_zoom(_borrowed_distance)
 
@@ -440,13 +528,28 @@ func _process(delta: float):
 			pan.x += 1.0
 		if pan != Vector2.ZERO:
 			pan = pan.normalized() * pan_speed * delta
-			position += Vector3(pan.x, 0.0, pan.y).rotated(Vector3.UP, deg_to_rad(rotation_degrees.y))
+			hold_at(_target_aim + Vector3(pan.x, 0.0, pan.y).rotated(Vector3.UP, deg_to_rad(rotation_degrees.y)))
 
-	# Clamped unconditionally, not inside the pan branch: a host driving position (the
-	# Battle3D camera mirror) writes it earlier in the same frame and must be bounded too.
+	# The two eased channels (#520). Headless, land now: nobody is watching, the asymptotic lerp
+	# never settles, and a suite sampling the rig must read the DECISION rather than frame timing.
+	# Fourth member of the escape Pacing.beat, CameraController.pan_to and CameraController._process
+	# already keep, and kept for the same reason.
+	var glide := 1.0 if DisplayServer.get_name() == "headless" else 1.0 - exp(-glide_smoothing * delta)
+	_aim = _aim.lerp(_target_aim, glide)
+	_lift = _lift.lerp(_target_lift, glide)
+
+	# Clamped unconditionally, not inside the pan branch: a host driving the aim (the Battle3D camera
+	# mirror) writes it earlier in the same frame and must be bounded too. On the AIM rather than on
+	# the node, because `position` is derived below and a clamp written there would be undone on the
+	# next frame -- and on the TARGET as well as the live value, or an aim parked off the board would
+	# drag the camera back out to it every frame it eased in.
 	if pan_limit.has_area():
-		position.x = clampf(position.x, pan_limit.position.x, pan_limit.end.x)
-		position.z = clampf(position.z, pan_limit.position.y, pan_limit.end.y)
+		_target_aim.x = clampf(_target_aim.x, pan_limit.position.x, pan_limit.end.x)
+		_target_aim.z = clampf(_target_aim.z, pan_limit.position.y, pan_limit.end.y)
+		_aim.x = clampf(_aim.x, pan_limit.position.x, pan_limit.end.x)
+		_aim.z = clampf(_aim.z, pan_limit.position.y, pan_limit.end.y)
+
+	_apply_position()
 
 
 func _lerp_angle_degrees(from_degrees: float, to_degrees: float, weight: float) -> float:

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -127,6 +127,10 @@ var _pointer_vertex := Vector2i.ZERO
 var _pip_native: Vector2 = Vector2(1280.0, 720.0)
 # Last frame's playback_locked, so the square-on realign fires once per AI turn, not per frame.
 var _playback_owned_camera := false
+# ...and last frame's framed span (#520), for the same reason: the widen is an EDGE, so the player's
+# wheel is theirs again the instant the shot is set up. Gated on the published span itself -- the
+# store the answer is drawn from -- rather than on a copy of what it resolves to (#308).
+var _framed_span: Array[Vector2i] = []
 
 
 func _ready() -> void:
@@ -606,19 +610,36 @@ func _mirror_camera() -> void:
 			_rig.set_zoom(_rig.playback_distance)
 		else:
 			_rig.restore_view()
+	# ABOVE the early return, deliberately: how far the ground has been torn out is a fact about the
+	# BOARD, not about who owns the camera (#521). The tiles thud back into their sockets INSIDE
+	# execute_orders and the lock is put back in the same synchronous stretch, so a poll below the
+	# return would never see a frame with the staging cleared and the rig would stay in the sky for
+	# ever. The whole stage, never the cell under the camera: the diorama is one thing at one height,
+	# and asking per cell would dip the camera every time a pan crossed unstaged ground.
+	_rig.lift_to(BoardSpace.stage_offset())
 	if not cam.playback_locked:
 		return
 	# The 2D camera answers WHERE on the board; the board answers HOW HIGH. It used to keep
 	# _rig.position.y, i.e. whatever the opening shot had left there — see _aim_over. Continuous
 	# rather than per cell because this is a GLIDING pan: stepping the height at cell boundaries
 	# would jolt the whole diorama mid-beat.
+	#
+	# HELD rather than glided (#520): the 2D camera this mirrors already tweens its own travel, so
+	# easing on top of that ease is lag between the action and the frame it is in.
 	var flat := BoardSpace.of_pixels(cam.global_position, 0.0)
-	_rig.position = _aim_over(flat.x, flat.z)
+	_rig.hold_at(_aim_over(flat.x, flat.z))
 	# ...and the 2D camera answers WHERE, while the beat answers FROM WHICH SIDE (#520). Polled
 	# beside the position for the same reason it is: this is the one block that already runs every
 	# frame under playback. Below the early return deliberately -- the release edge above restores
 	# the player's own yaw, and re-aiming after it would undo the return in the same frame.
 	_rig.aim_along(cam.directed_line)
+	# ...and HOW WIDE, the third of the same three questions (#520). An EDGE, never a per-frame
+	# apply: the same rule the playback-distance reset above follows, so the shot is set up once and
+	# the wheel is the player's again for the rest of it.
+	if cam.framed_span != _framed_span:
+		_framed_span = cam.framed_span.duplicate()
+		if _framed_span.size() == 2:
+			_rig.widen_to_fit(_span_volume(_framed_span))
 
 
 func _unhandled_input(event: InputEvent) -> void:
@@ -917,15 +938,23 @@ func _center_on_pointer() -> void:
 
 
 # THE recentre, and the one answer to "put the rig over this cell": SPACE above, and #471's return
-# to the acting unit, which arrives as game.view_focus_requested. Snap rather than glide: this node
-# has always written position outright, and the rig smooths yaw and distance but not position.
+# to the acting unit, which arrives as game.view_focus_requested. A GLIDE since #520 -- both are
+# board play, which is exactly the scope the dev put the never-teleport rule at (2026-08-27: "that
+# only applies while we're on the map"). It snapped until then because the rig smoothed yaw and
+# distance but not position; now it smooths all three.
 #
 # The HEIGHT comes from the cell, and that is the whole of the fix the dev's Level_1 report forced
 # (2026-08-23). surface_point is the cell-shaped door onto the same surface plane _aim_over
 # evaluates continuously — one authority, two entry points BoardSpace already ships (#273 / #259),
 # and it is the seam UnitMirror places the sprite with, so the camera looks where the unit IS.
+#
+# surface_point carries the STAGED offset while _aim_over does not, so a call here while the board
+# is torn out would lift the rig twice -- once through the point and once through the rig's own lift
+# channel. Structurally unreachable rather than guarded: both callers are refused while playback
+# owns the board (SPACE by _unhandled_input's lock check, an order commit by there being no pass
+# running to commit during), and playback is the only thing that stages anything.
 func _center_rig_on(cell: Vector2i) -> void:
-	_rig.position = BoardSpace.surface_point(cell, game.board_heights)
+	_rig.glide_to(BoardSpace.surface_point(cell, game.board_heights))
 
 
 # THE aim point for a continuous world x/z — the AI pan's twin of _center_rig_on, which has a cell.
@@ -939,6 +968,16 @@ func _center_rig_on(cell: Vector2i) -> void:
 func _aim_over(x: float, z: float) -> Vector3:
 	var cell := Vector2i(floori(x), floori(z))
 	return Vector3(x, BoardSpace.surface_height_at(cell, x, z, game.board_heights), z)
+
+
+# The box a framed span (#520) must fit inside: the two cells' own surface points, through the same
+# seam UnitMirror stands a sprite with, so a walk that climbs is framed on the height it really
+# ends at. The rig grows it by its own fit margin -- only this scene knows the cells, only the rig
+# knows fov, aspect and pitch (Law #4: pass, don't look up).
+func _span_volume(span: Array[Vector2i]) -> AABB:
+	var heights: BoardHeights = game.board_heights
+	return AABB(BoardSpace.surface_point(span[0], heights), Vector3.ZERO) \
+			.expand(BoardSpace.surface_point(span[1], heights))
 
 
 func _update_pointer(screen_pos: Vector2) -> void:

--- a/docs/design/presentation-effects.md
+++ b/docs/design/presentation-effects.md
@@ -244,11 +244,14 @@ yank the camera too, and that is a knob to turn in play rather than a rule to gu
   `battle3d` already had a **player-initiated** rig recentre that never touches the mirror — SPACE —
   so this is a second caller of `_center_rig_on(cell)`, and the two guard cases in
   `test_camera_follow.gd` keep saying exactly what they said before.
-- **SNAP, not glide** (dev call). Two reasons beyond the feel: the rig smooths yaw and distance but
-  **not position** — every writer, WASD included, assigns it outright — so a glide is a mechanism to
-  invent, not a duration to pick; and the 2D twin's `center_on_position` sets `lock_manual_input`,
-  refusing the player's own camera on the way in, which is the wrong answer for someone who just
-  gave an order.
+- **SNAP, not glide** (dev call) — **SUPERSEDED 2026-08-27, and by the same person.** The original
+  reasoning was that the rig smoothed yaw and distance but **not position**, so a glide was a
+  mechanism to invent rather than a duration to pick. #520 diff 2b slice 1 invented it, on his own
+  ruling that a camera on the board must never teleport, and this recentre is one of the four
+  callers that changed. What did **not** change is the other half of the bullet, and it is still
+  load-bearing: the 2D twin's `center_on_position` sets `lock_manual_input`, refusing the player's
+  own camera on the way in, which is the wrong answer for someone who just gave an order — so the
+  glide is the **rig's** own channel (`CameraRig3D.glide_to`) and never a hop through that door.
 - **`game.focus_view_on(unit)` derives the cell ONCE and emits it.** The **projected** destination,
   which is already what every gate and pick layer means by "where this unit acts from" ([#126](https://github.com/Phaazoid/Godoiosis/issues/126)),
   so a queued move is followed rather than second-guessed. The 2D camera is written there and the 3D

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -7,7 +7,7 @@ its child [#49 Action Queue UX](https://github.com/Phaazoid/Godoiosis/issues/49)
 This is a *guidelines* doc, not a spec — it captures the principles we're holding the work to,
 plus the running order of the queue-UX checklist. Update it as items land.
 
-**Canon checked through #565 (2026-08-26).**
+**Canon checked through #577 (2026-08-27).**
 
 ## Principles
 

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -1338,8 +1338,82 @@ whether the camera turns or not — the first draft of `test_a_pass_turns_the_ca
 did exactly that and survived every mutant. It aims diagonally now, and asserts the gap is real
 before asserting the camera closed it.
 
-Still open on #520: the pitch driver, the shake and micro-sway, the knockback and cliff follows
-(diff 2b), and lethality-aware direction (diff 2c).
+## The camera MOVES AS ONE THING ([#520](https://github.com/Phaazoid/Godoiosis/issues/520) diff 2b slice 1, BUILT 2026-08-27)
+
+Yaw and distance were eased from the start; **position never was.** `CameraRig3D._process` lerped
+`rotation_degrees.y` and `_camera.position.z` and nothing else, so every writer that moved the rig
+across the board cut. That is what the dev's scratchpad note is about — *"the camera still has a few
+cases where it teleports - this should never happen, it should always be a pan"* — and it is the
+same movement the tear-out needs, which is why the two are one slice.
+
+**The rule has a SCOPE, and it is his** (2026-08-27): *"that only applies while we're on the map.
+One exception we can make is the transition from the map view to the battle view — what we're
+creating now. We can start with a pan, but I reserve the right to change the call on that."* So it
+is not a global invariant: three writers still cut on purpose, and the transition is a declared
+exception rather than an instance of the rule.
+
+**`position` is now DERIVED from two channels**, `_aim + _lift`, written in exactly one place.
+- `_aim` is the point on the board. `hold_at()` snaps it, `glide_to()` pans it. A raw
+  `rig.position = …` is *overwritten* on the next frame rather than half-honoured — which is a
+  loud failure, and it invalidated five test fixtures that had been shoving the rig that way.
+- `_lift` is how far the torn-out diorama has risen (#521). Its own channel because the two ease on
+  different clocks: **board tracking under playback is HELD** — the 2D camera it mirrors already
+  tweens its own travel, and easing on top of an ease is lag between the action and the frame it is
+  in — while the lift is the map→battle transition and is the one thing that pans.
+
+**Which writers glide, and which still cut.** The four the dev named are the whole glide list:
+the pass-end view return (`restore_view`), both recentres (SPACE and #471's return to the acting
+unit), and R. The snaps are `frame()`/`pose()` — a rig still lerping unprojects at one distance and
+picks at another, desyncing every screen-space read taken on the way in — WASD, because a held key
+is already continuous and easing it only adds lag, and the playback mirror, for the compounding
+reason above. All of them go through `hold_at`, so none leaves a stale target for the ease to fight.
+
+**THE GAP THIS CLOSED, and it was flagged at PR #568 and missed in its own build:** `_aim_over`
+answers the *board's* surface, so before this the fight lifted into the diorama and the camera
+stayed down watching the hole. The lift poll deliberately sits **above** `_mirror_camera`'s
+playback gate: `execute_orders` clears the staging and puts the lock back in one synchronous
+stretch, so a poll below the gate would never see a frame with the tiles home and the rig would
+stay in the sky for ever.
+
+**`_center_rig_on` must never be reached while the board is staged** — `BoardSpace.surface_point`
+carries the staged offset and `_aim_over` does not, so a call there would lift twice. Structural
+rather than guarded: both its callers are refused while playback owns the board, and playback is
+the only thing that stages anything.
+
+**An AI move is framed across BOTH ENDS** (dev: *"instead of just centering on the unit, it should
+try to show both their start and end position in the initial shot (should be doable unless super
+zoomed in)"*). Two already-eased channels, no new machinery: the 2D camera travels to the
+**midpoint** via `pan_to_position` — `pan_to`'s position-taking half, which the unit-taking one now
+delegates to — and the rig **widens its distance** through `widen_to_fit`.
+
+- **The follow is gone, and that is the point.** `pan_to` ended with `follow(unit)`; framing both
+  ends only means anything if the camera *holds* while the walk crosses it, because following would
+  drag the far end straight back out of frame. `test_the_move_phase_takes_the_camera_to_whoever_is_walking`
+  was rewritten rather than patched — its name pinned the rule that changed.
+- **`widen_to_fit` widens only, never narrows.** A short hop already has both ends in frame at the
+  playback distance; pulling *in* to fit one answers a question nobody asked. `set_zoom` is the
+  door, so the board's own ceiling still clamps it — which is the ticket's own *"unless super
+  zoomed in"*, expressed as a clamp rather than a special case.
+- **It is an EDGE, never a per-frame apply**, the same rule the playback-distance reset follows: the
+  shot is set up once and the wheel is the player's again for the rest of the pass. Gated on
+  `framed_span` itself — the store the answer is drawn from — not on a copy of what it resolves to.
+- **`framed_span` is a THIRD published field beside `directed_line`,** and folding them together
+  would be wrong: that one is an ANGLE and this is a FIT, so one field answering both would spin the
+  camera side-on to every walk.
+
+**The testing shape, and the limitation stated rather than hidden: the ease is invisible headless.**
+`_process` lands both position channels in one frame — the fourth escape of its kind in the repo,
+beside `Pacing.beat`, `pan_to` and `CameraController._process` — because a suite sampling an
+asymptotic lerp reads frame timing rather than the rig. So the cases pin the **decision**: a pan
+moves where the camera is *heading* and leaves the camera alone, a snap moves both. That difference
+is exactly what separates the four calls from the three, and it is what every mutant here attacks.
+
+One live interaction the change surfaced: **the pointer re-picks on camera movement** (#471), so
+the cell under a motionless cursor legitimately changes while the rig is in the air — a SPACE case
+must read the cell it acted on *before* the flight, not after.
+
+Still open on #520: the impact layer (pitch driver, shake, micro-sway) and the follows (knockback,
+cliff) — the rest of diff 2b — and lethality-aware direction (diff 2c).
 
 ## The fight TEARS OUT of the board ([#521](https://github.com/Phaazoid/Godoiosis/issues/521) slice A, BUILT 2026-08-26)
 
@@ -1403,6 +1477,9 @@ painted cell** after a plain-board pass, read off the seam directly.
 **The feels-test fork is one bool**, `Experiments.Flag.DIORAMA_BYSTANDERS`: off stages the cells the
 fight touches, on adds the ground every other unit stands on so the diorama keeps its spatial
 context. A session-scoped dev toggle — one of the two gets deleted once it has been played.
+
+**The camera goes up with it** — built in #520 diff 2b slice 1 above, not here. Slice A shipped
+without it, and the section above says why that gap was invisible from inside this one.
 
 Still open on #521: the transition both ways (rise, white-out, the one-by-one slam in queue order,
 the exit thud and its dust shockwave), and strata on the cut edges, which is art-pass work.

--- a/tests/dev/test_moods_tool.gd
+++ b/tests/dev/test_moods_tool.gd
@@ -328,7 +328,7 @@ func test_a_tab_with_no_host_degrades_instead_of_crashing() -> void:
 const GAME_SETTING_NODES := ["BoardOverlays", "UnitMirror", "BoardMirror"]
 # CameraRig is the one node that holds BOTH, so it cannot be excluded wholesale: framing is mood and
 # handling is not, and only the property name separates them.
-const CAMERA_HANDLING := ["zoom_step", "smoothing", "pan_speed",
+const CAMERA_HANDLING := ["zoom_step", "smoothing", "glide_smoothing", "pan_speed",
 	"orbit_sensitivity", "pan_margin_cells", "zoom_out_slack"]   # min_distance went with the floor
 
 

--- a/tests/presentation/test_camera_follow.gd
+++ b/tests/presentation/test_camera_follow.gd
@@ -17,7 +17,7 @@ const LEVEL_1 := "res://Scenarios/missions/Level_1.tres"
 
 var _scene: Node3D
 var _game: Node2D
-var _rig: Node3D
+var _rig: CameraRig3D
 var _camera3d: Camera3D
 
 
@@ -29,7 +29,7 @@ func before_test() -> void:
 	get_tree().root.add_child(_scene)
 	await await_idle_frame()
 	_game = _scene.game
-	_rig = _scene.get_node("CameraRig") as Node3D
+	_rig = _scene.get_node("CameraRig") as CameraRig3D
 	_camera3d = _scene.get_node("CameraRig/Pitch/Camera") as Camera3D
 	_scene.load_mission(PROLOG)
 	await await_idle_frame()
@@ -126,28 +126,84 @@ func test_a_menu_takes_the_zoom_wheel_back() -> void:
 #
 # LIMIT, stated rather than implied: pan_to snaps headless, so this pins the WIRE, not the ordering.
 # That the pan precedes the walk is structural -- the await sits above the phase.
-func test_the_move_phase_takes_the_camera_to_whoever_is_walking() -> void:
+# REWRITTEN for #520 diff 2b: the rule this pins CHANGED, so patching the old assertion would have
+# left its name pinning something the code no longer does. It used to read follow_unit -- the move
+# phase panned to the walker and then TRACKED them. The dev's ask (scratchpad, 2026-08-26) is
+# "instead of just centering on the unit, it should try to show both their start and end position in
+# the initial shot", and framing both ends only means anything if the camera HOLDS while the walk
+# crosses it: a follow would drag the far end straight back out of frame. So there is no follow left
+# to assert, and what replaces it is where the camera actually went.
+#
+# The midpoint is re-derived from the walk's own two ends rather than written down, so a fixture that
+# moves cannot red this and a board with different geometry still asks the same question.
+func test_the_move_phase_frames_the_walk_across_both_its_ends() -> void:
 	var mover := _mobile_player_unit()
 	assert_object(mover).override_failure_message(
 			"fixture: no player unit on this board can move").is_not_null()
 
+	var grid: TileMapLayer = _game.grid
 	_cam().set_playback_locked(true)
+	await _settle()
 
 	# Control first: the same pass with nothing queued must move the camera nowhere, or the case
 	# below would pass on any pan at all rather than on the move's.
+	var parked: Vector2 = _cam().global_position
 	await _game.order_executor.execute_orders(mover)
 	await _settle()
-	assert_object(_cam().follow_unit).override_failure_message(
-			"an empty pass panned the camera somewhere").is_null()
+	assert_vector(_cam().global_position).override_failure_message(
+			"an empty pass panned the camera somewhere").is_equal_approx(parked, Vector2.ONE * 0.01)
 
+	var from: Vector2i = mover.movement.cell
 	_queue_a_move(mover)
+	var to: Vector2i = mover.get_projected_destination()
+	assert_bool(to != from).override_failure_message(
+			"fixture: the queued move goes nowhere").is_true()
+	var midpoint: Vector2 = (GridUtils.cell_world(grid, from) + GridUtils.cell_world(grid, to)) * 0.5
+	# ...and the midpoint is deliberately NOT either end, or "both ends" would be indistinguishable
+	# from the centre-on-the-unit shot this replaced.
+	assert_bool(midpoint.distance_to(GridUtils.cell_world(grid, to)) > 1.0) \
+		.override_failure_message("start and end are the same point; the case proves nothing").is_true()
 
 	await _game.order_executor.execute_orders(mover)
 	await _settle()
 
+	assert_vector(_cam().global_position).override_failure_message(
+			"the move phase framed one end of the walk, not both") \
+		.is_equal_approx(midpoint, Vector2.ONE * 0.01)
 	assert_object(_cam().follow_unit).override_failure_message(
-			"the move phase played with the camera pointed wherever it was left").is_same(mover)
+			"the camera tracked the walker, which drags the far end of the walk out of frame").is_null()
 	_cam().set_playback_locked(false)
+
+
+# ...and the 3D half of the same shot: the span is published for the rig, which widens its distance
+# to hold both ends. Pinned at the SEAM (what the executor publishes) rather than at a zoom number,
+# which is a fit and therefore a function of fov, pitch and the fit margin -- all knobs.
+func test_the_move_phase_publishes_the_span_for_the_rig_to_widen_to() -> void:
+	var mover := _mobile_player_unit()
+	assert_object(mover).override_failure_message(
+			"fixture: no player unit on this board can move").is_not_null()
+
+	var from: Vector2i = mover.movement.cell
+	_queue_a_move(mover)
+	var to: Vector2i = mover.get_projected_destination()
+
+	# Sampled MID-PASS: execute_orders clears the lock on its way out, and set_playback_locked wipes
+	# the span on both edges, so the aftermath cannot answer this. Not awaited -- GDScript runs a
+	# coroutine synchronously to its first await, so the publish has already happened by the time
+	# this returns and the walk is still in front of us.
+	_game.order_executor.execute_orders(mover)
+	var published: Array[Vector2i] = _cam().framed_span
+	while _game.order_executor.executing_plan != null:
+		await await_idle_frame()
+	await _settle()
+
+	var expected: Array[Vector2i] = [from, to]
+	assert_array(published).override_failure_message(
+			"the move phase published no span, so the rig has nothing to widen to") \
+		.is_equal(expected)
+	assert_array(_cam().framed_span).override_failure_message(
+			"the span outlived the pass -- the next squad's walk would open at this one's zoom") \
+		.is_empty()
 
 
 # ...and so does the side-channel tail. ADDED BY FALSIFICATION, not by reasoning: deleting the
@@ -375,6 +431,87 @@ func test_a_pass_gives_the_player_their_view_back() -> void:
 			"the zoom stayed at the playback distance").is_equal_approx(distance, 0.01)
 
 
+# ...and it FLIES back rather than cutting (#520 diff 2b). The most visible of the four pans the
+# dev's never-teleport rule covers: this fires at the end of every Execute and every enemy turn.
+#
+# Pinned as the DECISION -- the target moved, the camera did not -- because headless both position
+# channels land inside the frame the release edge fires in (the rig's own escape), so the aftermath
+# cannot tell a pan from a cut. The case above is the wire; this is what kind of movement it is.
+func test_the_view_return_is_a_pan_rather_than_a_cut() -> void:
+	_rig.hold_at(Vector3(_rig.pan_limit.position.x, _rig.position.y, _rig.pan_limit.position.y))
+	await _settle()
+	_rig.stash_view()
+
+	_rig.hold_at(Vector3(_rig.pan_limit.end.x, _rig.position.y, _rig.pan_limit.end.y))
+	await _settle()
+	var away: Vector3 = _rig.position
+	assert_bool(away.distance_to(_rig._borrowed_position) > 1.0).override_failure_message(
+			"the borrowed view is where the rig already sits; the case proves nothing").is_true()
+
+	_rig.restore_view()
+
+	assert_that(_rig.position).override_failure_message(
+			"the view return teleported -- it wrote the camera's position, not its target") \
+		.is_equal(away)
+	assert_that(_rig._target_aim).is_equal(_rig._borrowed_position)
+
+
+# The same rule at the other three: #471's return to the acting unit. Driven through the real
+# signal, and asserted with NO await for the same reason as above -- before #520 this call wrote
+# position outright and would still be at the unit by the time the statement after it ran.
+func test_a_committed_order_pans_the_rig_back_rather_than_cutting_to_it() -> void:
+	var unit := _player_unit()
+	assert_object(unit).is_not_null()
+	_rig.hold_at(Vector3(_rig.pan_limit.position.x, _rig.position.y, _rig.pan_limit.position.y))
+	await _settle()
+	var before: Vector3 = _rig.position
+
+	_game.focus_view_on(unit)
+
+	assert_bool(_rig._target_aim.distance_to(before) > 1.0).override_failure_message(
+			"nothing was aimed at, so 'the camera did not jump' proves nothing").is_true()
+	assert_that(_rig.position).override_failure_message(
+			"the return to the acting unit still cuts").is_equal(before)
+
+
+# --- Riding the tear-out (#521, wired here in #520 diff 2b) -----------------------------------
+
+# THE GAP THIS CLOSES, flagged at PR #568 and missed in its build: _aim_over answers the BOARD's own
+# surface, so the fight lifted off into the diorama and the camera stayed down watching the hole.
+#
+# Driven through BoardSpace's real staging seam, and the expected height re-derived from that seam's
+# own offset -- the lift is a GameKnobs value, so the case pins "the camera goes with it", never how
+# far up "it" is.
+func test_the_camera_rides_the_tear_out_up_off_the_board() -> void:
+	var unit := _player_unit()
+	assert_object(unit).is_not_null()
+	_cam().set_playback_locked(true)
+	await _cam().pan_to(unit)
+	await _settle()
+	var grounded: Vector3 = _rig.position
+
+	var stage: Array[Vector2i] = [unit.movement.cell]
+	BoardSpace.stage(stage, BoardSpace.lift_offset())
+	await _settle()
+
+	# Non-vacuous: the lift is a real distance rather than a knob someone has zeroed.
+	assert_bool(BoardSpace.stage_offset().length() > 1.0).override_failure_message(
+			"the stage lift is zero; the case proves nothing").is_true()
+	assert_that(_rig.position).override_failure_message(
+			"the fight lifted off the board and the camera stayed down on it") \
+		.is_equal(grounded + BoardSpace.stage_offset())
+
+	# ...and the poll sits ABOVE the mirror's playback gate, which is what keeps the rig out of the
+	# sky once a pass ends: execute_orders clears the staging and puts the lock back in ONE
+	# synchronous stretch, so a poll below the gate would never see a frame with the tiles home.
+	_cam().set_playback_locked(false)
+	BoardSpace.clear_staging()
+	await _settle()
+	assert_float(_rig.position.y - _rig._target_aim.y).override_failure_message(
+			"the camera stayed lifted after playback let go -- the lift poll is below the gate") \
+		.is_equal_approx(0.0, 0.001)
+
+
 # ...and a BOARD SWAP drops what was borrowed, rather than flying back to a pose from a board that
 # no longer exists. ScenarioManager.clear_board releases the playback lock, so without this the
 # release fires the restore on the dead board. Invalidation is structural -- frame() and pose() both
@@ -499,7 +636,7 @@ func test_the_3d_camera_follows_the_ai_camera() -> void:
 	# The opening shot sits over the player's squad, i.e. over this very unit, so the rig
 	# has to be shoved off first — to a corner of its own pan limit, which the clamp will
 	# leave alone.
-	_rig.position = Vector3(_rig.pan_limit.position.x, _rig.position.y, _rig.pan_limit.position.y)
+	_rig.hold_at(Vector3(_rig.pan_limit.position.x, _rig.position.y, _rig.pan_limit.position.y))
 	assert_bool(_rig.position.distance_to(expected) > 1.0) \
 		.override_failure_message("the rig was already there; the case proves nothing").is_true()
 	await _settle()
@@ -729,7 +866,7 @@ func test_zooming_fully_out_still_shows_the_whole_board() -> void:
 		await _settle()
 		var board: AABB = _scene._board_volume()
 		var center := board.get_center()
-		_rig.position = Vector3(center.x, _rig.position.y, center.z)
+		_rig.hold_at(Vector3(center.x, _rig.position.y, center.z))
 		_rig.set_zoom(_rig.max_distance)
 		_camera3d.position.z = _rig._target_distance   # settle the exponential lerp outright
 		await _settle()
@@ -785,17 +922,22 @@ func test_space_recentres_the_diorama_on_the_pointer() -> void:
 	var unit := _player_unit()
 	var cell: Vector2i = unit.movement.cell
 	_scene._update_pointer(_screen_of(cell))
-	_rig.position = Vector3(_rig.position.x + 12.0, _rig.position.y, _rig.position.z + 12.0)
+	_rig.hold_at(Vector3(_rig.position.x + 12.0, _rig.position.y, _rig.position.z + 12.0))
 	var before := _rig.position
 
 	var space := InputEventKey.new()
 	space.keycode = KEY_SPACE
 	space.pressed = true
-	_scene._unhandled_input(space)
-
 	# The WHOLE point, height included (2026-08-23). It used to keep `before.y` — which is how the
 	# rig came to sit at the board's ceiling for ever on any board with elevation.
+	#
+	# Read BEFORE the key, not after the flight: SPACE is a PAN since #520, and the pointer poll
+	# re-picks on CAMERA movement (#471), so the cell under a motionless cursor legitimately changes
+	# while the rig is in the air. What SPACE acted on is the cell it was over when the key arrived.
 	var point := BoardSpace.surface_point(BoardSpace.flat(_scene._pointer_cell), _game.board_heights)
+	_scene._unhandled_input(space)
+	await _settle()   # headless the glide lands on the next frame
+
 	assert_that(_rig.position).is_equal(point)
 	assert_bool(_rig.position.distance_to(before) > 1.0).is_true()
 
@@ -812,7 +954,7 @@ func test_a_committed_order_brings_the_rig_back_to_the_acting_unit() -> void:
 	assert_object(unit).is_not_null()
 	# The opening shot sits over the player's squad, i.e. over this very unit, so the rig has to be
 	# shoved off first -- to a corner of its own pan limit, which the clamp will leave alone.
-	_rig.position = Vector3(_rig.pan_limit.position.x, _rig.position.y, _rig.pan_limit.position.y)
+	_rig.hold_at(Vector3(_rig.pan_limit.position.x, _rig.position.y, _rig.pan_limit.position.y))
 	var before := _rig.position
 	# The unit's PROJECTED cell, which is what focus_view_on means by "where this unit is acting
 	# from" -- read through the same expression rather than assumed to be movement.cell.
@@ -842,7 +984,7 @@ func test_moving_the_camera_re_picks_the_cell_under_a_still_pointer() -> void:
 			"the fixture never got the pointer onto the unit's cell").is_equal(_picked(cell))
 
 	# The mouse does not move; the world does.
-	_rig.position = Vector3(_rig.position.x + 6.0, _rig.position.y, _rig.position.z + 6.0)
+	_rig.hold_at(Vector3(_rig.position.x + 6.0, _rig.position.y, _rig.position.z + 6.0))
 	await _settle()
 
 	assert_that(_scene._pointer_cell).override_failure_message(
@@ -864,7 +1006,7 @@ func test_moving_the_camera_re_picks_the_cell_under_a_still_pointer() -> void:
 func test_the_return_aims_at_the_surface_not_at_the_board_ceiling() -> void:
 	var unit := _player_unit()
 	assert_object(unit).is_not_null()
-	_rig.position = Vector3(_rig.position.x, 12.0, _rig.position.z)
+	_rig.hold_at(Vector3(_rig.position.x, 12.0, _rig.position.z))
 
 	_game.focus_view_on(unit)
 	await _settle()
@@ -886,7 +1028,7 @@ func test_the_ai_pan_aims_at_the_surface_too() -> void:
 	_game.game_state = _game.GameState.AI_TURN
 	_cam().set_playback_locked(true)
 	await _cam().pan_to(unit)
-	_rig.position = Vector3(_rig.position.x, 12.0, _rig.position.z)
+	_rig.hold_at(Vector3(_rig.position.x, 12.0, _rig.position.z))
 	await _settle()
 
 	var wanted := _surface_aim(BoardSpace.of_pixels(_cam().global_position, 0.0))

--- a/tests/presentation/test_camera_rig.gd
+++ b/tests/presentation/test_camera_rig.gd
@@ -164,6 +164,14 @@ func test_frame_snaps_the_camera_rather_than_easing_to_it() -> void:
 	var rig := _rig()
 	rig.frame(AABB(Vector3.ZERO, Vector3(50, 1, 50)))
 	assert_float(_camera().position.z).is_equal_approx(rig._target_distance, 0.001)
+	# ...and the AIM, which is the half this case stopped covering the moment #520 made position an
+	# eased channel: the NAME claimed all three axes while the body asserted one, so a frame()
+	# routed through glide_to passed the whole suite. FOUND BY MUTATION, not by reasoning.
+	# Asserted as "nothing is left to ease" rather than as a coordinate, so the fit stays derived.
+	assert_that(rig._aim).override_failure_message(
+			"frame() eased toward the fit instead of landing on it -- every screen-space read taken " \
+			+ "on the way in unprojects at one place and picks at another") \
+		.is_equal(rig._target_aim)
 
 
 func test_frame_adopts_the_fit_as_home_so_reset_returns_to_it() -> void:
@@ -205,7 +213,9 @@ func test_pose_lands_the_camera_exactly_where_it_was_authored() -> void:
 	assert_float(_camera().position.z).is_equal_approx(16.0, 0.001)
 
 
-func test_pose_snaps_both_smoothed_axes_rather_than_easing_to_them() -> void:
+# RENAMED for #520 diff 2b: it was "..._both_smoothed_axes_...", and position became a third one.
+# A name that undercounts what it covers is the same blind spot the frame() case above had.
+func test_pose_snaps_every_smoothed_axis_rather_than_easing_to_them() -> void:
 	# frame()'s reason, applied to yaw as well: a rig still lerping unprojects at one basis
 	# and picks at another. Deliberately NOT awaiting a frame — the smoothing would hide it.
 	var rig := _rig()
@@ -216,6 +226,9 @@ func test_pose_snaps_both_smoothed_axes_rather_than_easing_to_them() -> void:
 			"yaw is still easing toward the authored pose — screen-space reads desync on the way" \
 			).is_equal_approx(130.0, 0.001)
 	assert_float(_camera().position.z).is_equal_approx(rig._target_distance, 0.001)
+	assert_that(rig._aim).override_failure_message(
+			"the aim is still easing toward the authored pose, for the same reason") \
+		.is_equal(rig._target_aim)
 
 
 func test_pose_leaves_the_ceiling_and_pan_on_the_board_exactly_as_framing_does() -> void:

--- a/tests/presentation/test_camera_rig.gd
+++ b/tests/presentation/test_camera_rig.gd
@@ -174,9 +174,15 @@ func test_frame_adopts_the_fit_as_home_so_reset_returns_to_it() -> void:
 	# Non-vacuous: the fit must differ from the scene's authored home, or R proves nothing.
 	assert_bool(framed_position.distance_to(Vector3(0, 1, 0)) > 1.0).is_true()
 
-	rig.position = Vector3(999, 1, 999)
+	# hold_at, not a raw write: `position` is DERIVED from the rig's two channels since #520, so an
+	# assignment to it is overwritten on the next frame and this fixture would shove nothing.
+	rig.hold_at(Vector3(999, 1, 999))
 	rig.set_zoom(1.0)   # any distance other than the one R must restore
 	_key(KEY_R)
+	# R is a PAN now, so the aim lands on the next frame rather than inside the keypress. Headless
+	# the glide closes in one (CameraRig3D._process's escape), which is what keeps this a decision
+	# rather than a reading of frame timing.
+	await await_idle_frame()
 	assert_that(rig.position).is_equal(framed_position)
 	assert_float(rig._target_distance).is_equal_approx(framed_distance, 0.001)
 
@@ -236,10 +242,11 @@ func test_pose_adopts_the_authored_yaw_as_home_unlike_framing() -> void:
 	var rig := _rig()
 	rig.pose(Vector3(20, 1, 14), 135.0, 16.0, BOARD)
 
-	rig.position = Vector3(5, 1, 5)
+	rig.hold_at(Vector3(5, 1, 5))
 	rig._target_yaw_degrees = 0.0
 	rig.set_zoom(1.0)   # any distance other than the one R must restore
 	_key(KEY_R)
+	await await_idle_frame()   # R is a pan since #520; headless the glide lands in one frame
 
 	assert_that(rig.position).is_equal(Vector3(20, 1, 14))
 	assert_float(rig._target_yaw_degrees).override_failure_message(
@@ -367,12 +374,153 @@ func test_a_short_drag_still_reads_as_a_click() -> void:
 func test_panning_is_clamped_to_the_framed_board() -> void:
 	var rig := _rig()
 	rig.frame(AABB(Vector3.ZERO, Vector3(10, 1, 10)))
-	rig.position = Vector3(500, 1, 500)
+	# Through the door, for the reason above: a raw `position =` is derived away rather than
+	# clamped, and this case would then pass on the rig never having left the board at all.
+	rig.hold_at(Vector3(500, 1, 500))
 	rig._process(0.016)
 	# Non-vacuous: it moved, and it stopped exactly at the bound rather than anywhere.
 	assert_float(rig.position.x).is_less(500.0)
 	assert_float(rig.position.x).is_equal_approx(rig.pan_limit.end.x, 0.001)
 	assert_float(rig.position.z).is_equal_approx(rig.pan_limit.end.y, 0.001)
+
+
+# --- The pan, and the snaps that stay snaps (#520) ---------------------------------
+#
+# The EASE ITSELF IS INVISIBLE HEADLESS: _process lands both position channels in one frame (the
+# rig's own escape, the fourth in the repo), because a suite sampling an asymptotic lerp reads frame
+# timing rather than the rig. So these pin the DECISION -- a pan moves where the camera is HEADING
+# and leaves the camera alone, a snap moves both -- which is exactly what separates the four calls
+# the dev asked to stop teleporting from the three that must keep cutting.
+
+func test_a_glide_moves_where_the_camera_is_heading_and_not_the_camera() -> void:
+	var rig := _rig()
+	rig.hold_at(Vector3(4, 1, 4))
+	var before: Vector3 = rig.position
+
+	rig.glide_to(Vector3(20, 1, 18))
+
+	# Non-vacuous: there is real distance to travel, so "it has not arrived" cannot pass by the
+	# destination already sitting under the camera.
+	assert_bool(before.distance_to(Vector3(20, 1, 18)) > 1.0).override_failure_message(
+			"the glide had nowhere to go; the case proves nothing").is_true()
+	assert_that(rig.position).override_failure_message(
+			"the pan teleported -- it wrote the camera's position instead of its target") \
+		.is_equal(before)
+	assert_that(rig._target_aim).is_equal(Vector3(20, 1, 18))
+
+
+func test_a_snap_moves_both_so_nothing_is_left_for_the_ease_to_fight() -> void:
+	var rig := _rig()
+	rig.glide_to(Vector3(4, 1, 4))
+	rig.hold_at(Vector3(20, 1, 18))
+
+	assert_that(rig.position).is_equal(Vector3(20, 1, 18))
+	# The target too, and that half is the load-bearing one: a snap that moved only the camera
+	# would be dragged straight back to wherever the last pan was heading on the very next frame.
+	assert_that(rig._target_aim).override_failure_message(
+			"the snap left a stale target behind, so the ease pulls the camera off it") \
+		.is_equal(Vector3(20, 1, 18))
+
+
+func test_the_ease_closes_the_gap_a_pan_opened() -> void:
+	var rig := _rig()
+	rig.frame(AABB(Vector3.ZERO, Vector3(30, 1, 30)))
+	rig.hold_at(Vector3(4, 1, 4))
+	rig.glide_to(Vector3(20, 1, 18))
+	assert_bool(rig.position.distance_to(Vector3(20, 1, 18)) > 1.0).override_failure_message(
+			"precondition: the pan left no gap to close").is_true()
+
+	await await_idle_frame()
+
+	assert_that(rig.position).override_failure_message(
+			"the target moved and the camera never followed it -- nothing eases the aim") \
+		.is_equal(Vector3(20, 1, 18))
+
+
+func test_the_diorama_lift_carries_the_camera_up_with_it() -> void:
+	# #521's half: the fight tears out of the board and the camera has to go with it, or it stays
+	# down on the board watching a hole. A SECOND channel rather than part of the aim, because the
+	# aim is held every frame by the playback mirror and the lift is the one thing that pans.
+	var rig := _rig()
+	rig.frame(AABB(Vector3.ZERO, Vector3(30, 1, 30)))
+	rig.hold_at(Vector3(12, 1, 12))
+	var grounded: Vector3 = rig.position
+
+	rig.lift_to(Vector3(0.0, 9.0, 0.0))
+	await await_idle_frame()
+
+	assert_that(rig.position).override_failure_message(
+			"the camera stayed down on the board while the diorama rose") \
+		.is_equal(grounded + Vector3(0.0, 9.0, 0.0))
+
+	# ...and back down when the tiles thud into their sockets, without anyone remembering to undo it.
+	rig.lift_to(Vector3.ZERO)
+	await await_idle_frame()
+	assert_that(rig.position).override_failure_message(
+			"the camera never came back down -- the lift latched instead of being polled") \
+		.is_equal(grounded)
+
+
+# --- Widening to fit a span (#520) --------------------------------------------------
+#
+# The move phase's half of "instead of just centering on the unit, it should try to show both their
+# start and end position in the initial shot" (dev, scratchpad 2026-08-26). Asserted by EQUIVALENCE
+# against what framing that span outright solves for, never as a distance number, so fov, pitch and
+# the fit margin all stay the dev's knobs.
+
+func test_widening_to_a_span_reaches_the_distance_that_span_needs() -> void:
+	var rig := _rig()
+	var board := AABB(Vector3.ZERO, Vector3(64, 1, 40))
+	var span := AABB(Vector3(6, 0, 5), Vector3.ZERO).expand(Vector3(52, 1, 34))
+
+	rig.frame(span, board)
+	var wanted: float = rig._target_distance   # the oracle
+
+	rig.frame(AABB(Vector3(28, 0, 18), Vector3(4, 1, 4)), board)   # ...and a close opening shot
+	assert_float(rig._target_distance).override_failure_message(
+			"the shot already sat at the span's distance; the widen proves nothing").is_less(wanted)
+	var aim: Vector3 = rig.position
+
+	rig.widen_to_fit(span)
+
+	assert_float(rig._target_distance).override_failure_message(
+			"the widen did not pull back far enough to hold both ends of the walk") \
+		.is_equal_approx(wanted, 0.001)
+	assert_that(rig.position).override_failure_message(
+			"the widen moved the camera; it may only touch the distance").is_equal(aim)
+
+
+func test_widening_never_pulls_in_on_a_short_hop() -> void:
+	# A hop already has both ends in frame at the distance the pass opened on, so fitting it would
+	# mean zooming IN to a two-cell walk -- answering a question nobody asked.
+	var rig := _rig()
+	var board := AABB(Vector3.ZERO, Vector3(64, 1, 40))
+	var hop := AABB(Vector3(30, 0, 20), Vector3.ZERO).expand(Vector3(32, 1, 20))
+
+	rig.frame(hop, board)
+	var hop_distance: float = rig._target_distance
+	rig.frame(board)
+	assert_float(hop_distance).override_failure_message(
+			"the hop needs the whole-board distance; the case proves nothing").is_less(rig._target_distance)
+	var opened: float = rig._target_distance
+
+	rig.widen_to_fit(hop)
+
+	assert_float(rig._target_distance).override_failure_message(
+			"the widen pulled IN to fit a two-cell hop").is_equal_approx(opened, 0.001)
+
+
+func test_a_span_too_big_to_fit_stops_at_the_boards_own_ceiling() -> void:
+	# The ticket's own "should be doable unless super zoomed in": a span that will not fit is not a
+	# licence to leave the zoom ceiling the board sets behind.
+	var rig := _rig()
+	rig.frame(AABB(Vector3.ZERO, Vector3(20, 1, 20)))
+	var ceiling: float = rig.max_distance
+
+	rig.widen_to_fit(AABB(Vector3(-400, 0, -400), Vector3(800, 1, 800)))
+
+	assert_float(rig._target_distance).override_failure_message(
+			"the widen escaped the board's own zoom ceiling").is_equal_approx(ceiling, 0.001)
 
 
 func test_disabling_manual_input_refuses_keys_but_keeps_smoothing_alive() -> void:

--- a/tests/presentation/test_camera_rig.gd
+++ b/tests/presentation/test_camera_rig.gd
@@ -450,6 +450,29 @@ func test_the_ease_closes_the_gap_a_pan_opened() -> void:
 		.is_equal(Vector3(20, 1, 18))
 
 
+# The clamp bites the TARGET as well as the live aim, and this is the consequence that buys those
+# two lines. Headless the pair is otherwise indistinguishable — the ease lands in one frame, so a
+# surviving off-board target is re-clamped every frame and the camera never visibly moves. What it
+# costs is LATER: painting a tile grows the board and widens the limit without moving the view
+# (#231's rule), and a destination the clamp had already refused would come back to life there.
+func test_a_pan_aimed_off_the_board_does_not_come_back_when_the_board_grows() -> void:
+	var rig := _rig()
+	rig.frame(AABB(Vector3.ZERO, Vector3(20, 1, 20)))
+	rig.glide_to(Vector3(500, 1, 500))
+	await await_idle_frame()
+	var clamped: Vector3 = rig.position
+	# Non-vacuous: the aim really was outside, so a no-op clamp cannot pass this.
+	assert_bool(clamped.distance_to(Vector3(500, 1, 500)) > 1.0).override_failure_message(
+			"the aim was already inside the limit; the case proves nothing").is_true()
+
+	rig.rebound(AABB(Vector3.ZERO, Vector3(600, 1, 600)))
+	await await_idle_frame()
+
+	assert_that(rig.position).override_failure_message(
+			"the camera flew off to a destination the clamp had already refused, the moment the " \
+			+ "board grew enough to allow it").is_equal(clamped)
+
+
 func test_the_diorama_lift_carries_the_camera_up_with_it() -> void:
 	# #521's half: the fight tears out of the board and the camera has to go with it, or it stays
 	# down on the board watching a hole. A SECOND channel rather than part of the aim, because the

--- a/tests/presentation/test_camera_start.gd
+++ b/tests/presentation/test_camera_start.gd
@@ -23,7 +23,7 @@ const AUTHORED_DISTANCE := 15.5
 
 var _scene: Node3D
 var _game: Node2D
-var _rig: Node3D
+var _rig: CameraRig3D
 var _camera3d: Camera3D
 
 
@@ -35,7 +35,7 @@ func before_test() -> void:
 	get_tree().root.add_child(_scene)
 	await await_idle_frame()
 	_game = _scene.game
-	_rig = _scene.get_node("CameraRig") as Node3D
+	_rig = _scene.get_node("CameraRig") as CameraRig3D
 	_camera3d = _scene.get_node("CameraRig/Pitch/Camera") as Camera3D
 	_scene.load_mission(PROLOG)
 	await await_idle_frame()
@@ -156,7 +156,7 @@ func test_clearing_the_board_forgets_the_last_missions_start() -> void:
 func test_capture_reads_the_live_rig_rather_than_where_it_is_heading() -> void:
 	# You are storing the shot you are LOOKING at. Set the targets away from the live values and
 	# the captured pose must follow the live ones — the same rule _describe_view (#240) follows.
-	_rig.position = Vector3(7.0, 1.0, 5.0)
+	_rig.hold_at(Vector3(7.0, 1.0, 5.0))
 	_rig.rotation_degrees.y = 20.0
 	_camera3d.position.z = 11.0
 	_rig._target_yaw_degrees = 200.0
@@ -176,7 +176,7 @@ func test_a_captured_pose_reloads_as_the_shot_it_was_captured_from() -> void:
 	# The authoring loop end to end: fly the camera, press Capture, save, load, and be back where
 	# you were. This is the one case that would catch a capture and an apply that each work but
 	# disagree about what the three numbers MEAN.
-	_rig.position = Vector3(9.0, 1.0, 6.0)
+	_rig.hold_at(Vector3(9.0, 1.0, 6.0))
 	_rig.rotation_degrees.y = 63.0
 	_camera3d.position.z = 13.0
 

--- a/tests/presentation/test_staging.gd
+++ b/tests/presentation/test_staging.gd
@@ -213,6 +213,32 @@ func test_a_pass_tears_the_fight_out_and_puts_the_board_back() -> void:
 				"%s was left in the sky after the pass" % cell).is_equal(Vector3.ZERO)
 
 
+# ...and a board SWAPPED mid-tear-out puts it down too (#520 diff 2b). Only execute_orders clears
+# the staging, so an interrupted pass — F2, Mission Select — used to hand the fresh board a lifted
+# set of cells nothing would ever put back down, and since the rig now RIDES that lift the camera
+# went with them. `BoardSpace` is a static and outlives the board exactly the way playback_locked
+# does, which is the line this one now sits beside in clear_board.
+#
+# Staged DIRECTLY rather than through a pass: what is under test is the clear, and driving a real
+# pass to reach the state would clear it on the way out.
+func test_a_board_swap_puts_the_tear_out_down() -> void:
+	var cells: Array[Vector2i] = _painted_cells().slice(0, 3)
+	assert_bool(cells.size() == 3).override_failure_message(
+			"fixture: this board has fewer than three painted cells").is_true()
+	BoardSpace.stage(cells, BoardSpace.lift_offset())
+	await _settle()
+	assert_bool(BoardSpace.stage_offset().length() > 1.0).override_failure_message(
+			"the stage lift is zero; the case proves nothing").is_true()
+
+	_game.scenario_manager.clear_board()
+	await _settle()
+
+	for cell in cells:
+		assert_vector(BoardSpace.staged_offset(cell)).override_failure_message(
+				"%s stayed in the sky after the board it belonged to was swapped out" % cell) \
+			.is_equal(Vector3.ZERO)
+
+
 # WHICH ground goes up, asked of the decision itself. The pass cases above cannot see this: the
 # staging is cleared before execute_orders returns, so a version that staged the WHOLE BOARD and put
 # it back would satisfy every one of them. Driven at _stage_the_fight because that is the decision,


### PR DESCRIPTION
Closes the first slice of #520 diff 2b, and with it two of your scratchpad notes.

## What changed

**The rig's position was the one axis nothing eased.** Yaw and distance were lerped in `_process` from the start; position was assigned outright by every writer, so every recentre cut. That is your note — *"the camera still has a few cases where it teleports - this should never happen, it should always be a pan"* — scoped by you to board play, with the map-to-battle transition a declared exception that starts as a pan and stays your call to change.

`position` is now **derived from two channels**, `_aim + _lift`, written in exactly one place.

- `_aim` is the point on the board. `hold_at()` snaps it, `glide_to()` pans it.
- `_lift` is how far the torn-out diorama has risen, eased on its own clock — so board tracking under playback stays instant (the 2D camera it mirrors is already tweening; easing on top of an ease is lag) while the transition is the one thing that pans.

**Which writers glide, and which still cut.** The four you named glide: the pass-end view return, both recentres (SPACE and the return to a unit you just gave an order to), and R. `frame()`/`pose()` still snap — a rig mid-lerp unprojects at one distance and picks at another — and so do WASD (a held key is already continuous) and the playback mirror.

**I owed you this one from PR #568: the camera never followed the tear-out.** `_aim_over` answers the *board's* surface, so the fight lifted into the diorama and the camera stayed down watching the hole. I flagged the hole and the guessed lift value in that PR and missed this. It is the `_lift` channel above, and its poll deliberately sits *above* the mirror's playback gate — `execute_orders` clears the staging and puts the lock back in one synchronous stretch, so a poll below the gate would never see a frame with the tiles home and the rig would stay in the sky.

**An AI move is framed across both its ends** — *"instead of just centering on the unit, it should try to show both their start and end position in the initial shot"*. The 2D camera travels to the **midpoint** and the rig **widens its distance** to hold the span. The widen only ever widens: a short hop already has both ends in frame, and pulling in to fit one answers a question nobody asked. A span too big to fit clamps at the board's own zoom ceiling, which is your *"unless super zoomed in"* expressed as a clamp rather than a special case.

**The closing `follow()` is gone from the move phase, and that is the point** — framing both ends only means anything if the camera *holds* while the walk crosses it. Following would drag the far end straight back out of frame.

## Knob

`CameraRig3D.glide_smoothing`, on the Game tab under **Camera handling** ("Pan glide speed"). Ships at 6.0 against the yaw/zoom `smoothing`'s 8.0 — deliberately a shade slower, because this is a travel rather than a response, but that is a guess and it is one slider.

## Flagged for your play-check

- **The pass-end return is the most visible change** — every Execute and every enemy turn now ends by flying back rather than cutting. If that reads as slow, it is the knob above, not a structural problem.
- **The transition pan is provisional by your own reservation.** It shares the one glide value with the four pans; if you want it to pace differently, that is a one-line fork and I have marked where.
- **The move-phase shot no longer tracks the walker.** Worth watching on a long walk across a big board: both ends are in frame by construction, but the unit crosses the frame rather than sitting in the middle of it.

## Verification

`presentation dev squad ai flow` green locally; CI has the full tree.

**Mutants — seven run, six killed, one survived and that is the finding.** Confirmed dead at the intended case, each with its own message: the pan teleports; the snap leaves a stale target; the mirror never polls the lift; the lift poll sits below the playback gate; the move phase frames the destination alone; the widen narrows as well as widens; the published span outlives the pass.

**`frame()` routed through `glide_to` passed all 28 rig cases.** `test_frame_snaps_the_camera_rather_than_easing_to_it` asserted the *zoom* axis only — position was not easable when it was written, and this slice made it one, so the case's name went on claiming all three axes while covering two. `pose()` had the identical gap and its case name undercounted out loud ("both smoothed axes", of which there are now three), so it is renamed rather than patched. Both now assert that nothing is left for the ease to close, and both red under the mutant.

One live interaction the change surfaced, worth knowing: **the pointer re-picks on camera movement**, so the cell under a motionless cursor legitimately changes while the rig is in the air — a SPACE case has to read the cell it acted on *before* the flight.

**Test fixtures swept:** five places shoved `rig.position` directly to set up a case. A raw write is now derived away rather than half-honoured, so all five go through `hold_at`. One of them matters beyond tidiness — the pan-limit clamp case would have passed on the rig never leaving the board at all.

**One test rewritten, not patched:** `test_the_move_phase_takes_the_camera_to_whoever_is_walking` asserted `follow_unit`, which is the rule that changed.

Canon: `docs/design/visual-clarity.md` -> *The camera MOVES AS ONE THING*. `presentation-effects.md`'s "SNAP, not glide" ruling on the #471 recentre is marked **superseded** with its date and the half of it that still stands.

Still open on #520: the impact layer (pitch driver, shake, micro-sway) and the follows (knockback, cliff).
