### PR TITLE
#597: no test fails for want of authored content

### DIFF
--- a/tests/dev/test_board_lint.gd
+++ b/tests/dev/test_board_lint.gd
@@ -176,8 +176,9 @@ func test_a_look_preset_that_no_longer_exists_degrades_the_board() -> void:
 
 	# Non-vacuous against a preset that DOES resolve — otherwise this case passes on any non-empty name.
 	var real: Array[String] = LookKnobs.saved_presets()
-	assert_array(real).override_failure_message(
-		"precondition: no look presets are shipped, so the twin below proves nothing").is_not_empty()
+	if real.is_empty():   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("no look presets are shipped, so the resolving twin cannot be shown")
+		return
 	game.scenario_manager.current_look_preset = real[0]
 	_assert_silent(BoardLint.Severity.DEGRADES, "no longer exists")
 

--- a/tests/dev/test_character_editor.gd
+++ b/tests/dev/test_character_editor.gd
@@ -44,7 +44,9 @@ func _tool() -> CharacterEditorTool:
 
 func test_update_refuses_an_unloaded_character() -> void:
 	var tool := _tool()
-	assert_int(tool.load_dropdown.item_count).is_greater(0)   # empty catalog would make this vacuous
+	if tool.load_dropdown.item_count == 0:   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("the character catalog is empty, so there is nothing to load and refuse")
+		return
 	tool.load_dropdown.select(0)
 
 	tool.update_button.pressed.emit()
@@ -56,7 +58,9 @@ func test_update_refuses_an_unloaded_character() -> void:
 func test_update_allows_the_loaded_character_at_reason_level() -> void:
 	# Reason level only -- an actual allowed press would re-save a tracked cast file.
 	var tool := _tool()
-	assert_int(tool.load_dropdown.item_count).is_greater(0)
+	if tool.load_dropdown.item_count == 0:   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("the character catalog is empty, so there is nothing to load")
+		return
 	tool.load_dropdown.select(0)
 	tool._on_load_pressed()
 
@@ -65,7 +69,9 @@ func test_update_allows_the_loaded_character_at_reason_level() -> void:
 
 func test_new_clears_the_loaded_identity() -> void:
 	var tool := _tool()
-	assert_int(tool.load_dropdown.item_count).is_greater(0)
+	if tool.load_dropdown.item_count == 0:   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("the character catalog is empty, so there is nothing to load")
+		return
 	tool.load_dropdown.select(0)
 	tool._on_load_pressed()
 	assert_str(tool._loaded_name).is_not_empty()
@@ -105,7 +111,9 @@ func test_slot_pick_stages_the_catalog_file_itself() -> void:
 	# catalog FILE resource, so a save writes an ExtResource reference, never an embedded copy.
 	var tool := _tool()
 	var catalog := tool._equippable_catalog()
-	assert_int(catalog.size()).is_greater(0)
+	if catalog.is_empty():   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("the equippable catalog is empty, so no slot pick can stage a file")
+		return
 	tool._on_new_pressed()
 
 	tool._on_slot_picked(0, 1)   # first catalog entry

--- a/tests/dev/test_dev_tool_overwrite_guards.gd
+++ b/tests/dev/test_dev_tool_overwrite_guards.gd
@@ -88,7 +88,9 @@ func test_a_cleared_board_has_no_loaded_scenario() -> void:
 
 func test_item_editor_refuses_an_unloaded_target() -> void:
 	var tool: ItemEditorTool = overlay.get_node("%Item Editor")
-	assert_int(tool.load_dropdown.item_count).is_greater(0)   # empty catalog would make this vacuous
+	if tool.load_dropdown.item_count == 0:   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("the item catalog is empty, so there is nothing to load and refuse")
+		return
 	tool.load_dropdown.select(0)
 
 	tool.update_button.pressed.emit()
@@ -218,7 +220,9 @@ func test_the_helper_confirm_wire_fires_the_callable() -> void:
 
 func test_character_update_asks_before_overwriting() -> void:
 	var tool: CharacterEditorTool = overlay.get_node("%Character")
-	assert_int(tool.load_dropdown.item_count).is_greater(0)   # empty cast would make this vacuous
+	if tool.load_dropdown.item_count == 0:   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("the cast is empty, so there is nothing to load and overwrite")
+		return
 	tool.load_dropdown.select(0)
 	tool._on_load_pressed()
 

--- a/tests/dev/test_look_presets.gd
+++ b/tests/dev/test_look_presets.gd
@@ -2,13 +2,15 @@
 # is pinned next door in test_moods_tool.gd; what these guard is that the twelve .tres files on disk
 # are structurally complete and still round-trip through the real apply path.
 #
-# EVERY case here is a "for each preset" loop, so an empty scan would make all of them vacuously
-# green -- the #264 blind shape, where the discriminating power lives in the fixture's data rather
-# than in the assertion. `_names()` asserts non-empty before returning, which is what closes it.
+# EVERY case here is a "for each preset" loop, so an empty scan makes all of them vacuously green
+# -- the #264 blind shape, where the discriminating power lives in the fixture's data rather than
+# in the assertion. `_names()` used to close that by ASSERTING non-empty; since 2026-08-27 it
+# warns instead, because deleting presets is authoring and an absence of authored content is not a
+# failure (tests/README.md rule 9). The vacuity is real, and now audible rather than fatal.
 #
 # Deliberately NOT asserted: how many presets there are, or that any particular one exists. The dev
 # was told to rename, retune and delete these freely; a case naming "Opus 3 Citrinitas" would turn
-# his own tidying red. Non-empty is the real invariant.
+# his own tidying red -- and so, it turned out, would demanding that any preset exist at all.
 extends GdUnitTestSuite
 
 const SCENE_PATH := "res://Scenes/Battle3D/Battle3D.tscn"
@@ -34,13 +36,12 @@ func after_test() -> void:
 
 # --- Helpers ---------------------------------------------------------------------------
 
-# The precondition every case below leans on. A scan that returned nothing would otherwise make
-# each loop pass by never running.
+# Every case below loops over this. An empty scan makes them all vacuous, which is said out loud
+# rather than failed -- an absence of authored content is not a defect (tests/README.md rule 9).
 func _names() -> Array[String]:
 	var names := LookKnobs.saved_presets()
-	assert_array(names).override_failure_message(
-		"no presets found under %s -- every case in this file would pass vacuously" % LookKnobs.PRESET_DIR
-	).is_not_empty()
+	if names.is_empty():   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("no presets found under %s -- every case in this file is vacuous" % LookKnobs.PRESET_DIR)
 	return names
 
 

--- a/tests/dev/test_mod_scaling_editor.gd
+++ b/tests/dev/test_mod_scaling_editor.gd
@@ -138,7 +138,9 @@ func test_a_mod_with_no_family_gets_no_scaling_sliders() -> void:
 
 	# ...and picking one opens it, against a family the catalog really has a main for.
 	var family := _a_family_with_a_blend()
-	assert_int(family).is_not_equal(WeaponData.WeaponType.NONE)   # no family base has a blend: proves nothing
+	if family == WeaponData.WeaponType.NONE:   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("no family base authors a main with a scaling blend, so there is nothing to measure against")
+		return
 	var with_family := _show(_mod(family))
 	assert_int(_sliders(with_family.editor_container, []).size()).is_equal(Stats.SCALING_STATS.size())
 
@@ -156,14 +158,18 @@ func _a_family_with_a_blend() -> WeaponData.WeaponType:
 # instead of calling _store_scaling_change directly.
 func test_dragging_a_slider_writes_the_shift_onto_the_mod() -> void:
 	var family := _a_family_with_a_blend()
-	assert_int(family).is_not_equal(WeaponData.WeaponType.NONE)   # no family base has a blend: proves nothing
+	if family == WeaponData.WeaponType.NONE:   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("no family base authors a main with a scaling blend, so there is nothing to measure against")
+		return
 	var mod := _mod(family)
 	var tool_ref := _show(mod)
 	var reference := tool_ref._reference_blend(family)
 
 	# A stat the family leans on NOT AT ALL, so the drag cannot be mistaken for a no-op.
 	var untouched := Stats.SCALING_STATS.filter(func(s): return not reference.has(s))
-	assert_array(untouched).is_not_empty()   # this family already uses all four: proves nothing
+	if untouched.is_empty():   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("this family leans on every scaling stat, so no drag can be told from a no-op")
+		return
 	var target: Stats.Stat = untouched[0]
 
 	var sliders := _sliders(tool_ref.editor_container, [])

--- a/tests/dev/test_prototype_editor.gd
+++ b/tests/dev/test_prototype_editor.gd
@@ -74,7 +74,9 @@ func test_an_established_template_still_builds_an_instance() -> void:
 	for key in WeaponCatalog.get_family_bases():
 		family_key = key
 		break
-	assert_str(family_key).is_not_empty()   # no family templates on disk: this case proves nothing
+	if family_key == "":   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("no family templates on disk, so there is nothing to rebase onto")
+		return
 	tool_ref._rebase_on_type(_type_index(family_key))
 	assert_bool(tool_ref.current_item is WeaponInstance).is_true()
 
@@ -91,7 +93,9 @@ func test_loading_a_prototype_hands_back_the_catalog_object_itself() -> void:
 	for key in prototypes:
 		name = key
 		break
-	assert_str(name).is_not_empty()   # nothing in Prototypes/: this case proves nothing
+	if name == "":   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("nothing in Prototypes/, so there is no catalog object to hand back")
+		return
 	var loaded := _tool()._editable_copy(prototypes[name])
 	assert_object(loaded).is_same(prototypes[name])
 
@@ -116,7 +120,9 @@ func test_picking_a_family_fills_in_that_familys_main_as_a_shared_ref() -> void:
 	var tool_ref := _tool()
 	var made := _new_prototype()
 	var family := _a_family_with_a_main()
-	assert_int(family).is_not_equal(WeaponData.WeaponType.NONE)   # no family base has a main: proves nothing
+	if family == WeaponData.WeaponType.NONE:   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("no family base authors a main attack, so none can fill in")
+		return
 
 	tool_ref._on_prototype_family_picked(made, WeaponData.WeaponType.keys()[family])
 	assert_object(made.main_attack).is_same(WeaponCatalog.family_main(family))

--- a/tests/dev/test_weapon_template_lint.gd
+++ b/tests/dev/test_weapon_template_lint.gd
@@ -6,7 +6,19 @@
 # content razor: nothing here asserts what a template CONTAINS -- not a space count, not a
 # capacity, not a family. They claim only that the shipped set passes its own rule, and that what
 # a file writes is what loads back.
+#
+# None of it may REQUIRE the dev to ship content of a given shape -- an absence of authored
+# content is not a failure (tests/README.md rule 9, dev 2026-08-27). The sweeps grade whatever
+# is on disk and pass vacuously on an empty one; the mechanism law owns a fixture instead.
 extends GdUnitTestSuite
+
+const FIXTURE_PATH := "user://__test_template_lint_variant.tres"
+
+
+func after_test() -> void:
+	if FileAccess.file_exists(FIXTURE_PATH):
+		DirAccess.remove_absolute(FIXTURE_PATH)
+
 
 
 func _template(family: WeaponData.WeaponType = WeaponData.WeaponType.CHAINSWORD) -> WeaponData:
@@ -102,7 +114,6 @@ func test_no_shipped_template_is_uncarryable() -> void:
 			if finding["severity"] == WeaponTemplateLint.Severity.BLOCKS:
 				broken.append("%s: %s" % [name, finding["text"]])
 	assert_array(broken).is_empty()
-	assert_int(templates.size()).is_greater(0)   # nothing scanned: this sweep proves nothing
 
 
 # ==============================================================================
@@ -114,7 +125,6 @@ func test_no_shipped_template_is_uncarryable() -> void:
 # line must load with mods actually in it. Reading the file's own text rather than pinning a mod
 # count is what keeps this blind to what the dev authors (the content razor).
 func test_a_saved_variants_fitted_mods_survive_the_load() -> void:
-	var checked := 0
 	var empty: Array[String] = []
 	var saved := WeaponCatalog.get_saved()
 	for name in saved:
@@ -122,14 +132,32 @@ func test_a_saved_variants_fitted_mods_survive_the_load() -> void:
 		var text := FileAccess.get_file_as_string(weapon.resource_path)
 		if not text.contains("\nspaces = "):
 			continue
-		checked += 1
 		var total := 0
 		for i in range(weapon.space_count()):
 			total += weapon.space(i).size()
 		if total == 0:
 			empty.append(name)
 	assert_array(empty).is_empty()
-	assert_int(checked).is_greater(0)   # no shipped variant carries a fitted mod: this guard proves nothing
+
+# The mechanism the sweep above cannot reach on its own. space_1/2/3 became one `spaces` array,
+# and a renamed .tres key is dropped SILENTLY on load -- the file keeps its text, the mods just
+# stop arriving. The sweep sees that only while some shipped variant happens to carry a fitted mod,
+# and DEMANDING one exist is what made deleting content a test failure (#597). So the law owns a
+# fixture instead: authored here, written by the real writer, read back cold with CACHE_MODE_IGNORE
+# and asserted not-same, or the round trip would just be reading the object it saved.
+func test_a_fitted_mod_survives_a_save_and_load() -> void:
+	var weapon := WeaponInstance.make(_template())
+	var mod := WeaponModData.new()
+	mod.display_name = "Fixture Mod"
+	assert_bool(weapon.fit(0, mod)).is_true()
+	assert_int(ResourceSaver.save(weapon, FIXTURE_PATH)).is_equal(OK)
+	# The writer must put the key in the file, or the load below proves nothing about it.
+	assert_str(FileAccess.get_file_as_string(FIXTURE_PATH)).contains("\nspaces = ")
+
+	var loaded := ResourceLoader.load(FIXTURE_PATH, "", ResourceLoader.CACHE_MODE_IGNORE) as WeaponInstance
+	assert_object(loaded).is_not_null()
+	assert_object(loaded).is_not_same(weapon)
+	assert_int(loaded.space(0).size()).is_equal(1)
 
 
 # The other half of the fireball rule. .tres omits properties at their default, so a template that
@@ -144,4 +172,3 @@ func test_every_prototype_writes_its_mod_spaces_rather_than_inheriting_the_defau
 		if not FileAccess.get_file_as_string(template.resource_path).contains("\nmod_spaces = "):
 			silent.append(name)
 	assert_array(silent).is_empty()
-	assert_int(prototypes.size()).is_greater(0)   # nothing in Prototypes/: this guard proves nothing

--- a/tests/flow/test_mission_look.gd
+++ b/tests/flow/test_mission_look.gd
@@ -142,6 +142,5 @@ func test_the_default_look_carries_no_dead_key() -> void:
 # in the load dropdown, Delete can never target it and Save As cannot shadow it -- all structural
 # rather than a filename check anyone could get wrong later.
 func test_the_default_is_not_a_listed_preset() -> void:
-	assert_array(LookKnobs.saved_presets()).is_not_empty()   # or the next line passes vacuously
 	assert_bool(LookKnobs.DEFAULT_PATH.begins_with(LookKnobs.PRESET_DIR)).override_failure_message(
 		"the default sits inside the scanned folder, so it can be listed, deleted or shadowed").is_false()

--- a/tests/items/test_armor_catalog.gd
+++ b/tests/items/test_armor_catalog.gd
@@ -32,7 +32,10 @@ var _cell_seq := 0
 
 
 func _armors() -> Dictionary:
-	return ArmorCatalog.get_editable()
+	var armors := ArmorCatalog.get_editable()
+	if armors.is_empty():   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("ArmorCatalog scanned nothing -- every roster and rule case in this file is vacuous")
+	return armors
 
 
 # A distinct cell per spawn: nothing here reads the board, but two units on one tile is a
@@ -64,12 +67,6 @@ func _body_with_con(con: int) -> Unit:
 
 # --- the scan ---
 
-func test_the_catalog_is_populated() -> void:
-	# Vacuity guard. Every loop below iterates the catalog, so an empty scan would turn this whole
-	# file green while pinning nothing -- exactly the failure a coverage suite must not have.
-	assert_dict(_armors()).override_failure_message(
-		"ArmorCatalog scanned nothing -- every roster and rule case in this file is now vacuous."
-		).is_not_empty()
 
 
 func test_every_entry_is_armor_data() -> void:


### PR DESCRIPTION
Closes #597. Tests only, +79/-32 across 9 files.

Applies the ruling from #596 -- *"a lack of authored content shouldn't cause tests to fail"* -- to the rest of the class, **case by case rather than as a blanket guard deletion**. Dropping a guard without replacing what it protected leaves a silently vacuous test, which is the exact failure the guards were written for.

## Three shapes, by what each case is for

**Cannot be DRIVEN without content -> `push_warning` + return** (11 sites): prototype editor x3, mod scaling editor x3, character editor x3, dev-tool overwrite guards x2, board lint x1. The absence stays audible without being called a fault.

**A SWEEP over shipped content -> guard dropped, passes vacuously** -- nothing authored violates nothing: weapon template lint x2, and `test_armor_catalog`'s dedicated `test_the_catalog_is_populated` case deleted with its warning folded into the `_armors()` helper. `test_look_presets`' `_names()` warns rather than asserts.

**A MECHANISM law -> a fixture it owns**: `test_a_fitted_mod_survives_a_save_and_load` replaces the guard that demanded some shipped variant carry a fitted mod. The fault it guards is the `space_1/2/3` -> `spaces` rename dropping a key silently on load, so it round-trips a `WeaponInstance` through the real writer and reads it back with `CACHE_MODE_IGNORE` plus `is_not_same` -- otherwise it would assert against the object it had just saved.

## Falsified, because the new failure mode is a case that SKIPS

A `warn + return` that fires when it shouldn't turns a test into a silent no-op, and a green run cannot tell you the difference. So: mutate `CharacterEditorTool`'s refusal string, run the suite.

```
test_update_refuses_an_unloaded_character  FAILED
```

The case still runs and still bites. That is one mutant against one of the eleven sites -- they share an identical shape, but only this one is measured. Reverted, `git status` clean after.

## Two things #597 had wrong

- **`test_character_editor.gd` holds three sites, not one.** Two carry no telltale `# ... vacuous` comment, so the issue's table -- built from that grep -- undercounted them.
- **`test_mission_look.gd:145` was already a bad guard.** It demanded presets exist so "the next line" would not pass vacuously; that line compares two constants (`DEFAULT_PATH.begins_with(PRESET_DIR)`) and cannot be vacuous either way. Dropped rather than converted.

One stale comment fell out of the work: `test_look_presets`' header claimed *"`_names()` asserts non-empty before returning, which is what closes it"* -- false the moment the helper changed. It now says the vacuity is real and audible rather than closed.

## Verified

Area runs only, per `CLAUDE.md`'s test-cadence rule.

| area | result |
|---|---|
| `dev` | 389 cases, 0 errors, 0 failures |
| `flow` | 235 cases, 0 errors, 0 failures |
| `items` | 69 cases, 0 errors, 0 failures |

389 in `dev` against 388 on main is the one case this adds.

## Not in scope

The picker-teeth fork (a fixture-owned family-locked mod so `test_mod_fitting`'s refusal direction bites regardless of shipped content) still needs the decision #597 lays out -- a temp `.tres` in the scanned directory versus a seam on `WeaponModCatalog`. Left open deliberately.
