### PR TITLE
#617: one arm() for the play fixtures, so the bridge's own board is armed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ tools/report-worker/.wrangler/
 # Content fixtures a test AUTHORS into the scanned content tree and removes again (#604). Ignored
 # rather than merely cleaned up, so a run that dies before after_test still cannot dirty the tree.
 /Resources/**/__test_*.tres
+
+# agy (Antigravity CLI) session state — a local agent harness's own cache, not project output.
+# Ignored so that driving a playtest through that harness doesn't leave untracked noise in
+# `git status` (dev, 2026-08-27). The Play API's own runtime files are /playrun/ above.
+/.antigravitycli/

--- a/play/board_builder.gd
+++ b/play/board_builder.gd
@@ -105,6 +105,17 @@ static func spawn(board: Dictionary, data: UnitData, cell: Vector2i) -> Unit:
 	board.squad_manager.create_squad(unit)
 	return unit
 
+# Give a unit a plain working weapon. The ONE answer (#617): this lived as three byte-similar
+# copies (bridge, host, tests/play), and the two production ones never set weapon_type — so
+# WeaponInstance.make() refused the unmapped NONE family (#82), returned null, and the bridge's
+# own `new` board spawned everybody unarmed. Any mapped family works; the point is that it IS one.
+static func arm(unit: Unit, power: int) -> void:
+	var template := WeaponData.new()
+	template.weapon_type = WeaponData.WeaponType.CHAINSWORD
+	template.main_attack = WeaponAttackData.new()
+	template.main_attack.power = power   # scaling_blend defaults to pure STR — nothing else to set
+	unit.add_item(WeaponInstance.make(template))   # add_item auto-equips the first weapon
+
 # Load a saved scenario (.tres) onto an already-built board. COROUTINE — await it.
 static func load_scenario(board: Dictionary, path: String) -> Array[Unit]:
 	var scenario: ScenarioData = load(path)

--- a/play/play_bridge.gd
+++ b/play/play_bridge.gd
@@ -129,8 +129,8 @@ func _cmd_new() -> String:
 	var p := BoardBuilder.spawn(_board, _mk("Vanguard", Team.Faction.PLAYER), Vector2i(0, 0))
 	var e := BoardBuilder.spawn(_board, _mk("Raider", Team.Faction.ENEMY), Vector2i(5, 0))
 	await process_frame
-	_arm(p, 6)
-	_arm(e, 4)
+	BoardBuilder.arm(p, 6)
+	BoardBuilder.arm(e, 4)
 	_session = PlaySession.new(_board)
 	return "New board (2 units)\n\n" + BoardView.render_overview(_session)
 
@@ -182,8 +182,3 @@ func _ack(r: Dictionary) -> String:
 func _mk(name: String, faction: Team.Faction) -> UnitData:
 	return UnitFactory.create_unit_data(Stats.STAT_DEFAULTS.duplicate(), name, faction)
 
-func _arm(unit: Unit, power: int) -> void:
-	var template := WeaponData.new()
-	template.main_attack = WeaponAttackData.new()
-	template.main_attack.power = power   # scaling_blend defaults to pure STR — nothing else to set
-	unit.add_item(WeaponInstance.make(template))

--- a/play/play_host.gd
+++ b/play/play_host.gd
@@ -21,8 +21,8 @@ func _run() -> void:
 	# so unit_instance is built, movement is wired to the grid, and inventory is sized.
 	await process_frame
 
-	_arm(p1, 6)
-	_arm(e1, 4)
+	BoardBuilder.arm(p1, 6)
+	BoardBuilder.arm(e1, 4)
 
 	var session := PlaySession.new(board)
 
@@ -53,11 +53,6 @@ func _run() -> void:
 func _data(name: String, faction: Team.Faction) -> UnitData:
 	return UnitFactory.create_unit_data(Stats.STAT_DEFAULTS.duplicate(), name, faction)
 
-func _arm(unit: Unit, power: int) -> void:
-	var template := WeaponData.new()
-	template.main_attack = WeaponAttackData.new()
-	template.main_attack.power = power   # scaling_blend defaults to pure STR — nothing else to set
-	unit.add_item(WeaponInstance.make(template))   # add_item auto-equips the first weapon
 
 func _section(title: String) -> void:
 	print("\n========== %s ==========" % title)

--- a/tests/play/test_board_builder_arm.gd
+++ b/tests/play/test_board_builder_arm.gd
@@ -1,0 +1,55 @@
+# Guards BoardBuilder.arm — the ONE way a play fixture gives a unit a working weapon (#617).
+#
+# It used to be three byte-similar copies (play_bridge, play_host, tests/play), and the two
+# PRODUCTION ones never set weapon_type: WeaponInstance.make() refuses the unmapped NONE family
+# (#82), returns null, and the bridge's own `new` board therefore spawned both units unarmed.
+#
+# Note which way the drift ran. Law #4's usual warning is that a duplicate propagates INTO
+# fixtures; here the fixture was the only copy anyone repaired, so the suite stayed permanently
+# green about a helper that did not work anywhere it shipped. It could not have caught the bug:
+# it built its own units with its own correct copy and never touched either host.
+extends GdUnitTestSuite
+
+const BoardBuilder := preload("res://play/board_builder.gd")
+
+const PLAYER := Team.Faction.PLAYER
+
+var _board: Dictionary
+
+
+func before_test() -> void:
+	_board = BoardBuilder.build(self)
+	auto_free(_board.root)
+	BoardBuilder.paint_rect(_board.grid, Rect2i(-2, -2, 8, 8))
+
+
+func _spawn() -> Unit:
+	var data := UnitFactory.create_unit_data(Stats.STAT_DEFAULTS.duplicate(), "Fixture", PLAYER)
+	return BoardBuilder.spawn(_board, data, Vector2i(0, 0))
+
+
+func test_arm_leaves_the_unit_actually_holding_a_weapon() -> void:
+	var unit := _spawn()
+	# Non-vacuity: a bare fixture unit starts with nothing, so the assertion below is about arm()
+	# and not about whatever a UnitData happened to seed.
+	assert_bool(unit.has_equipped_weapon()) \
+		.override_failure_message("fixture: a fresh unit should start unarmed") \
+		.is_false()
+
+	BoardBuilder.arm(unit, 6)
+
+	assert_bool(unit.has_equipped_weapon()) \
+		.override_failure_message("arm() granted nothing — make() refused the family and returned null") \
+		.is_true()
+
+
+func test_the_armed_weapon_is_a_real_family_carrying_the_requested_power() -> void:
+	var unit := _spawn()
+	BoardBuilder.arm(unit, 6)
+
+	var weapon := unit.get_equipped_weapon() as WeaponInstance
+	assert_object(weapon).is_not_null()
+	# An unmapped weapon_type is what broke this, so pin that it resolved to a real family class
+	# rather than merely that something got equipped.
+	assert_int(weapon.template.weapon_type).is_not_equal(WeaponData.WeaponType.NONE)
+	assert_int(weapon.template.main_attack.power).is_equal(6)

--- a/tests/play/test_board_builder_arm.gd.uid
+++ b/tests/play/test_board_builder_arm.gd.uid
@@ -1,0 +1,1 @@
+uid://bvro5fsyeoxnp

--- a/tests/play/test_play_session.gd
+++ b/tests/play/test_play_session.gd
@@ -20,19 +20,13 @@ func before_test() -> void:
 	BoardBuilder.paint_rect(_board.grid, Rect2i(-2, -2, 12, 12))
 	var p := BoardBuilder.spawn(_board, _data("P1", PLAYER), Vector2i(0, 0))   # -> handle A
 	var e := BoardBuilder.spawn(_board, _data("E1", ENEMY), Vector2i(2, 0))    # -> handle a
-	_arm(p, 6)
-	_arm(e, 4)
+	BoardBuilder.arm(p, 6)
+	BoardBuilder.arm(e, 4)
 	_session = PlaySession.new(_board)
 
 func _data(name: String, fac: Team.Faction) -> UnitData:
 	return UnitFactory.create_unit_data(Stats.STAT_DEFAULTS.duplicate(), name, fac)
 
-func _arm(unit: Unit, power: int) -> void:
-	var template := WeaponData.new()
-	template.weapon_type = WeaponData.WeaponType.CHAINSWORD   # any mapped family works (#82); pass-through
-	template.main_attack = WeaponAttackData.new()
-	template.main_attack.power = power   # scaling_blend defaults to pure STR — nothing else to set
-	unit.add_item(WeaponInstance.make(template))
 
 # Law #2: the HP the preview promises is exactly what execution leaves behind.
 func test_preview_equals_execution() -> void:
@@ -140,7 +134,7 @@ func test_rescue_revives_adjacent_downed_ally() -> void:
 	BoardBuilder.paint_rect(b.grid, Rect2i(-2, -2, 8, 8))
 	var hero: Unit = BoardBuilder.spawn(b, _data("Hero", PLAYER), Vector2i(0, 0))
 	var ally: Unit = BoardBuilder.spawn(b, _data("Ally", PLAYER), Vector2i(1, 0))
-	_arm(hero, 3)
+	BoardBuilder.arm(hero, 3)
 	var sess = PlaySession.new(b)
 	ally.take_damage(ally.get_current_hp())   # damage == HP: overkill 0 <= ceiling -> DOWNED at 1 hp
 	assert_bool(ally.is_downed()).is_true()


### PR DESCRIPTION
Closes #617.

`{"cmd":"new"}` — the bridge's built-in board, and the first thing its ready banner tells a driver to send — spawned **both units unarmed**.

```
- A Vanguard  P  hp20/20  solo  (unarmed)
- a Raider    E  hp20/20  solo  (unarmed)
+ A Vanguard  P  hp20/20  solo  CHAINSWORD pow6 melee[1]/ctr
+ a Raider    E  hp20/20  solo  CHAINSWORD pow4 melee[1]/ctr
```

`_arm` never set `weapon_type`, so it defaulted to `NONE` and `WeaponInstance.make()` refused the unmapped family exactly as #82 intends, returning null.

**The loud failure worked and still didn't help.** `ERROR: no subclass mapped for weapon_type NONE` fired once per unit on every `new` — but a driver reads `playrun/state.txt`, not the host's stderr, so the one channel carrying the diagnosis was the one nobody watches. What reached the driver was the word `(unarmed)`, which reads as a deliberate fixture choice.

## The defect was a three-way duplicate

| | set `weapon_type`? |
|---|---|
| `play/play_bridge.gd` | no — broken |
| `play/play_host.gd` | no — broken |
| `tests/play/test_play_session.gd` | yes |

Both production copies were broken; the only correct one was the one that never ships. Law #4's usual warning is that a duplicate propagates *into* fixtures (#108's four test files) — here it ran the other way, leaving the suite permanently green about a helper that did not work anywhere real. Patching the two would have left three copies and the same drift, so this adds one `BoardBuilder.arm()` beside `build`/`spawn`/`paint_rect` and deletes the locals.

## Verification

- `tests/play` — **42/42, 0 failures, 0 orphans**.
- **Falsified** — dropping the `weapon_type` line reds the new case *and four others*, because the suite and the hosts finally share one helper. That coupling is the fix: before it, no test could have caught this.
- **Live bridge** — `new` now reports `CHAINSWORD pow6 / pow4`, and the host log carries no `make()` error.

Two notes for the reviewer:

- The second commit is unrelated housekeeping — ignoring `.antigravitycli/`, the `agy` harness's session cache, so driving a playtest through that harness doesn't leave permanent untracked noise in `git status`. Happy to split it out if you'd rather.
- `tests/play/test_guard.gd` and `test_knockback.gd` have their own `_arm`-shaped helpers. Both set `weapon_type` correctly and one also seeds HP, so they're left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
