### PR TITLE
#598: content born in the dev tools gets a uid

### DIFF
--- a/Classes/dev/DevWidgets.gd
+++ b/Classes/dev/DevWidgets.gd
@@ -703,6 +703,7 @@ static func save_over(resource: Resource, path: String, status_label: Label = nu
 	DirAccess.make_dir_recursive_absolute(path.get_base_dir())
 	var target := _live_target(resource, path)
 	var prior_uids := uid_map_in_file(path)   # a committed file's uids must survive an overwrite (#481)
+	_ensure_header_uid(path, prior_uids)   # ...and a file that never had one gets it minted (#598)
 	target.take_over_path(path)
 	var err := ResourceSaver.save(target, path)
 	if err != OK:
@@ -820,6 +821,35 @@ static func _set_uid(line: String, uid: String) -> String:
 # have stamped it on its next save, which is the churn that ticket exists to stop. Registry rather
 # than the target's own header: tests/law/test_resource_uid_references.gd asks ResourceUID, so this
 # is the same answer the law will grade the line against.
+
+
+# A resource BORN through the dev tools carries no uid, and never gains one. ResourceSaver.save()
+# writes none at runtime (#481), and restore_uids can only put back what the PRIOR file held -- so
+# the header uid has no source at all on a file that never had one, while the editor stamps one on
+# everything IT writes. Nine of ten authored weapon .tres were uid-less when this landed (#598).
+#
+# Why it matters: a `path=`-only ext_resource is a reference to a FILENAME. Move the target and
+# every holder dangles, which is #596's failure one layer down -- Godot can follow a uid across a
+# move and cannot follow a path.
+#
+# Registry BEFORE minting: if ResourceUID already claims this path, that id IS this file's uid and
+# a fresh one would be a second uid for one file. Only a path nothing claims gets a new id.
+#
+# Scoped to save_over deliberately, NOT to restore_uids: the other caller of that pair is the
+# lookdev meshlib generator, whose artifact already carries a uid stamped earlier (#540), so it has
+# nothing to mint and no reason to grow the behaviour.
+static func _ensure_header_uid(path: String, uids: Dictionary) -> void:
+	if uids.get("_header", "") != "":
+		return
+	var claimed := _registered_uid(path)
+	if claimed != "":
+		uids["_header"] = claimed
+		return
+	var id := ResourceUID.create_id()
+	ResourceUID.add_id(id, path)
+	uids["_header"] = ResourceUID.id_to_text(id)
+
+
 static func _registered_uid(target_path: String) -> String:
 	if target_path == "":
 		return ""

--- a/tests/dev/test_dev_tool_save_uid.gd
+++ b/tests/dev/test_dev_tool_save_uid.gd
@@ -80,3 +80,51 @@ func test_restore_uids_corrects_a_minted_uid() -> void:
 	var text := FileAccess.get_file_as_string(TEMP_PATH)
 	assert_str(text).contains('uid="%s"' % original)
 	assert_str(text).not_contains('uid="%s"' % minted)
+
+
+func _stage_without_uid() -> void:
+	_write('[gd_resource type="Resource" format=3]\n\n[resource]\n')
+
+
+# The gap #598 closes. restore_uids puts back only what the PRIOR file held, and the header has no
+# other source -- so a .tres born through a dev tool started uid-less and stayed that way forever,
+# while the editor stamps one on everything IT writes. Nine of ten authored weapon .tres were in
+# that state when this landed, which is what makes a rename break every holder (#596, one layer up).
+#
+# The uid is read back through uid_map_in_file rather than a second parser here: one answer to
+# "what uid does this file carry".
+func test_save_over_mints_a_uid_for_a_file_that_never_had_one() -> void:
+	_stage_without_uid()
+	assert_str(FileAccess.get_file_as_string(TEMP_PATH)).not_contains("uid=")   # precondition
+	var res := load(TEMP_PATH)
+	assert_object(res).is_not_null()
+
+	assert_bool(DevWidgets.save_over(res, TEMP_PATH, null)).is_true()
+
+	var minted: String = DevWidgets.uid_map_in_file(TEMP_PATH).get("_header", "")
+	assert_str(minted).is_not_empty()
+
+	# ...and REGISTERED, not merely written. A uid nothing claims is exactly what
+	# tests/law/test_resource_uid_references.gd exists to catch, so minting one would be a new way
+	# to redden that law rather than a fix.
+	_staged_id = ResourceUID.text_to_id(minted)   # so after_test releases it
+	assert_bool(ResourceUID.has_id(_staged_id)).is_true()
+	assert_str(ResourceUID.get_id_path(_staged_id)).is_equal(TEMP_PATH)
+
+
+# Minting must happen ONCE. A fresh id per save would rewrite the header on every Update and put the
+# file permanently in `git status` -- the dirty-tree rule's acceptance half, and the failure mode
+# #540 and #111 both were.
+func test_a_minted_uid_does_not_change_on_the_next_save() -> void:
+	_stage_without_uid()
+	var res := load(TEMP_PATH)
+	assert_bool(DevWidgets.save_over(res, TEMP_PATH, null)).is_true()
+	var first: String = DevWidgets.uid_map_in_file(TEMP_PATH).get("_header", "")
+	assert_str(first).is_not_empty()
+	_staged_id = ResourceUID.text_to_id(first)
+
+	var text_after_first := FileAccess.get_file_as_string(TEMP_PATH)
+	assert_bool(DevWidgets.save_over(res, TEMP_PATH, null)).is_true()
+
+	assert_str(DevWidgets.uid_map_in_file(TEMP_PATH).get("_header", "")).is_equal(first)
+	assert_str(FileAccess.get_file_as_string(TEMP_PATH)).is_equal(text_after_first)   # byte-stable


### PR DESCRIPTION
Closes #598, **rescoped** -- see [the correction on the issue](https://github.com/Phaazoid/Godoiosis/issues/598#issuecomment-5446963175). Its original claim was mine and was wrong: `356a2e7` was not a rename (`git show -M -C` pairs none of those files), so uids would not have prevented #596. A uid follows a file that MOVES and dies with one that is DELETED. The full 97-header + 469-reference backfill is dropped; this is the cheap half the dev asked for.

## The gap

`restore_uids` fills an `ext_resource` line from `ResourceUID` when the prior file lacked one (#540), but the **header** can only ever come from `prior`:

```gdscript
if line.begins_with("[gd_resource"):
    want = prior.get("_header", "")          # <- prior file only
elif line.begins_with("[ext_resource"):
    want = prior.get(_quoted_attr(line, "id"), "")
    if want == "":
        want = _registered_uid(...)          # <- registry fallback
```

`ResourceSaver.save()` writes no uid at runtime, so on a file that never had one the header has **no source at all**. Every `.tres` born through a dev tool started uid-less and stayed that way, while the editor stamps one on everything it writes -- nine of ten authored weapon `.tres` carried none.

This is the shape `CLAUDE.md` already warns about in another guise: an early-out computed on the INPUT side (`prior.is_empty()`), which goes stale the moment there is something to write that did not come from `prior`.

## The change

`save_over` fills the header uid before `restore_uids` writes. The existing writer still does all the writing -- no new text manipulation, which the dirty-tree rule forbids.

**Registry before minting.** If `ResourceUID` already claims the path, that id IS the file's uid; a fresh one would be a second uid for one file. Only a path nothing claims gets a new id.

**Scoped to `save_over`, not `restore_uids`.** The other caller of that pair is the lookdev meshlib generator, whose artifact already carries a uid stamped earlier (#540) -- nothing to mint, and no reason to grow the behaviour. The asymmetry is deliberate and commented.

**No backfill.** The 97 existing uid-less files gain one whenever they are next saved through a tool, which is a diff he is already looking at.

## Falsified

Comment out the mint, run the suite:

```
test_save_over_preserves_the_uids_it_overwrites          PASSED
test_restore_uids_corrects_a_minted_uid                  PASSED
test_save_over_mints_a_uid_for_a_file_that_never_had_one  FAILED
```

The two #481 cases still pass, so the mint is exactly what discriminates and the existing preservation behaviour is untouched. Reverted, `git status` clean after.

## The second case is the dirty-tree guard

`test_a_minted_uid_does_not_change_on_the_next_save` asserts the file is **byte-identical** across two saves. A fresh id per save would rewrite the header on every Update and put every edited file permanently in `git status` -- the acceptance half of the dirty-tree rule, and the failure #540 and #111 both were.

Checked rather than assumed: every test that calls `save_over` targets a `user://` path, and `ChainSword.tres` -- the one `res://` path a test names -- already carries a uid, so no committed file is rewritten by a test run. Worktree verified clean mid-run.

## Verified

`dev`: **390 cases, 0 errors, 0 failures** (388 base + the 2 added here). That area is the one that exercises the shared save route.
