### PR TITLE
#614: a carried rune names its carvings' power, pattern and reach

### DIFF
--- a/play/board_view.gd
+++ b/play/board_view.gd
@@ -171,7 +171,7 @@ static func _unit_line(session, unit: Unit) -> String:
 		squad_tag = "sq%d%s" % [session._squad_id(unit.squad), "(lead)" if unit.is_leader() else ""]
 	var wep := "(unarmed)"
 	if unit.has_equipped_weapon():
-		wep = _weapon_str(unit.get_equipped_weapon())
+		wep = _weapon_str(unit.get_equipped_weapon(), unit)
 	var state := "  [DOWNED]" if unit.is_downed() else ""
 	# Whose watch the "!" cells belong to, and what it fires (#413). Named on the unit line rather
 	# than in a second block: the footprint is on the board, this says who is behind it.
@@ -184,10 +184,10 @@ static func _unit_line(session, unit: Unit) -> String:
 		squad_tag, wep, state,
 	]
 
-static func _weapon_str(e: EquippableData) -> String:
+static func _weapon_str(e: EquippableData, wielder: Unit) -> String:
 	var rune := e as RuneData
 	if rune != null:
-		return "rune[%s x%d]" % [RuneData.Size.keys()[rune.size], rune.inscriptions.size()]
+		return _rune_str(rune, wielder)
 	var inst := e as WeaponInstance
 	if inst == null or inst.template == null:
 		return "(equip)"
@@ -207,6 +207,47 @@ static func _weapon_str(e: EquippableData) -> String:
 		s += "/ctr"
 	if main != null and main.hits_allies:
 		s += "/ff"   # friendly-fire: its blast hits allies in range too
+	return s
+
+# A rune gets the same treatment the weapon branch above gets, for the reason stated there (#614):
+# a line naming only the rune's SIZE hides power, reach and who can counter, which is most of what
+# a carving is. Lists the CATALOGUE (choice_attacks) rather than the channelable subset, and marks
+# what cannot fire with its own reason — the law RuneData.choice_attacks states for the menu.
+static func _rune_str(rune: RuneData, wielder: Unit) -> String:
+	var head := "rune[%s x%d]" % [RuneData.Size.keys()[rune.size], rune.inscriptions.size()]
+	if wielder == null:
+		return head
+	var parts: Array[String] = []
+	for attack in rune.choice_attacks(wielder):
+		parts.append(_carving_str(rune, wielder, attack))
+	if parts.is_empty():
+		return head
+	return head + "  " + "; ".join(parts)
+
+static func _carving_str(rune: RuneData, wielder: Unit, attack: AttackData) -> String:
+	var s := "%s pow%d %s" % [attack.display_name, attack.power, _pattern_str(attack.attack_pattern)]
+	# A carving's element is its SIGILS (repeats = weight, so dedupe). elemental_damage_type is
+	# WeaponAttackData-only — reading it on a TransmutationData is a runtime error, not a blank.
+	var carving := attack as TransmutationData
+	if carving != null:
+		var seen: Array[Elemental.Element] = []
+		for sigil in carving.sigils:
+			if sigil == Elemental.Element.NONE or seen.has(sigil):
+				continue
+			seen.append(sigil)
+			s += "/" + Elemental.Element.keys()[sigil]
+	# heals/deals_no_damage reinterpret the power printed above, so a line without them misreads.
+	if attack.heals:
+		s += "/heal"
+	if attack.deals_no_damage:
+		s += "/nodmg"
+	if attack.can_counter:
+		s += "/ctr"
+	if attack.hits_allies:
+		s += "/ff"
+	var reason := rune.attack_block_reason(wielder, attack)
+	if reason != "":
+		s += " (blocked: %s)" % reason
 	return s
 
 static func _pattern_str(p: AttackPattern) -> String:

--- a/tests/play/test_board_view_rune.gd
+++ b/tests/play/test_board_view_rune.gd
@@ -1,0 +1,160 @@
+# Guards the headless unit line for a carried RUNE (#614). BoardView's weapon branch has always
+# named power, pattern and counter — the rune branch named a size and a count, so a driver reading
+# the bridge could not see an alchemist's reach, damage or counter at all and had to go read the
+# .tres files. Asserts through render_overview rather than the private helper, so the wire that
+# hands the WIELDER down (_unit_line -> _weapon_str -> _rune_str) is covered as well as the format:
+# the rune's attack list is a property OF the pairing, so a rune rendered without its wielder can
+# only ever report a catalogue.
+extends GdUnitTestSuite
+
+const BoardBuilder := preload("res://play/board_builder.gd")
+const PlaySession := preload("res://play/play_session.gd")
+const BoardView := preload("res://play/board_view.gd")
+
+const PLAYER := Team.Faction.PLAYER
+const FIRE := Elemental.Element.FIRE
+const WATER := Elemental.Element.WATER
+
+var _board: Dictionary
+
+
+func before_test() -> void:
+	_board = BoardBuilder.build(self)
+	auto_free(_board.root)
+	BoardBuilder.paint_rect(_board.grid, Rect2i(-2, -2, 12, 12))
+
+
+# ---- fixtures ----
+
+func _spawn(unit_name: String, cell := Vector2i(0, 0)) -> Unit:
+	var data := UnitFactory.create_unit_data(Stats.STAT_DEFAULTS.duplicate(), unit_name, PLAYER)
+	return BoardBuilder.spawn(_board, data, cell)
+
+
+# Aura + affinity together, mirroring tests/runes/test_channel_reasons.gd's alchemist: a carving
+# channels off BOTH, so seeding one alone still reads as blocked.
+func _give_aura(unit: Unit, element: Elemental.Element, amount: int = 5) -> void:
+	var aura: Dictionary[Elemental.Element, int] = {}
+	aura[element] = amount
+	unit.unit_instance.aura = aura
+	var affinity: Array[Elemental.Element] = [element]
+	unit.unit_instance.affinity = affinity
+
+
+func _line_carving(display_name: String, power: int, length: int) -> TransmutationData:
+	var t := TransmutationData.new()
+	t.display_name = display_name
+	t.power = power
+	var p := ForwardLinePattern.new()
+	p.length = length
+	t.attack_pattern = p
+	t.sigils.assign([FIRE] as Array[Elemental.Element])
+	return t
+
+
+func _wide_carving(display_name: String, power: int, length: int, width: int) -> TransmutationData:
+	var t := TransmutationData.new()
+	t.display_name = display_name
+	t.power = power
+	var p := ForwardWidePattern.new()
+	p.length = length
+	p.width = width
+	t.attack_pattern = p
+	t.sigils.assign([FIRE] as Array[Elemental.Element])
+	return t
+
+
+func _rune_of(carvings: Array[TransmutationData]) -> RuneData:
+	var rune := RuneData.new()
+	rune.size = RuneData.Size.LARGE
+	for c in carvings:
+		assert_bool(rune.inscribe(c)) \
+			.override_failure_message("fixture carving '%s' failed to inscribe" % c.display_name) \
+			.is_true()
+	return rune
+
+
+func _overview() -> String:
+	var session = PlaySession.new(_board)
+	return BoardView.render_overview(session)
+
+
+# ==============================================================================
+#  The bug: a rune's reach and power were invisible
+# ==============================================================================
+
+func test_a_rune_line_names_every_carvings_power_and_pattern() -> void:
+	var alch := _spawn("Isaac")
+	_give_aura(alch, FIRE)
+	alch.add_item(_rune_of([
+		_line_carving("Emberline", 4, 3),
+		_wide_carving("Emberwash", 2, 2, 1),
+	]))
+
+	var text := _overview()
+
+	# The size/count head is kept — it is the one thing the old line got right.
+	assert_str(text).contains("rune[LARGE x2]")
+	# ...and each carving now carries what actually decides a move: damage and reach.
+	assert_str(text).contains("Emberline pow4 ForwardLine[L3]")
+	assert_str(text).contains("Emberwash pow2 ForwardWide[L2 W1]")
+
+
+func test_a_carvings_element_comes_from_its_sigils() -> void:
+	# elemental_damage_type is WeaponAttackData-only; a carving carries FIRE in `sigils`, and
+	# reading the weapon field here would be a runtime error rather than a blank.
+	var alch := _spawn("Isaac")
+	_give_aura(alch, FIRE)
+	alch.add_item(_rune_of([_line_carving("Emberline", 4, 3)]))
+
+	assert_str(_overview()).contains("ForwardLine[L3]/FIRE")
+
+
+# ==============================================================================
+#  The catalogue law: unfireable is LISTED and explained, never hidden
+# ==============================================================================
+
+func test_an_unchannelable_carving_is_still_listed_and_carries_its_reason() -> void:
+	# RuneData.choice_attacks is deliberately the catalogue rather than the affordable subset —
+	# dropping the row would tell a driver the carving does not exist, when what it needs to know
+	# is what would unlock it.
+	#
+	# The wielder must still be able to WIELD the rune: can_equip (#157) needs one channelable
+	# carving, so "an alchemist with no aura" renders (unarmed) and cannot exercise this at all.
+	# Aura FIRE 1 pays the cheap carving and leaves the expensive one 2 wildcards short of 1.
+	var alch := _spawn("Rebecca")
+	_give_aura(alch, FIRE, 1)
+	var payable := _line_carving("Emberline", 4, 3)                 # sigils [FIRE]
+	var unpayable := _line_carving("Emberstorm", 6, 3)
+	unpayable.sigils.assign([FIRE, FIRE, WATER] as Array[Elemental.Element])
+	var rune := _rune_of([payable, unpayable])                      # payable first: it sets temper
+
+	# Preconditions, or the case passes vacuously on a rune nobody could hold.
+	assert_bool(payable.can_channel(alch, rune.temper)) \
+		.override_failure_message("fixture: the cheap carving must channel or the rune won't equip") \
+		.is_true()
+	assert_bool(unpayable.can_channel(alch, rune.temper)) \
+		.override_failure_message("fixture: the expensive carving must NOT channel") \
+		.is_false()
+	alch.add_item(rune)
+
+	var text := _overview()
+
+	assert_str(text).contains("Emberline pow4 ForwardLine[L3]")
+	assert_str(text).contains("Emberstorm pow6 ForwardLine[L3]")
+	assert_str(text).contains("blocked:")
+
+
+# ==============================================================================
+#  The widened signature changes nothing for a weapon
+# ==============================================================================
+
+func test_a_weapon_line_is_unchanged_by_the_wielder_parameter() -> void:
+	var fighter := _spawn("Ross")
+	var template := WeaponData.new()
+	template.weapon_type = WeaponData.WeaponType.CHAINSWORD
+	template.main_attack = WeaponAttackData.new()
+	template.main_attack.power = 6
+	fighter.add_item(WeaponInstance.make(template))
+
+	assert_str(_overview()).contains("CHAINSWORD pow6 melee[1]/ctr")

--- a/tests/play/test_board_view_rune.gd.uid
+++ b/tests/play/test_board_view_rune.gd.uid
@@ -1,0 +1,1 @@
+uid://cicbuvni5eotd


### PR DESCRIPTION
Closes #614.

`BoardView`'s weapon branch has always named power, pattern and counter; the rune branch returned a size and a count. Playing `Level_1` through the bridge, that meant an alchemist's reach was invisible — the only way to find that Isaac's Freeze is a `ForwardLine` length 3 was to open the `.tres` files directly.

```
- A Isaac  P  hp20/20  solo  rune[MEDIUM x2]
+ A Isaac  P  hp20/20  solo  rune[MEDIUM x2]  Freeze pow4 ForwardLine[L3]/WATER/ctr/ff; Splash pow2 ForwardWide[L2 W3]/WATER/nodmg/ctr/ff
```

Six lines below the rune branch is the comment that already argues against it — *"Show the PATTERN, not just the weapon_type enum ... Hiding it once made a correct no-counter look like a bug."* The rune branch was the pre-fix version of that same bug.

**Follows the existing law rather than inventing a view policy.** Lists the catalogue (`RuneData.choice_attacks`) rather than the channelable subset, marking each unfireable carving with `attack_block_reason`'s own words — so the headless view and the action menu cannot disagree about what a rune offers or why a row is dead.

**`_weapon_str` takes the wielder** (one call site). Not incidental: aura and affinity gate what a rune can fire, so a rune rendered without its wielder can only ever report a catalogue, never the live picture.

**Two traps worth knowing:**

- A carving's element is its `sigils`. `elemental_damage_type` is `WeaponAttackData`-only, so reading it on a `TransmutationData` is a runtime error, not a blank.
- `heals` / `deals_no_damage` are named because both reinterpret the power printed beside them. Level_1's Splash is `pow2/nodmg` — without the marker it reads as a weak attack rather than pure utility.

## Verification

- `tests/play` — **44/44, 0 failures, 0 orphans**. Area folder only.
- **Falsified** — reverting `_rune_str` to the old head-only string reds the first case and aborts the suite.
- **Live board** — this is the step that earned its place. It caught two things reasoning had wrong: Freeze is `/ff` (its line hits allies, and I had parked a squadmate directly in its lane) and Splash is width 3, not 1.

The new suite asserts through `render_overview` rather than the private helper, so the wire that hands the wielder down is covered as well as the format. Its blocked-carving case carries explicit `can_channel` preconditions — a no-aura alchemist cannot equip the rune at all (`can_equip`, #157) and renders `(unarmed)`, which would have passed vacuously.

No gameplay seam is touched; the diff is confined to `play/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
