### PR TITLE
#582: author downwards — the hole plane stops being a lid, and the brush can aim at its own height

### DIFF
--- a/Classes/board/HoverPresenter.gd
+++ b/Classes/board/HoverPresenter.gd
@@ -65,7 +65,13 @@ func refresh() -> void:
 
 func update_hover_visuals(hovered_cell: Vector2i) -> void:
 	if game.grid.get_cell_tile_data(hovered_cell) == null:
-		return   # off the map -- every mode draws nothing out there
+		# Off the map -- every mode draws nothing out there. CLEARING is part of drawing nothing
+		# (#582): a bare return left the last card standing, so the readout went on describing a
+		# cell the pointer had left, and while chasing an unclickable tile it insisted the cell was
+		# at height -1 when the board said -3. A card that cannot be trusted to be about NOW is
+		# worse than no card.
+		game.hover_info_panel.clear()
+		return
 
 	# Only IDLE produces squad icons. They're collected rather than drawn inline because that
 	# branch clears icon types partway through; drawing once at the end survives the clear.
@@ -91,7 +97,12 @@ func update_hover_visuals(hovered_cell: Vector2i) -> void:
 		for icontype in icons_to_draw[unit]:
 			game.overlay_manager.create_unit_icon(unit, icontype)
 
+# CLEARS the card rather than filling it (#582). Dev mode never wrote it, so it held whatever the
+# last IDLE hover had left -- a card from before the mode was even entered, which is how a readout
+# for a cell at -3 came to say -1. Clearing rather than describing, because the dev-mode height
+# readout is HeightDebugOverlay's and a second voice for it is a second thing to keep in step.
 func _hover_dev_mode(cell: Vector2i) -> void:
+	game.hover_info_panel.clear()
 	var board: BoardContext = game._board()
 	if not board.is_walkable(cell) or game.unit_at_pointer(cell) != null:
 		game.cursor_controller.set_state(CursorController.CursorState.INVALID)

--- a/Classes/dev/DevController.gd
+++ b/Classes/dev/DevController.gd
@@ -500,6 +500,22 @@ func elevation_brush_live() -> bool:
 	return _elevation_brush() != null
 
 
+# The row a pick should resolve against instead of the board's geometry (#582), or NO_COLUMN while
+# ordinary picking stands. Lives HERE beside brush_ghost() because it is the same question that one
+# answers -- what the next click is aimed at -- and a host assembling it out of brush fields would be
+# a second place that knows what "the brush's height" means.
+#
+# Reads elevation_brush_live() rather than the paint mode, so the aim follows the LEVEL row exactly:
+# offered in TERRAIN and CORNER, which are the two modes that ask for a height at all.
+func brush_pick_row() -> int:
+	var brush := _elevation_brush()
+	if brush == null or not brush.pick_at_brush_height:
+		return BoardPicker.NO_COLUMN
+	# A "top row" is the row ABOVE the top cell -- pick_cell's convention, so a surface sits at
+	# row * ROW_HEIGHT. column_tops_from spells the same +1.
+	return BoardSpace.top_row_of(brush.selected_elevation()) + 1
+
+
 # The scroll wheel sets the level the elevation brush places at (#260).
 func _nudge_elevation(delta: int) -> void:
 	var brush := _elevation_brush()

--- a/Classes/dev/TileBrushTool.gd
+++ b/Classes/dev/TileBrushTool.gd
@@ -61,8 +61,22 @@ var _state_values: Array[Terrain.TileState] = []
 var _elevation := 0
 var _rise := Terrain.RampRise.NONE
 var _climb := Terrain.UNITS_PER_LEVEL
+
+# Whether a click is aimed at the brush's own Height plane rather than at the block you can see
+# (#582). Public because the pick reads it, and OFF by default: it trades away reaching a tall
+# column, which is the commoner gesture by far.
+#
+# It exists because the two halves of "I can't click this cell" have different causes. An INVISIBLE
+# floor occluding a sunken block is a picker bug and is fixed there. A one-cell well two units deep
+# is not: the ground beside it really does hide it at the rig's fixed pitch, and no picking rule
+# recovers what the camera cannot see. So the brush stops asking what is VISIBLE and asks what it is
+# AIMED at -- the same move #340 already made for the ghost, which shows the tile at the height you
+# picked rather than the height the cell happens to be.
+var pick_at_brush_height := false
+
 var _elevation_row: HBoxContainer
 var _elevation_spin: SpinBox
+var _pick_plane_row: HBoxContainer
 var _rise_row: HBoxContainer
 var _rise_option: OptionButton
 var _climb_row: HBoxContainer
@@ -421,6 +435,21 @@ func _build_extra_controls() -> void:
 		+ "Half is the gentle slope, one unit over one cell, so two of them stacked climb a level "
 		+ "across two cells. Greyed out with the direction, for the same reason."))
 
+	_pick_plane_row = HBoxContainer.new()
+	DevWidgets.add_checkbox(_pick_plane_row, "Aim at brush height", pick_at_brush_height,
+		func(on: bool): pick_at_brush_height = on,
+		DevWidgets.wrap_tooltip(
+			"Where a click LANDS while you author below the surface. Off, the pointer picks the "
+			+ "block you can see -- which is what you want almost always, and it is how you reach a "
+			+ "tall column to erase it. On, it picks the cell under the pointer on the brush's own "
+			+ "Height plane instead, whether or not anything is in the way. The ghost shows the "
+			+ "answer either way, so you can see where the click goes before you make it.\n\n"
+			+ "Turn it on to dig a hole ONE CELL wide: at the camera's angle you cannot see into "
+			+ "one deeper than a level, so the cell you just sank stops being clickable. Anything "
+			+ "two cells across is visible on its own and does not need this. 3D view only -- the "
+			+ "flat 2D board has no depth to be hidden by."))
+	add_child(_pick_plane_row)
+
 	_set_paint_mode(PaintMode.TERRAIN)
 
 func selected_elevation() -> int:
@@ -610,6 +639,9 @@ func _set_paint_mode(mode: PaintMode) -> void:
 	_elevation_row.visible = mode == PaintMode.TERRAIN or mode == PaintMode.CORNER
 	_rise_row.visible = mode == PaintMode.TERRAIN
 	_climb_row.visible = mode == PaintMode.TERRAIN
+	# Rides the LEVEL row exactly (#582): it aims at that height, so it is offered wherever that
+	# height is asked for and nowhere else. Same predicate DevController._elevation_brush gates on.
+	_pick_plane_row.visible = _elevation_row.visible
 	update_zone_highlight()   # draws on entering ZONE mode, clears on leaving it
 
 # NB the height readout is NOT lit from here. Painting height into an invisible store is blind, so it

--- a/Classes/presentation/BoardPicker.gd
+++ b/Classes/presentation/BoardPicker.gd
@@ -21,6 +21,13 @@ class_name BoardPicker
 #   as an analytic plane intersection before or after it, so a real column in front
 #   of a hole still wins by ray order rather than by a hand-written comparison.
 #   The rect is the caller's policy (board + authoring apron), never derived here.
+#   THE PLANE IS A FLOOR, NOT A LID (#582): it answers for ABSENT columns, and only a column
+#   BELOW it stays visible through it. It used to end the walk like any other hit, which made an
+#   INVISIBLE surface occlude a block that is plainly drawn — a cell painted more than one unit
+#   down became unpaintable, unerasable and unselectable at once, since every dev gesture reads
+#   this one answer. So a plane hit is now HELD rather than returned, and the walk goes on: the
+#   first real column below plane level wins, the first real column at or above it blocks and the
+#   held hit stands. Ray order still decides everything a ray can actually see.
 # - A ROW IS A NUMBER, NOT A TRUTH VALUE (#294): "nothing here" is NO_COLUMN, so every row in
 #   range — 0 and below included — is an ordinary answer. Nothing may gate on `row > 0`.
 
@@ -93,6 +100,37 @@ static func max_top(tops: Dictionary[Vector2i, int]) -> int:
 	return tallest
 
 
+# The column a ray meets a HORIZONTAL plane in, at `top_row` (#582) — the answer when the brush is
+# authoring at a height the board's own geometry hides. Deliberately NOT a walk: a 1-cell well two
+# units deep genuinely cannot be seen at the rig's 40 degree pitch, so no amount of ray-order
+# cleverness reaches it and the tool has to stop asking what is VISIBLE and start asking what the
+# brush is AIMED at. Nothing occludes a plane, so `tops` is not a parameter here.
+#
+# `plane` is the same authoring rect pick_cell takes, and it is still the caller's policy: outside
+# it there is no board to author, so the answer is the same miss.
+static func pick_on_plane(ray_origin: Vector3, ray_direction: Vector3, top_row: int,
+		plane: Rect2i) -> Vector3i:
+	var dir := ray_direction.normalized()
+	if not dir.is_finite() or is_zero_approx(dir.y):
+		return BoardSpace.NO_CELL   # along the surface: no crossing to read
+	var t := (top_row * BoardSpace.ROW_HEIGHT - ray_origin.y) / dir.y
+	if t < 0.0:
+		return BoardSpace.NO_CELL   # the plane is BEHIND the camera
+	var hit := ray_origin + dir * t
+	var column := Vector2i(floori(hit.x / BoardSpace.CELL_SIZE), floori(hit.z / BoardSpace.CELL_SIZE))
+	if not plane.has_point(column):
+		return BoardSpace.NO_CELL
+	return _top_cell(column, top_row)
+
+
+# pick_on_plane's camera convenience, pick_at's twin — the same reason #222 gives: a caller that
+# builds the origin/normal pair by hand is the copy this exists to stop.
+static func pick_at_height(camera: Camera3D, screen_pos: Vector2, top_row: int,
+		plane: Rect2i) -> Vector3i:
+	return pick_on_plane(camera.project_ray_origin(screen_pos),
+		camera.project_ray_normal(screen_pos), top_row, plane)
+
+
 # Ray-pair convenience: the cell under a camera's screen point. Every live caller
 # built the same origin/normal pair by hand (#222 collapsed three copies).
 static func pick_at(camera: Camera3D, screen_pos: Vector2, tops: Dictionary[Vector2i, int],
@@ -142,17 +180,31 @@ static func pick_cell(ray_origin: Vector3, ray_direction: Vector3, tops: Diction
 	var t_delta_z := cs / absf(dir.z) if step.y != 0 else INF
 	var t := 0.0
 
+	# A plane hit the walk is holding while it looks for a real column BELOW plane level (#582).
+	# NO_CELL means "none yet", and it doubles as the miss the walk falls out with -- the plane's
+	# answer only ever stands in for one that never came.
+	var pending := BoardSpace.NO_CELL
+
 	for i in _MAX_STEPS:
 		var y_enter := ray_origin.y + dir.y * t
 		if dir.y >= 0.0 and y_enter > ceiling * rh:
-			return BoardSpace.NO_CELL  # level or rising, already above every top
+			return pending  # level or rising, already above every top
 		var t_exit := minf(t_max_x, t_max_z)
 		var row := _top_row(col, tops, plane)
 		if row != NO_COLUMN:
 			var h: float = row * rh
 			var y_exit := ray_origin.y + dir.y * t_exit
 			if y_enter <= h or y_exit <= h:
-				return _top_cell(col, row)
+				# `tops` is the REAL board; anything else here came from the plane. Asked of the
+				# table rather than by comparing the row, because a real column may legitimately
+				# sit AT plane level and must still block.
+				if not tops.has(col):
+					if pending == BoardSpace.NO_CELL:
+						pending = _top_cell(col, row)
+				elif pending == BoardSpace.NO_CELL or row < BoardSpace.FLAT_TOP_ROW:
+					return _top_cell(col, row)
+				else:
+					return pending   # solid ground at or above the floor: the held hole stands
 		if t_max_x < t_max_z:
 			t = t_max_x
 			t_max_x += t_delta_x
@@ -162,8 +214,8 @@ static func pick_cell(ray_origin: Vector3, ray_direction: Vector3, tops: Diction
 			t_max_z += t_delta_z
 			col.y += step.y
 		if _departed(col, step, min_col, max_col):
-			return BoardSpace.NO_CELL
-	return BoardSpace.NO_CELL
+			return pending
+	return pending
 
 
 # What the ray can hit in this column: the painted column's top row, else the plane's

--- a/Scenes/Battle3D/battle3d.gd
+++ b/Scenes/Battle3D/battle3d.gd
@@ -1030,7 +1030,14 @@ func _cancel() -> void:
 		game._on_right_click()
 
 
+# ONE pick, whichever question is live (#582). The brush's aim-at-height mode replaces the geometry
+# walk here rather than beside it, so cell_source, pointer_source and _vertex_under keep reading the
+# single _pointer_cell below -- hover, the ghost, paint, erase and the corner tool cannot come to
+# different conclusions about where the mouse is, which is the whole reason this funnel exists.
 func _pick(screen_pos: Vector2) -> Vector3i:
+	var row: int = game.dev_controller.brush_pick_row()
+	if row != BoardPicker.NO_COLUMN:
+		return BoardPicker.pick_at_height(_camera, screen_pos, row, _paint_plane())
 	return BoardPicker.pick_at(_camera, screen_pos, _tops, _paint_plane())
 
 

--- a/docs/design/verticality.md
+++ b/docs/design/verticality.md
@@ -934,7 +934,7 @@ refusal is answered by ordering — tile first, then height), and a ramp wears t
 `BoardHeights.set_cell` takes both and a cell is one answer; two brushes would be two ways to author
 one thing. The wheel is read **first** in `DevController.handle_tile_brush` and returns, so a notch
 mid-stroke changes the level without ending the stroke, and it is gated on `event.pressed` because
-Godot emits a press *and* a release per notch. Four rulings worth keeping:
+Godot emits a press *and* a release per notch. Five rulings worth keeping:
 
 - **Negative levels are reachable, deliberately.** The dev: *"if I start designing a level and want a
   dip, without allowing negatives, I would have to shift everything up. no bueno."* Nothing in
@@ -943,6 +943,24 @@ Godot emits a press *and* a release per notch. Four rulings worth keeping:
   deep tops out at level `0`, which was also its "there is no column here" answer, so a dip read as
   flat inside the authoring apron and was unclickable outside it. `BoardPicker.NO_COLUMN` separates
   the two — **a level is a number, not a truth value**, and nothing may gate on `level > 0`.
+  [#582](https://github.com/Phaazoid/Godoiosis/issues/582) is the other half: #294 made a dip
+  **representable**, and it was still not **reachable**. The apron's implicit floor sits at
+  `FLAT_TOP_ROW`, and it used to end the walk like any real hit — so an *invisible* surface occluded
+  a block that is plainly drawn, and a cell painted more than a level down became unpaintable,
+  unerasable and unselectable at once, every dev gesture reading the one pick. **The plane is a
+  floor, not a lid:** a plane hit is HELD, the walk goes on, the first real column below floor level
+  wins, and the first real column at or above it blocks with the held hit standing — which is what
+  keeps [#231](https://github.com/Phaazoid/Godoiosis/issues/231)'s erased cell answering for itself.
+- **What the camera cannot see, the brush aims at instead.** The second half of #582, and a separate
+  problem wearing the same symptom: a **one-cell** well two units deep is hidden by its own
+  neighbours, honestly, at the rig's fixed 40° pitch — measured, it needs 56° to see the floor, and
+  no picking rule recovers what is not on screen. Anything **two cells across is visible on its own
+  at any depth** (3×3 and 5×5 measured, every cell), so the gap is exactly the one-wide well. The
+  Tile Brush's **Aim at brush height** toggle answers it by changing the QUESTION: while it is on the
+  pick resolves against the brush's own Height plane (`BoardPicker.pick_on_plane`) rather than the
+  board, so nothing can occlude it. Off by default, because it trades away reaching a tall column to
+  erase it — the commoner gesture by far. It is #340's ruling one layer down: the ghost already shows
+  the tile at the height you picked rather than the height the cell happens to be.
 - **Elevation goes with the ground.** `BoardHeights.prune_groundless` runs at both sites the tile-state
   sweep does (brush erase, `resize_map`), because a height under no tile is invisible junk that
   resurrects the moment ground is repainted there. The predicate is a **parameter**, not an injected

--- a/tests/dev/test_dev_tree.gd
+++ b/tests/dev/test_dev_tree.gd
@@ -153,6 +153,43 @@ func test_a_stale_brush_flag_does_not_arm_from_another_page() -> void:
 		"the brush refuses to arm on its own page; the clause is refusing everything").is_true()
 
 
+# --- brush_pick_row(): where a click is AIMED (#582) ------------------------------------------
+
+# The toggle that lets the brush author a cell the camera cannot see. It is gated on the same arming
+# the rest of the brush is, and it rides the LEVEL row -- so it must go quiet in every mode that does
+# not ask for a height, and the moment the brush is not armed at all.
+func test_the_aim_row_follows_the_brush_height_and_only_while_it_is_armed() -> void:
+	game.set_dev_mode(true)
+	await _select("Tile Brush")
+	var brush: TileBrushTool = overlay.tile_brush
+	brush.brush_active = true
+	brush.paint_mode = TileBrushTool.PaintMode.TERRAIN
+
+	assert_int(game.dev_controller.brush_pick_row()).override_failure_message(
+		"the aim answered while the toggle was off; ordinary picking must stand") \
+		.is_equal(BoardPicker.NO_COLUMN)
+
+	brush.pick_at_brush_height = true
+	brush.set_elevation(-Terrain.UNITS_PER_LEVEL - 1)
+	assert_int(game.dev_controller.brush_pick_row()).override_failure_message(
+		"the aim did not follow the brush's own Height") \
+		.is_equal(BoardSpace.top_row_of(brush.selected_elevation()) + 1)
+	assert_int(game.dev_controller.brush_pick_row()).override_failure_message(
+		"a sunken aim came back at or above the floor; the case proves nothing") \
+		.is_less(BoardSpace.FLAT_TOP_ROW)
+
+	# The gates, one at a time: a mode with no level row, then no armed brush at all.
+	brush.paint_mode = TileBrushTool.PaintMode.ZONE
+	assert_int(game.dev_controller.brush_pick_row()).override_failure_message(
+		"the aim survived a mode that never asks for a height") \
+		.is_equal(BoardPicker.NO_COLUMN)
+	brush.paint_mode = TileBrushTool.PaintMode.TERRAIN
+	brush.brush_active = false
+	assert_int(game.dev_controller.brush_pick_row()).override_failure_message(
+		"the aim survived a disarmed brush") \
+		.is_equal(BoardPicker.NO_COLUMN)
+
+
 # --- showing(): the one answer to which page owns input (2026-08-23) -------------------------
 
 # It replaced four hand-rolled spellings, and the NESTED pair is why it has to be a function rather

--- a/tests/presentation/test_board_picker.gd
+++ b/tests/presentation/test_board_picker.gd
@@ -57,6 +57,26 @@ var _dipped_tops: Dictionary[Vector2i, int] = {
 }
 
 
+# Deeper than the plane by more than a whole level — the depth #582 was authored at, stated through
+# the constant so a re-based UNITS_PER_LEVEL cannot quietly float this fixture back up to the floor.
+const SUNKEN_HEIGHT := -Terrain.UNITS_PER_LEVEL - 1
+
+# ONE column, sunk, with nothing around it: the lone block the dev painted into open ground. The
+# void beside it is inside the apron, so the plane answers there and used to answer FIRST.
+var _sunken_tops: Dictionary[Vector2i, int] = {
+	Vector2i(0, 0): _top_for(SUNKEN_HEIGHT),
+}
+
+# _holed_tops with a sunken column added beyond the hole: the ray meets the HOLE, then solid ground
+# at plane level, then the pit — the only order that can tell "held" apart from "deferred". Same
+# hole at (1, 0), so the shallow ray the plane cases already use reaches it.
+var _hole_then_pit_tops: Dictionary[Vector2i, int] = {
+	Vector2i(0, 0): _top_for(SHORT_HEIGHT),
+	Vector2i(2, 0): _top_for(SHORT_HEIGHT),
+	Vector2i(3, 0): _top_for(SUNKEN_HEIGHT),
+}
+
+
 func _apron_of(tops: Dictionary[Vector2i, int]) -> Rect2i:
 	return BoardPicker.used_rect(tops).grow(APRON)
 
@@ -214,6 +234,83 @@ func test_a_dip_inside_the_plane_reads_as_the_dip_and_not_as_flat() -> void:
 		.is_less(BoardSpace.top_row_of(SHORT_HEIGHT))
 
 
+# --- The plane is a FLOOR, not a lid (#582) ------------------------------------
+
+func test_a_column_below_the_plane_is_visible_through_it() -> void:
+	# The headline. The apron's floor is INVISIBLE, so it must not hide a block that is drawn:
+	# a cell painted more than a level down used to pick as the void in front of it, which made it
+	# unpaintable, unerasable and unselectable at once.
+	var surface := BoardSpace.surface_y(BoardSpace.top_row_of(SUNKEN_HEIGHT))
+	var aim := Vector3(0.5, surface, 0.5)
+	var along := Vector3(2.0, -2.0, 0.0)
+	var plane := _apron_of(_sunken_tops)
+	var origin := aim - along.normalized() * 10.0
+
+	# Non-vacuity, and the whole mechanism in one line: the ray crosses the plane's own height
+	# SOMEWHERE ELSE, so under the old rule that column answered and this one never got asked.
+	assert_that(BoardSpace.flat(BoardPicker.pick_on_plane(origin, along, BoardSpace.FLAT_TOP_ROW, plane))) \
+		.override_failure_message("the ray meets the plane inside the sunken column; nothing occludes") \
+		.is_not_equal(Vector2i(0, 0))
+
+	assert_that(BoardPicker.pick_cell(origin, along, _sunken_tops, plane)) \
+		.override_failure_message("the invisible floor answered in front of a block you can see") \
+		.is_equal(_cell_at(Vector2i(0, 0), SUNKEN_HEIGHT))
+
+
+func test_ground_at_plane_level_blocks_and_the_held_hole_stands() -> void:
+	# The other side of the same rule, and the one that keeps #231: a held plane hit may only be
+	# beaten by a column BELOW the floor. Solid ground at floor level really does block, so the
+	# hole the ray entered first is the answer — never a pit further down the same ray.
+	var plane := _apron_of(_hole_then_pit_tops)
+	var cell := BoardPicker.pick_cell(Vector3(-1.5, 3.0, 0.5), Vector3(3.0, -2.0, 0.0),
+			_hole_then_pit_tops, plane)
+	assert_that(cell).override_failure_message(
+			"the hole lost its ray — to the ground that blocks, or to the pit past it") \
+		.is_equal(_cell_at(Vector2i(1, 0), SHORT_HEIGHT))
+	assert_bool(_hole_then_pit_tops.has(Vector2i(1, 0))).override_failure_message(
+			"the fixture's hole stopped being a hole; the case is vacuous").is_false()
+	assert_bool(_hole_then_pit_tops.has(Vector2i(2, 0))).override_failure_message(
+			"nothing blocks between the hole and the pit; the case is vacuous").is_true()
+
+
+func test_pick_on_plane_answers_the_crossing_column_and_not_the_blocker() -> void:
+	# The brush's aim (#582). Nothing can hide behind a plane — pick_on_plane takes no `tops` at
+	# all — so the tower this very ray strikes cannot change the answer. That is what lets the brush
+	# author a one-cell well the camera has no line into.
+	var origin := Vector3(-2.5, 5.0, 0.5)
+	var along := Vector3(4.0, -2.0, 0.0)
+	var row := BoardSpace.top_row_of(SUNKEN_HEIGHT) + 1
+	# The case states its own rect rather than borrowing the board's apron: a ray travels while it
+	# descends, so a crossing this far down lands well outside a board-sized one — which is the
+	# neighbouring case's point, not this one's.
+	var reach := _apron_of(_tower_tops).grow(APRON * 4)
+
+	var aimed := BoardPicker.pick_on_plane(origin, along, row, reach)
+	assert_that(aimed).override_failure_message("the aim fell outside its own rect") \
+		.is_not_equal(BoardSpace.NO_CELL)
+	assert_int(aimed.y).override_failure_message("the aimed cell came back at the wrong row") \
+		.is_equal(BoardSpace.top_row_of(SUNKEN_HEIGHT))
+
+	var struck := BoardPicker.pick_cell(origin, along, _tower_tops, reach)
+	assert_that(struck).override_failure_message("the ray strikes nothing; the case is vacuous") \
+		.is_not_equal(BoardSpace.NO_CELL)
+	assert_that(aimed).override_failure_message("the aim came back as the blocker the walk found") \
+		.is_not_equal(struck)
+
+
+func test_pick_on_plane_misses_outside_the_authoring_rect_and_behind_the_camera() -> void:
+	# The rect stays the caller's policy, exactly as pick_cell has it — and a plane the ray is
+	# travelling AWAY from is a miss, not a hit at a negative distance.
+	var plane := _apron_of(_tower_tops)
+	var outside := plane.end
+	assert_that(BoardPicker.pick_on_plane(Vector3(outside.x + 0.5, 5.0, outside.y + 0.5),
+			Vector3.DOWN, BoardSpace.FLAT_TOP_ROW, plane)).is_equal(BoardSpace.NO_CELL)
+	assert_that(BoardPicker.pick_on_plane(Vector3(0.5, 5.0, 0.5), Vector3.UP,
+			BoardSpace.FLAT_TOP_ROW, plane)).is_equal(BoardSpace.NO_CELL)
+	assert_that(BoardPicker.pick_on_plane(Vector3(0.5, 5.0, 0.5), Vector3(1.0, 0.0, 0.0),
+			BoardSpace.FLAT_TOP_ROW, plane)).is_equal(BoardSpace.NO_CELL)
+
+
 func test_a_ray_clearing_the_rim_strikes_the_dips_own_cell() -> void:
 	# The walk's hit test at h == 0, reached the way a real camera reaches it: over the near rim
 	# (both ends above the neighbours' top, so they do not answer) and down through the dip's
@@ -292,6 +389,20 @@ func test_pick_at_is_the_ray_pair_spelled_once() -> void:
 			camera.project_ray_origin(screen), camera.project_ray_normal(screen), tops, Rect2i())
 	assert_that(direct).is_not_equal(BoardSpace.NO_CELL)
 	assert_that(BoardPicker.pick_at(camera, screen, tops, Rect2i())).is_equal(direct)
+
+
+func test_pick_at_height_is_the_ray_pair_spelled_once() -> void:
+	# pick_at's twin, and the same reason it exists (#222): a caller building the origin/normal
+	# pair by hand is the copy these convenience wrappers are here to stop.
+	var board := _scene.get_node("Board") as GridMap
+	var camera := _scene.get_node("CameraRig/Pitch/Camera") as Camera3D
+	var plane := BoardPicker.used_rect(BoardPicker.column_tops_from(board)).grow(APRON)
+	var screen := camera.unproject_position(BoardSpace.standing_point(Vector3i(8, 2, 3)))
+	var direct := BoardPicker.pick_on_plane(camera.project_ray_origin(screen),
+			camera.project_ray_normal(screen), BoardSpace.FLAT_TOP_ROW, plane)
+	assert_that(direct).is_not_equal(BoardSpace.NO_CELL)
+	assert_that(BoardPicker.pick_at_height(camera, screen, BoardSpace.FLAT_TOP_ROW, plane)) \
+		.is_equal(direct)
 
 
 func test_occluded_cell_yields_the_blocker_not_the_hidden_cell() -> void:

--- a/tests/ui/test_tile_hover_readout.gd
+++ b/tests/ui/test_tile_hover_readout.gd
@@ -128,6 +128,41 @@ func test_every_tile_shows_a_card_with_its_kind() -> void:
 	assert_bool(game.hover_info_panel.hover_panel.visible).is_false()
 
 
+func test_leaving_the_map_takes_the_card_with_it() -> void:
+	# #582: the off-map branch used to bare-return, so the last card stayed up and went on
+	# describing a cell the pointer had left. A card is about NOW or it is a lie -- and this one
+	# lied about a tile's height while the dev was hunting why he could not click it.
+	game.hover_presenter.update_hover_visuals(Vector2i(2, 0))
+	await await_idle_frame()
+	assert_bool(game.hover_info_panel.visible) \
+		.override_failure_message("no card to leave behind; the case is vacuous").is_true()
+
+	var off_map := Vector2i(-40, -40)
+	assert_object(game.grid.get_cell_tile_data(off_map)) \
+		.override_failure_message("the fixture grew a tile out there").is_null()
+	game.hover_presenter.update_hover_visuals(off_map)
+	await await_idle_frame()
+	assert_bool(game.hover_info_panel.visible) \
+		.override_failure_message("the card outlived the tile it describes").is_false()
+
+
+func test_dev_mode_does_not_inherit_the_last_card_from_play() -> void:
+	# The other half of the same lie (#582), and the one that actually bit: DEV_MODE never wrote
+	# the card at all, so it held whatever IDLE last hovered -- a readout from before the mode was
+	# even entered. Cleared rather than filled, because the dev-mode height readout belongs to
+	# HeightDebugOverlay and must not gain a second voice.
+	game.hover_presenter.update_hover_visuals(Vector2i(2, 0))
+	await await_idle_frame()
+	assert_bool(game.hover_info_panel.visible) \
+		.override_failure_message("no card to carry over; the case is vacuous").is_true()
+
+	game.game_state = game.GameState.DEV_MODE
+	game.hover_presenter.update_hover_visuals(Vector2i(3, 0))
+	await await_idle_frame()
+	assert_bool(game.hover_info_panel.visible) \
+		.override_failure_message("the play card followed the dev into DEV_MODE").is_false()
+
+
 func test_a_named_tile_headers_its_authored_name() -> void:
 	# The 2026-08-12 report: the card assumed the name off the Kind enum, so an authored
 	# variant read as plain "Grass" however it was named.


### PR DESCRIPTION
Closes #582.

Painting a cell more than one unit below flat made it permanently unpaintable, unerasable and unselectable. Two independent causes wearing one symptom, so two fixes — plus the stale readout that made it unreadable.

## 1. The hole plane is a floor, not a lid

`BoardPicker._top_row` hands every absent in-plane column a floor at `FLAT_TOP_ROW`, and the walk returned the first column the ray dipped into — so an **invisible** surface occluded a block that is plainly drawn.

A plane hit is now **held**. The walk goes on: the first real column below floor level wins, the first at or above it blocks and the held hit stands. That last clause is what keeps #231's erased cell answering for itself.

Measured against the real picker on the board from the two reports, 69120 rays per cell:

| case | before | after |
|---|---|---|
| lone sunken cell, empty neighbours (shot 1) | 0 @ 25–45° | **19466 / 23820 / 28188** |
| #231 erased cell in a flat board | 17280 | **17280 — unchanged** |

## 2. The brush can aim at its own height

The other half is not a picker bug. A **one-cell** well two units deep is hidden by its own neighbours, honestly, at the rig's fixed 40°: it needs 56° to see the floor, and no picking rule recovers what is not on screen. Anything **two cells across is visible on its own at any depth** — 3×3 and 5×5 measured, every cell — so the gap is exactly the one-wide well, which is what shot 2 is.

So the brush stops asking what is VISIBLE and asks what it is AIMED at. New Tile Brush toggle **Aim at brush height**: the pick resolves against the brush's own Height plane (`BoardPicker.pick_on_plane`, no `tops` to be occluded by). **Off by default** — it trades away reaching a tall column to erase it, the commoner gesture by far. It is #340's ruling one layer down.

Same board, with the toggle on: **17280 at every pitch** — the cell's whole area, pitch-independent, as a plane must be.

`brush_pick_row()` lives beside `brush_ghost()` because it answers the same question, and `_pick` still returns ONE cell, so hover, the ghost, paint, erase and the corner tool cannot disagree about where the mouse is.

## 3. The hover card is about now, or it is a lie

Both report screenshots read "Height −1" for a cell the board had at −3. Two holes: `update_hover_visuals` bare-returned off the map, and `_hover_dev_mode` never touched the card at all — so in DEV_MODE it held whatever IDLE last hovered, from before the mode was entered. Both **cleared** rather than filled; `HeightDebugOverlay` owns the dev-mode height readout and must not gain a second voice.

## Verification

`tests/presentation` + `tests/dev` + `tests/ui` — 1058 cases, 0 orphans. 6 new cases across three suites.

Falsified, one mutant at a time, each killed by the case named for it:

1. real column always beats a held hole → `test_the_ground_plane_sits_on_the_top_face_not_the_slab_bottom` reds
2. return the plane hit instead of holding it → `test_a_column_below_the_plane_is_visible_through_it` reds
3. drop the held hit at walk end → `test_the_apron_catches_a_ray_that_walks_off_the_board` reds

Canon swept: `docs/design/verticality.md` — the #294 ruling gains its other half (representable was not reachable), plus the aim-toggle ruling. No embedded-content field added, so no `.tres` fixture sweep is owed.

## Not in scope

The dev camera pitch control, which would make an occluded cell visible generally rather than aimable — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
