### PR TITLE
#582 follow-up: the tile brush aims at one place

### DIFF
--- a/Classes/dev/DevController.gd
+++ b/Classes/dev/DevController.gd
@@ -500,16 +500,27 @@ func elevation_brush_live() -> bool:
 	return _elevation_brush() != null
 
 
-# The row a pick should resolve against instead of the board's geometry (#582), or NO_COLUMN while
-# ordinary picking stands. Lives HERE beside brush_ghost() because it is the same question that one
-# answers -- what the next click is aimed at -- and a host assembling it out of brush fields would be
-# a second place that knows what "the brush's height" means.
+# The row a pick resolves against while the brush is authoring at a height (#582), or NO_COLUMN while
+# ordinary geometry picking stands. Lives HERE beside brush_ghost() because it is the same question
+# that one answers -- what the next click is aimed at -- and a host assembling it out of brush fields
+# would be a second place that knows what "the brush's height" means.
+#
+# UNCONDITIONAL while the level row is up, and that is the correction #585 needed (dev, 2026-08-27:
+# "in the tile brush mode, it should only ever be selecting where my ghost tile is"). It shipped as an
+# opt-in toggle defaulting to OFF, which left the tool answering "where is the mouse" TWICE: the ghost
+# draws at the brush's height and the selector bracket at the picked column's own, so they sat at two
+# heights and two screen positions at once. They can only coincide when the PICK is on the plane --
+# the bracket reads its height straight off the picked cell -- and only then is the ghost under the
+# cursor at all, since the picked column is where the ray crosses. The geometry pick is what displaces
+# it. A drag was the other half: reading geometry the drag is MUTATING, the pick slips onto a
+# neighbour the moment a cell sinks, and a plane cannot.
 #
 # Reads elevation_brush_live() rather than the paint mode, so the aim follows the LEVEL row exactly:
-# offered in TERRAIN and CORNER, which are the two modes that ask for a height at all.
+# TERRAIN and CORNER, the two modes that ask for a height at all. ZONE and STATE keep geometry
+# picking, which is right -- they mark a cell you can SEE and have no height to aim at.
 func brush_pick_row() -> int:
 	var brush := _elevation_brush()
-	if brush == null or not brush.pick_at_brush_height:
+	if brush == null:
 		return BoardPicker.NO_COLUMN
 	# A "top row" is the row ABOVE the top cell -- pick_cell's convention, so a surface sits at
 	# row * ROW_HEIGHT. column_tops_from spells the same +1.

--- a/Classes/dev/TileBrushTool.gd
+++ b/Classes/dev/TileBrushTool.gd
@@ -62,21 +62,8 @@ var _elevation := 0
 var _rise := Terrain.RampRise.NONE
 var _climb := Terrain.UNITS_PER_LEVEL
 
-# Whether a click is aimed at the brush's own Height plane rather than at the block you can see
-# (#582). Public because the pick reads it, and OFF by default: it trades away reaching a tall
-# column, which is the commoner gesture by far.
-#
-# It exists because the two halves of "I can't click this cell" have different causes. An INVISIBLE
-# floor occluding a sunken block is a picker bug and is fixed there. A one-cell well two units deep
-# is not: the ground beside it really does hide it at the rig's fixed pitch, and no picking rule
-# recovers what the camera cannot see. So the brush stops asking what is VISIBLE and asks what it is
-# AIMED at -- the same move #340 already made for the ghost, which shows the tile at the height you
-# picked rather than the height the cell happens to be.
-var pick_at_brush_height := false
-
 var _elevation_row: HBoxContainer
 var _elevation_spin: SpinBox
-var _pick_plane_row: HBoxContainer
 var _rise_row: HBoxContainer
 var _rise_option: OptionButton
 var _climb_row: HBoxContainer
@@ -397,7 +384,11 @@ func _build_extra_controls() -> void:
 		% Terrain.UNITS_PER_LEVEL
 		+ "a half-level platform. Scroll the mouse wheel over the board to change it, one unit per "
 		+ "notch -- hold Ctrl to zoom the camera instead. Reset returns the brush to flat ground: "
-		+ "height 0, no ramp. Negative heights are dips."))
+		+ "height 0, no ramp. Negative heights are dips.\n\n"
+		+ "This is also where a click LANDS: the pointer picks the cell under it on THIS height's "
+		+ "plane, not the block you can see, so the ghost and the selector are one thing and a drag "
+		+ "cannot slip onto another layer as it paints. To reach a column whose top is somewhere "
+		+ "else -- to erase a tall one -- scroll to that height first."))
 
 	_rise_row = HBoxContainer.new()
 	var rise_label := Label.new()
@@ -434,21 +425,6 @@ func _build_extra_controls() -> void:
 		% Terrain.UNITS_PER_LEVEL
 		+ "Half is the gentle slope, one unit over one cell, so two of them stacked climb a level "
 		+ "across two cells. Greyed out with the direction, for the same reason."))
-
-	_pick_plane_row = HBoxContainer.new()
-	DevWidgets.add_checkbox(_pick_plane_row, "Aim at brush height", pick_at_brush_height,
-		func(on: bool): pick_at_brush_height = on,
-		DevWidgets.wrap_tooltip(
-			"Where a click LANDS while you author below the surface. Off, the pointer picks the "
-			+ "block you can see -- which is what you want almost always, and it is how you reach a "
-			+ "tall column to erase it. On, it picks the cell under the pointer on the brush's own "
-			+ "Height plane instead, whether or not anything is in the way. The ghost shows the "
-			+ "answer either way, so you can see where the click goes before you make it.\n\n"
-			+ "Turn it on to dig a hole ONE CELL wide: at the camera's angle you cannot see into "
-			+ "one deeper than a level, so the cell you just sank stops being clickable. Anything "
-			+ "two cells across is visible on its own and does not need this. 3D view only -- the "
-			+ "flat 2D board has no depth to be hidden by."))
-	add_child(_pick_plane_row)
 
 	_set_paint_mode(PaintMode.TERRAIN)
 
@@ -639,9 +615,6 @@ func _set_paint_mode(mode: PaintMode) -> void:
 	_elevation_row.visible = mode == PaintMode.TERRAIN or mode == PaintMode.CORNER
 	_rise_row.visible = mode == PaintMode.TERRAIN
 	_climb_row.visible = mode == PaintMode.TERRAIN
-	# Rides the LEVEL row exactly (#582): it aims at that height, so it is offered wherever that
-	# height is asked for and nowhere else. Same predicate DevController._elevation_brush gates on.
-	_pick_plane_row.visible = _elevation_row.visible
 	update_zone_highlight()   # draws on entering ZONE mode, clears on leaving it
 
 # NB the height readout is NOT lit from here. Painting height into an invisible store is blind, so it

--- a/docs/design/verticality.md
+++ b/docs/design/verticality.md
@@ -934,7 +934,7 @@ refusal is answered by ordering — tile first, then height), and a ramp wears t
 `BoardHeights.set_cell` takes both and a cell is one answer; two brushes would be two ways to author
 one thing. The wheel is read **first** in `DevController.handle_tile_brush` and returns, so a notch
 mid-stroke changes the level without ending the stroke, and it is gated on `event.pressed` because
-Godot emits a press *and* a release per notch. Five rulings worth keeping:
+Godot emits a press *and* a release per notch. Six rulings worth keeping:
 
 - **Negative levels are reachable, deliberately.** The dev: *"if I start designing a level and want a
   dip, without allowing negatives, I would have to shift everything up. no bueno."* Nothing in
@@ -956,11 +956,26 @@ Godot emits a press *and* a release per notch. Five rulings worth keeping:
   neighbours, honestly, at the rig's fixed 40° pitch — measured, it needs 56° to see the floor, and
   no picking rule recovers what is not on screen. Anything **two cells across is visible on its own
   at any depth** (3×3 and 5×5 measured, every cell), so the gap is exactly the one-wide well. The
-  Tile Brush's **Aim at brush height** toggle answers it by changing the QUESTION: while it is on the
-  pick resolves against the brush's own Height plane (`BoardPicker.pick_on_plane`) rather than the
-  board, so nothing can occlude it. Off by default, because it trades away reaching a tall column to
-  erase it — the commoner gesture by far. It is #340's ruling one layer down: the ghost already shows
-  the tile at the height you picked rather than the height the cell happens to be.
+  brush answers it by changing the QUESTION: while the level row is up, the pick resolves against the
+  brush's own Height plane (`BoardPicker.pick_on_plane`, via `DevController.brush_pick_row`) rather
+  than the board, so nothing can occlude it. It is #340's ruling one layer down — the ghost already
+  showed the tile at the height you picked rather than the height the cell happens to be.
+- **And it is NOT a preference — that was the correction, found in play.** It shipped in #585 as an
+  opt-in toggle defaulting to off, on the reasoning that it trades away reaching a tall column to
+  erase it. What that reasoning missed is that the tool then answers *"where is the mouse"* **twice**:
+  the ghost draws at the brush's height and the hover bracket at the picked column's own, so they sit
+  at two heights and two screen positions at once. Dev, 2026-08-27: *"my mouse is kind of in two
+  places at once … I don't know where I'm aiming, and I can't click/drag to paint low, because it
+  jumps between which is the correct layer. we need to compress this, in the tile brush mode, it
+  should only ever be selecting where my ghost tile is."* **They can only coincide when the PICK is on
+  the plane** — `BoardOverlays._marker_transform` reads its height straight off the picked cell — and
+  only then is the ghost under the cursor at all, since the picked column is where the ray crosses;
+  the geometry pick is what displaces it. The drag was the same fault moving: a pick that reads
+  geometry the drag is MUTATING slips onto a neighbour the moment a cell sinks, and a plane cannot.
+  So it is unconditional in **TERRAIN and CORNER**, the two modes that ask for a height; ZONE and
+  STATE keep geometry picking, marking a cell you can see. The accepted cost is the one the toggle
+  was protecting: reaching a column whose top is elsewhere means scrolling the wheel to that height
+  first, which the selector makes visible rather than surprising.
 - **Elevation goes with the ground.** `BoardHeights.prune_groundless` runs at both sites the tile-state
   sweep does (brush erase, `resize_map`), because a height under no tile is invisible junk that
   resurrects the moment ground is repainted there. The predicate is a **parameter**, not an injected

--- a/tests/dev/test_dev_tree.gd
+++ b/tests/dev/test_dev_tree.gd
@@ -155,28 +155,28 @@ func test_a_stale_brush_flag_does_not_arm_from_another_page() -> void:
 
 # --- brush_pick_row(): where a click is AIMED (#582) ------------------------------------------
 
-# The toggle that lets the brush author a cell the camera cannot see. It is gated on the same arming
-# the rest of the brush is, and it rides the LEVEL row -- so it must go quiet in every mode that does
-# not ask for a height, and the moment the brush is not armed at all.
-func test_the_aim_row_follows_the_brush_height_and_only_while_it_is_armed() -> void:
+# The aim is UNCONDITIONAL while the level row is up -- it is not a preference, it is the only way
+# the ghost and the selector can name one place. It rides that row exactly, so it must go quiet in
+# every mode that asks for no height, and the moment the brush is not armed at all.
+func test_the_aim_follows_the_brush_height_in_both_modes_that_ask_for_one() -> void:
 	game.set_dev_mode(true)
 	await _select("Tile Brush")
 	var brush: TileBrushTool = overlay.tile_brush
 	brush.brush_active = true
-	brush.paint_mode = TileBrushTool.PaintMode.TERRAIN
-
-	assert_int(game.dev_controller.brush_pick_row()).override_failure_message(
-		"the aim answered while the toggle was off; ordinary picking must stand") \
-		.is_equal(BoardPicker.NO_COLUMN)
-
-	brush.pick_at_brush_height = true
 	brush.set_elevation(-Terrain.UNITS_PER_LEVEL - 1)
-	assert_int(game.dev_controller.brush_pick_row()).override_failure_message(
-		"the aim did not follow the brush's own Height") \
-		.is_equal(BoardSpace.top_row_of(brush.selected_elevation()) + 1)
-	assert_int(game.dev_controller.brush_pick_row()).override_failure_message(
-		"a sunken aim came back at or above the floor; the case proves nothing") \
-		.is_less(BoardSpace.FLAT_TOP_ROW)
+
+	# TERRAIN paints a tile at a height and CORNER drags a point to one -- the same question, so the
+	# same answer. Corner mode reads it through _vertex_under, which drops the ray on the picked
+	# cell's surface, i.e. this plane.
+	for mode: TileBrushTool.PaintMode in [TileBrushTool.PaintMode.TERRAIN,
+			TileBrushTool.PaintMode.CORNER]:
+		brush.paint_mode = mode
+		assert_int(game.dev_controller.brush_pick_row()).override_failure_message(
+			"%s did not aim at the brush's own Height" % TileBrushTool.MODE_LABELS[mode]) \
+			.is_equal(BoardSpace.top_row_of(brush.selected_elevation()) + 1)
+		assert_int(game.dev_controller.brush_pick_row()).override_failure_message(
+			"a sunken aim came back at or above the floor; the case proves nothing") \
+			.is_less(BoardSpace.FLAT_TOP_ROW)
 
 	# The gates, one at a time: a mode with no level row, then no armed brush at all.
 	brush.paint_mode = TileBrushTool.PaintMode.ZONE

--- a/tests/presentation/test_input_bridge.gd
+++ b/tests/presentation/test_input_bridge.gd
@@ -920,6 +920,46 @@ func _unshadowed_cell(a: Vector2, b: Vector2) -> Vector2i:
 	return GridUtils.NO_CELL
 
 
+# The mouse is ONE place (#582 follow-up). Reported in play against the shipped #585: the ghost drew
+# at the brush's height while the selector bracket drew at the picked column's own, so they sat at two
+# heights AND two screen positions -- "my mouse is kind of in two places at once ... I don't know
+# where I'm aiming" -- and a drag slipped onto another layer the moment a cell sank under it.
+#
+# Asserted on what each renderer is HANDED rather than on the world Y it computes: BoardOverlays reads
+# the picked cell and BoardMirror reads the ghost, so agreeing here is the whole property, while
+# re-deriving surface_y on both sides would pass against any mutant that broke the pick.
+func test_the_brush_ghost_and_the_hover_selector_name_one_cell() -> void:
+	var uv := Vector2(0.5, 0.5)
+	var cell := _unshadowed_cell(uv, uv)
+	assert_object(cell).override_failure_message(
+			"no cell on this board picks back to itself").is_not_equal(GridUtils.NO_CELL)
+	_arm_brush()
+	var brush: TileBrushTool = _game.dev_overlay.tile_brush
+	brush.paint_mode = TileBrushTool.PaintMode.TERRAIN
+	brush.set_elevation(-Terrain.UNITS_PER_LEVEL - 1)
+	await _pump()
+
+	_scene._update_pointer(_screen_in(cell, uv))
+	var ghost: BrushGhost = _game.dev_controller.brush_ghost()
+	assert_object(ghost).override_failure_message("the armed brush previews nothing").is_not_null()
+
+	var hovered: Array[Vector3i] = _overlays.cells_of(BoardOverlays.Layer.HOVER)
+	assert_int(hovered.size()).override_failure_message(
+			"the pointer marked no cell; there is nothing to compare").is_equal(1)
+	# Non-vacuity, and the bug in one line: the brush is authoring BELOW the ground here, so a pick
+	# that read geometry would answer the surface row and disagree with the ghost.
+	assert_int(BoardSpace.top_row_of(ghost.height)).override_failure_message(
+			"the brush is level with the ground; the case cannot tell the two apart") \
+		.is_not_equal(_scene._tops.get(cell, BoardSpace.FLAT_TOP_ROW) - 1)
+
+	assert_object(ghost.cell).override_failure_message(
+			"the ghost and the selector are on different cells -- two places at once") \
+		.is_equal(BoardSpace.flat(hovered[0]))
+	assert_int(hovered[0].y).override_failure_message(
+			"the selector sits at the board's height while the ghost hangs at the brush's") \
+		.is_equal(BoardSpace.top_row_of(ghost.height))
+
+
 func test_the_pointer_vertex_follows_the_cursor_across_one_cell() -> void:
 	# The corner tool's answer changes halfway ACROSS a cell, so it is computed ABOVE
 	# _update_pointer's cell early-out. Below it the marker sticks to whichever corner the cursor


### PR DESCRIPTION
Follow-up to #585, which is merged. Closes the half of [#582](https://github.com/Phaazoid/Godoiosis/issues/582) that its toggle left open.

#585 shipped the brush-height aim as an **opt-in toggle, default off**. Found in play:

> my mouse is kind of in two places at once … I don't know where I'm aiming, and I can't click/drag to paint low, because it jumps between which is the correct layer. we need to compress this, in the tile brush mode, it should only ever be selecting where my ghost tile is.

## Why the toggle was the wrong shape

With it off, the tool answers *"where is the mouse"* **twice**:

| | draws at |
|---|---|
| ghost (`BoardMirror.show_brush_ghost`) | `surface_y(top_row_of(ghost.height))` — the brush's height |
| selector (`BoardOverlays._marker_transform`) | `surface_y(cell.y)` — the picked column's own |

Two heights, two screen positions. **They can only coincide when the pick is on the plane** — the bracket reads its height straight off the picked cell — and only then is the ghost under the cursor at all, since the picked column is *where the ray crosses*. The geometry pick is what displaces it; the plane pick is what puts the preview where you are pointing.

The drag was the same fault in motion: a pick reading geometry the drag is **mutating** slips onto a neighbour the moment a cell sinks — #582's original bug, arriving one gesture at a time. A plane cannot do that.

## The change

`DevController.brush_pick_row()` drops the toggle clause and answers the brush's row whenever `_elevation_brush()` is live — already exactly **TERRAIN or CORNER**, the two modes that ask for a height (dev's call: both, one rule for the whole tool). ZONE and STATE keep geometry picking; they mark a cell you can see. The checkbox and `pick_at_brush_height` are deleted; the Height row's tooltip absorbs the one sentence worth keeping.

Nothing else moved. `_pick` already funnels to one `_pointer_cell`, and `_vertex_under` already reads `surface_y(cell.y)`, so corner mode's vertex comes off the same plane for free.

**Accepted cost**, the one the toggle was protecting: reaching a column whose top is elsewhere means scrolling the wheel to that height first. The selector shows which cell, so it is visible rather than surprising.

## Verification

`tests/presentation` + `tests/dev`, 0 orphans.

The regression shipped **green** — nothing pinned the two markers against each other. `test_the_brush_ghost_and_the_hover_selector_name_one_cell` (in the input-bridge wire suite, on the real `Battle3D.tscn`) does now. It asserts what each renderer is *handed* — the picked cell versus the ghost — rather than the world Y each computes, because re-deriving `surface_y` on both sides would pass against any mutant that broke the pick.

Falsified, one line at a time, each killed by the case named for it:

1. terrain back on geometry picking (the shipped default) → `test_the_brush_ghost_and_the_hover_selector_name_one_cell` reds with *"the selector sits at the board's height while the ghost hangs at the brush's"*
2. narrow the rule to TERRAIN only → `test_the_aim_follows_the_brush_height_in_both_modes_that_ask_for_one` reds with *"Corners did not aim at the brush's own Height"*

Canon swept: `docs/design/verticality.md` — the #585 ruling said "toggle, off by default"; it now says why it is not a preference. No embedded-content field added, so no `.tres` fixture sweep is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
