### PR TITLE
#622: a shared board fixture, and the witness that makes it safe

### DIFF
--- a/tests/law/test_board_scoped_state.gd
+++ b/tests/law/test_board_scoped_state.gd
@@ -1,0 +1,138 @@
+# The invariant a shared test fixture rests on (#622): NO STATIC HOLDS BOARD-SCOPED STATE UNLESS
+# clear_board RESETS IT.
+#
+# Why this is a law and not a comment. `clear_board()` is the reset door, and it is correct -- but
+# it is HAND-MAINTAINED, and every line in it cites the leak it was added for: the Prolog accident
+# (stale last_loaded_path), a sandbox inheriting the last mission's look (#253), camera start
+# (#234), AI factions (#150), a tear-out left in the sky (#521), the playback lock (#484). Each of
+# those comments records someone not remembering. A new `static var` holding battle-scoped state is
+# covered only if the next person remembers too.
+#
+# So the classification is forced rather than trusted: a static in the board/presentation domain is
+# TUNING (process-scoped by design -- a `static var` rather than a `const` exactly so a knob can
+# write it), a CACHE (derived and idempotent), or BOARD-SCOPED (must die with the board). Anything
+# in none of the three fails here, naming itself, until its author says which it is.
+#
+# The tuning arm is DERIVED from GameKnobs.CLASS_KNOBS rather than listed: that table names 98
+# statics across the codebase, which covers 19 of the 28 in this domain for free and leaves only
+# the 9 below to declare by hand. tests/dev/test_game_knobs.gd already reads the same table the
+# same way to snapshot them. Law #4: one enumeration, and the two readers cannot drift.
+#
+# Scope is board/ + presentation/ deliberately: that is the domain a shared Battle3D fixture would
+# share. Widening it is a decision about which suites may share next, not a tidy-up.
+extends GdUnitTestSuite
+
+const DOMAIN := ["res://Classes/board", "res://Classes/presentation"]
+const SCENARIO_MANAGER := "res://Classes/flow/ScenarioManager.gd"
+
+# Board-scoped state that legitimately lives in a static, each naming the call that must clear it.
+# BoardSpace is static because the mirror and the camera rig both read the staging with no board
+# reference to hand -- see #622's note that moving it onto a board-owned node is the ideal fix and
+# is blocked on exactly that. Until then it is declared here and the second case keeps it honest.
+const BOARD_SCOPED := {
+	"_staged": "BoardSpace.clear_staging(",
+	"_stage_offset": "BoardSpace.clear_staging(",
+	"staging_version": "BoardSpace.clear_staging(",
+}
+
+# Process-scoped and therefore safe to survive a board reset, but NOT named by a knob table.
+# Two kinds, and the distinction is worth keeping visible:
+#   - derived caches, content-addressed and idempotent; re-deriving costs time, never correctness.
+#   - tuning values that no knob reaches. They are `static var` rather than `const` for a knob's
+#     sake and no knob arrived, so today nothing can move them -- the inverse of #264's born-dead
+#     slider. Harmless to sharing, which is why they sit here rather than failing, but they are
+#     real gaps against the 2026-08-12 rule that an aesthetic value gets a knob. Filed separately.
+const PROCESS_SCOPED := [
+	"_cube_mesh", "_cage_texture", "_cube_key",   # UnitHealthBar: cage geometry, keyed by _cube_key
+	"_art_top_cache",                             # UnitSprite3D: per-texture art top, keyed by path
+	"GUARD_RING_SCALE",                           # tuning, no knob
+	"texels_per_unit",                            # tuning, no knob
+]
+
+
+func _statics() -> Dictionary:
+	var found := {}   # name -> "File.gd"
+	var rx := RegEx.create_from_string("(?m)^static var (\\w+)")
+	for dir: String in DOMAIN:
+		for file: String in ResourceDir.files_with_extension(dir, "gd"):
+			var path := "%s/%s" % [dir, file]
+			var f := FileAccess.open(path, FileAccess.READ)
+			assert_object(f).override_failure_message("could not read %s" % path).is_not_null()
+			var text := f.get_as_text()
+			f.close()
+			for m: RegExMatch in rx.search_all(text):
+				found[m.get_string(1)] = file
+	return found
+
+
+func _knobbed() -> Dictionary:
+	var names := {}
+	for knob: Dictionary in GameKnobs.CLASS_KNOBS:
+		if knob.has("static"):
+			names[str(knob["static"])] = true
+	return names
+
+
+# ==============================================================================
+#  The law
+# ==============================================================================
+
+func test_every_static_in_the_board_domain_declares_what_kind_it_is() -> void:
+	var knobbed := _knobbed()
+	var unclassified: Array[String] = []
+	for name: String in _statics():
+		if knobbed.has(name) or PROCESS_SCOPED.has(name) or BOARD_SCOPED.has(name):
+			continue
+		unclassified.append("%s (%s)" % [name, _statics()[name]])
+	assert_array(unclassified).override_failure_message(
+		("These statics are classified by nothing: %s\n"
+		+ "A static in this domain must be one of three things, and which one decides whether a "
+		+ "board reset has to reach it:\n"
+		+ "  TUNING       -> give it a GameKnobs.CLASS_KNOBS row (it is then covered here for free)\n"
+		+ "  CACHE        -> derived and idempotent; add it to PROCESS_SCOPED with what keys it\n"
+		+ "  BOARD-SCOPED -> add it to BOARD_SCOPED naming the call that clears it, and make "
+		+ "clear_board() make that call") % ", ".join(unclassified)).is_empty()
+
+
+func test_every_board_scoped_static_is_actually_reset_by_clear_board() -> void:
+	# Declaring something board-scoped and then not clearing it is the failure this half exists for:
+	# the declaration above would otherwise be a comment that reads as a guarantee.
+	var f := FileAccess.open(SCENARIO_MANAGER, FileAccess.READ)
+	assert_object(f).is_not_null()
+	var src := f.get_as_text()
+	f.close()
+	var start := src.find("func clear_board")
+	assert_int(start).override_failure_message("clear_board() is gone or renamed").is_greater(-1)
+	var end := src.find("\nfunc ", start + 10)
+	var body := src.substr(start, (end - start) if end > start else -1)
+
+	var missing: Array[String] = []
+	for name: String in BOARD_SCOPED:
+		if not body.contains(BOARD_SCOPED[name]):
+			missing.append("%s (expected clear_board to call %s)" % [name, BOARD_SCOPED[name]])
+	assert_array(missing).override_failure_message(
+		"Board-scoped statics nothing resets: %s" % ", ".join(missing)).is_empty()
+
+
+func test_the_scan_actually_found_something() -> void:
+	# Non-vacuity, and not decoration: point DOMAIN at an empty folder, or let the regex stop
+	# matching, and BOTH cases above pass over zero statics. tests/dev/test_look_presets.gd carries
+	# the same guard for the same reason.
+	var statics := _statics()
+	# 28 in the domain today. The floor is deliberately well under that -- it is a rot detector,
+	# not a census, and a census would fail every time someone adds or removes one.
+	assert_int(statics.size()).override_failure_message(
+		"the static scan matched nothing -- DOMAIN or the regex has rotted").is_greater(20)
+	assert_int(_knobbed().size()).override_failure_message(
+		"CLASS_KNOBS named no statics -- the tuning arm has rotted, and every knobbed static "
+		+ "would now read as unclassified").is_greater(50)
+	# The declared lists must describe things that EXIST; a stale name is a rule guarding nothing.
+	var stale: Array[String] = []
+	for name: String in BOARD_SCOPED:
+		if not statics.has(name):
+			stale.append(name)
+	for name: String in PROCESS_SCOPED:
+		if not statics.has(name):
+			stale.append(name)
+	assert_array(stale).override_failure_message(
+		"declared here but no longer a static in the domain: %s" % ", ".join(stale)).is_empty()

--- a/tests/law/test_board_scoped_state.gd.uid
+++ b/tests/law/test_board_scoped_state.gd.uid
@@ -1,0 +1,1 @@
+uid://dqmfclvksu2uq

--- a/tests/presentation/test_board_fingerprint.gd
+++ b/tests/presentation/test_board_fingerprint.gd
@@ -1,0 +1,145 @@
+# Proves BoardFingerprint can actually SEE a leak (#622, leaf B), and — the case that matters most —
+# that apply_scenario() genuinely returns a mutated board to its captured state.
+#
+# That last claim is the whole premise of sharing one Battle3D across a suite instead of rebuilding
+# it per case (~58% of CI, #619). If the reset door does not restore, sharing is unsafe and the
+# right answer is to keep paying for a fresh scene. So this suite is the thing that decides it, and
+# a red here is a finding rather than a chore.
+#
+# It lives in tests/presentation because it needs the real host, which is precisely the folder the
+# work is meant to speed up. That is the correct place for it even so: the witness has to observe
+# the same scene the shared fixture would share.
+extends GdUnitTestSuite
+
+const SCENE_PATH := "res://Scenes/Battle3D/Battle3D.tscn"
+const PROLOG := "res://Scenarios/missions/Prolog.tres"
+
+var _scene: Node3D
+var _game: Node2D
+
+
+func before_test() -> void:
+	get_tree().root.size = Vector2i(1280, 720)
+	PlayerSettings.reset_for_test()
+	_scene = (load(SCENE_PATH) as PackedScene).instantiate() as Node3D
+	_scene.auto_play = false
+	get_tree().root.add_child(_scene)
+	await await_idle_frame()
+	_game = _scene.game
+	_scene.load_mission(PROLOG)
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	await DialogFixtures.end_all_dialog(self)
+	BoardSpace.clear_staging()
+	get_tree().root.remove_child(_scene)
+	_scene.free()
+
+
+func _take() -> Dictionary:
+	return BoardFingerprint.take(_scene, _game.scenario_manager)
+
+
+# ==============================================================================
+#  No false positives — the property everything else rests on
+# ==============================================================================
+
+func test_two_readings_of_an_untouched_board_are_identical() -> void:
+	# If this is ever flaky the whole approach is dead, because every case would report a leak it
+	# did not cause. It is first for that reason.
+	var before := _take()
+	await await_idle_frame()
+	var after := _take()
+
+	var diff := BoardFingerprint.differences(before, after)
+	assert_array(diff).override_failure_message(
+		"an untouched board reported movement: %s" % ", ".join(diff)).is_empty()
+
+
+# ==============================================================================
+#  It sees each kind of leak the taxonomy names (#622)
+# ==============================================================================
+
+func test_it_sees_a_board_mutation() -> void:
+	var before := _take()
+	var units: Array[Unit] = []
+	for child in _game.units_root.get_children():
+		if child is Unit:
+			units.append(child as Unit)
+	assert_int(units.size()).override_failure_message("Prolog spawned no units").is_greater(0)
+	units[0].set_current_hp(units[0].get_current_hp() - 1)
+
+	var diff := BoardFingerprint.differences(before, _take())
+	assert_array(diff).override_failure_message("a damaged unit went unnoticed").is_not_empty()
+
+
+func test_it_sees_a_tuning_static_left_moved() -> void:
+	var was := OverlayManager.SQUAD_RING_ALPHA
+	var before := _take()
+	OverlayManager.SQUAD_RING_ALPHA = was * 0.5 + 0.1
+	var diff := BoardFingerprint.differences(before, _take())
+	OverlayManager.SQUAD_RING_ALPHA = was
+
+	assert_str(", ".join(diff)).override_failure_message(
+		"a moved class knob went unnoticed").contains("SQUAD_RING_ALPHA")
+
+
+func test_it_sees_staging_left_lifted() -> void:
+	# The one piece of board-scoped state that lives in a static (#622); clear_board clears it, and
+	# this is what would catch the day it stops.
+	var before := _take()
+	var cells: Array[Vector2i] = [Vector2i(0, 0), Vector2i(1, 0)]
+	BoardSpace.stage(cells, Vector3(0, 40, 0))
+
+	var diff := BoardFingerprint.differences(before, _take())
+	BoardSpace.clear_staging()
+
+	assert_str(", ".join(diff)).override_failure_message(
+		"a lifted tear-out went unnoticed").contains("staging")
+
+
+# ==============================================================================
+#  The claim leaf A rests on: the reset door really does restore
+# ==============================================================================
+
+func test_the_reset_recipe_returns_a_mutated_board_to_its_baseline() -> void:
+	# The RECIPE, not apply_scenario alone -- this is what a shared fixture would run per case, and
+	# the two extra steps are both there for a measured reason.
+	#
+	# WARM-UP. WeaponInstance.spaces is lazily grown (`while spaces.size() <= index`) rather than
+	# sized from the template, so a freshly made instance holds [] and a loaded one holds [[],[],[]].
+	# Both mean "no mods fitted", but it makes capture -> apply -> capture not a fixed point on the
+	# FIRST cycle only. Applying once before taking the baseline lands on the fixed point; the
+	# underlying churn (an @export whose written form depends on whether anything touched it) is a
+	# save-path issue in its own right and is filed separately, not papered over here.
+	#
+	# DIALOG. load_mission arms the #182 lesson; apply_scenario is the BOARD door and does not
+	# re-arm it, so case 1 would run with a timeline live and every later case without. Ending it is
+	# part of the reset rather than something the fingerprint should be taught to ignore.
+	var pristine: ScenarioData = _game.scenario_manager.capture_scenario("__pristine")
+	await _reset_to(pristine)
+	var baseline := _take()
+
+	var units: Array[Unit] = []
+	for child in _game.units_root.get_children():
+		if child is Unit:
+			units.append(child as Unit)
+	assert_int(units.size()).override_failure_message("Prolog spawned no units").is_greater(1)
+	units[0].set_current_hp(maxi(1, units[0].get_current_hp() - 3))
+	units[1].movement.set_cell(units[1].movement.cell + Vector2i(1, 0))
+	assert_array(BoardFingerprint.differences(baseline, _take())).override_failure_message(
+		"the fixture failed to dirty the board, so the restore below proves nothing").is_not_empty()
+
+	await _reset_to(pristine)
+
+	var diff := BoardFingerprint.differences(baseline, _take())
+	assert_array(diff).override_failure_message(
+		("the reset recipe did NOT restore the baseline. Each line is something a shared fixture "
+		+ "would leak between cases:\n  %s") % "\n  ".join(diff)).is_empty()
+
+
+func _reset_to(pristine: ScenarioData) -> void:
+	_game.scenario_manager.apply_scenario(pristine)
+	await DialogFixtures.end_all_dialog(self)
+	await await_idle_frame()

--- a/tests/presentation/test_board_fingerprint.gd.uid
+++ b/tests/presentation/test_board_fingerprint.gd.uid
@@ -1,0 +1,1 @@
+uid://coiojvoojy5ms

--- a/tests/presentation/test_shared_board.gd
+++ b/tests/presentation/test_shared_board.gd
@@ -1,0 +1,91 @@
+# Exercises SharedBoard through its own four hooks (#622, leaves A and D), because machinery with no
+# consumer is the born-dead wire this project keeps paying for (#103, #264): it would compile, ship,
+# and be wrong in a way nothing could report.
+#
+# It is deliberately its own suite rather than a conversion of an existing one. What is under test
+# here is the FIXTURE -- that the scene is genuinely shared, that a case which dirties the board
+# hands the next one a clean board, and that check() is reached at all. Converting a real suite is
+# the next leaf and a separate question: it asks whether THAT suite's cases stay green, which is a
+# different claim and a different blast radius.
+extends GdUnitTestSuite
+
+const SCENE_PATH := "res://Scenes/Battle3D/Battle3D.tscn"
+const PROLOG := "res://Scenarios/missions/Prolog.tres"
+
+var _board := SharedBoard.new(SCENE_PATH, PROLOG)
+var _opened_id := 0
+
+
+func before() -> void:
+	await _board.open(self)
+	_opened_id = _board.scene.get_instance_id() if _board.scene != null else 0
+
+
+func before_test() -> void:
+	await _board.reset(self)
+
+
+func after_test() -> void:
+	await _board.check(self)
+
+
+func after() -> void:
+	_board.close()
+
+
+func _units() -> Array[Unit]:
+	var units: Array[Unit] = []
+	for child in _board.game.units_root.get_children():
+		if child is Unit:
+			units.append(child as Unit)
+	return units
+
+
+# ==============================================================================
+#  The sharing itself
+# ==============================================================================
+
+func test_the_board_is_loaded_and_usable() -> void:
+	assert_object(_board.scene).is_not_null()
+	assert_object(_board.game).is_not_null()
+	assert_int(_units().size()).override_failure_message(
+		"the shared board came up with no units, so every case below proves nothing").is_greater(0)
+
+
+func test_every_case_gets_the_same_scene_instance_rather_than_a_rebuild() -> void:
+	# THE claim: one Battle3D for the whole suite. Compared against the id recorded in before(),
+	# not against another case, so this does not depend on execution order.
+	#
+	# In fresh mode the id legitimately differs -- that is the mode doing its job -- so the
+	# assertion states which branch it is in rather than being skipped silently (#449's lesson
+	# that a settings-driven surface must say which branch it asserts on).
+	if SharedBoard.fresh_mode():
+		assert_int(_board.scene.get_instance_id()).override_failure_message(
+			"fresh mode should rebuild, so this case should NOT match before()'s scene"
+			).is_not_equal(_opened_id)
+		return
+	assert_int(_board.scene.get_instance_id()).override_failure_message(
+		"the scene was rebuilt between before() and this case -- nothing is being shared"
+		).is_equal(_opened_id)
+
+
+# ==============================================================================
+#  A dirty case does not contaminate the next one
+# ==============================================================================
+
+func test_a_case_may_dirty_the_board_freely() -> void:
+	# after_test resets before it diffs, so ordinary mutation is not a leak -- it is the case doing
+	# its job. If this reddens, the reset door cannot undo a plain HP change and sharing is off.
+	var units := _units()
+	assert_int(units.size()).is_greater(0)
+	units[0].set_current_hp(maxi(1, units[0].get_current_hp() - 5))
+
+
+func test_and_the_next_case_still_sees_full_health() -> void:
+	# The payoff of the case above, and the only one here that is deliberately order-dependent:
+	# gdUnit4 runs cases in declaration order, and what it asserts is precisely that the previous
+	# case's damage did not survive.
+	for unit: Unit in _units():
+		assert_int(unit.get_current_hp()).override_failure_message(
+			"%s arrived damaged -- the previous case leaked through the reset" % unit.get_unit_name()
+			).is_equal(unit.get_max_hp())

--- a/tests/presentation/test_shared_board.gd.uid
+++ b/tests/presentation/test_shared_board.gd.uid
@@ -1,0 +1,1 @@
+uid://o3er2okbxfue

--- a/tests/support/board_fingerprint.gd
+++ b/tests/support/board_fingerprint.gd
@@ -1,0 +1,192 @@
+# A TOTAL snapshot of everything a test could dirty, so a shared-scene fixture can prove it did not
+# (#622, leaf B). Two calls: take() before a case and take() after, then differences() names what
+# moved. Nothing here resets anything -- that is clear_board's job, and keeping the two apart is the
+# point: this is the independent witness, not the mechanism under test.
+#
+# WHY A DIFF AND NOT "RUN THE NEXT TEST AND SEE". A leak observed by a later case is a flake -- it
+# depends on what that case happens to look at. A diff against the pristine state is DETERMINISTIC:
+# it fails at the case that leaked, every run, naming the field. That is the whole argument for
+# sharing a scene at all; without it, sharing trades a slow suite for an unreliable one.
+#
+# THREE THINGS IT COVERS, matching the three places state lives (#622's taxonomy):
+#   1. the BOARD, via ScenarioManager.capture_scenario -- the same #87 door apply_scenario reverses.
+#   2. TUNING, via the knob tables, which already enumerate every process-scoped value a panel or a
+#      test can move. Derived, never listed: Law #4, so this and the panels cannot disagree.
+#   3. the RESIDUE that belongs to neither -- staging, Dialogic, and the settings stores.
+#
+# The board half compares by REFLECTION rather than by serializing. Serializing looks obvious and is
+# wrong: ResourceSaver mints `[sub_resource id="..."]` ids per save, so two saves of identical data
+# differ and every case would report a leak. Reflection over PROPERTY_USAGE_STORAGE is derived from
+# the @export declarations, so it needs no field list here and picks up new fields automatically --
+# which is the same reason #258's embedded-content trap exists and the same defence against it.
+class_name BoardFingerprint
+
+# Floats and colours are compared with LookKnobs.same_value, which is APPROXIMATE on purpose: engine
+# properties store single precision and a euler component round-trips through a basis, so an exact
+# compare reports movement that never happened (the lesson #212 records for the Moods tab's own
+# "has this moved?").
+const MAX_DEPTH := 6
+
+
+static func take(host: Node3D, scenario_manager) -> Dictionary:
+	return {
+		"board": _board_state(scenario_manager),
+		"class_knobs": GameKnobs.capture_class_baseline(host),
+		"node_knobs": _node_knobs(host),
+		"staged_cells": _sorted_cells(BoardSpace.staged_cells()),
+		"dialog_running": Dialogic.current_timeline != null,
+		# The camera is re-framed by apply_scenario (board_loaded -> fit_camera), so this is not
+		# expected to move -- which is exactly why it is sampled. "The reset probably covers it"
+		# is an argument; a diff is a guarantee, and camera suites are the ones most likely to
+		# leave it somewhere.
+		"camera": _resource_state(_camera_pose(host), 0),
+		# A case that exits leaving ATTACK_TARGETING or a selection live hands the next case a
+		# board mid-gesture. game_state is the one flag that says so.
+		"game_state": _game_state(host),
+	}
+
+
+static func _camera_pose(host: Node3D) -> Resource:
+	if host == null or not host.has_method("capture_camera_start"):
+		return null
+	return host.capture_camera_start()
+
+
+static func _game_state(host: Node3D) -> Variant:
+	if host == null:
+		return null
+	var game: Variant = host.get("game")
+	return null if game == null else game.get("game_state")
+
+
+static func differences(before: Dictionary, after: Dictionary) -> PackedStringArray:
+	var out := PackedStringArray()
+	_diff_value("board", before.get("board"), after.get("board"), out, 0)
+	_diff_indexed("class knob", GameKnobs.CLASS_KNOBS, before.get("class_knobs", []),
+			after.get("class_knobs", []), out)
+	_diff_indexed("look knob", _node_knob_table(), before.get("node_knobs", []),
+			after.get("node_knobs", []), out)
+	if str(before.get("staged_cells")) != str(after.get("staged_cells")):
+		out.append("BoardSpace staging: %s -> %s" % [before.get("staged_cells"), after.get("staged_cells")])
+	if before.get("dialog_running") != after.get("dialog_running"):
+		out.append("Dialogic timeline running: %s -> %s"
+				% [before.get("dialog_running"), after.get("dialog_running")])
+	_diff_value("camera", before.get("camera"), after.get("camera"), out, 0)
+	if before.get("game_state") != after.get("game_state"):
+		out.append("game_state: %s -> %s" % [before.get("game_state"), after.get("game_state")])
+	return out
+
+
+# --- the board half ------------------------------------------------------------------------------
+
+# capture_scenario is the #87 door and it is total by construction: apply_scenario is its inverse,
+# so anything apply_scenario would restore is something this sees. Its own deliberate omissions
+# (the queued plan, the aiming cursor, projected knockback) are re-derived rather than stored, which
+# is exactly why they are not leak candidates.
+static func _board_state(scenario_manager) -> Dictionary:
+	var scenario: ScenarioData = scenario_manager.capture_scenario("__fingerprint")
+	return _resource_state(scenario, 0)
+
+
+static func _resource_state(res: Resource, depth: int) -> Variant:
+	if res == null:
+		return null
+	if depth >= MAX_DEPTH:
+		return "<depth>"
+	var state := {}
+	for prop: Dictionary in res.get_property_list():
+		if not (int(prop.get("usage", 0)) & PROPERTY_USAGE_STORAGE):
+			continue
+		var name: String = prop.get("name", "")
+		if name == "" or name == "resource_local_to_scene" or name == "resource_path" \
+				or name == "resource_name" or name == "script":
+			continue
+		state[name] = _plain(res.get(name), depth + 1)
+	return state
+
+
+static func _plain(value: Variant, depth: int) -> Variant:
+	if value is Resource:
+		return _resource_state(value as Resource, depth)
+	if value is Array:
+		var items := []
+		for item: Variant in value:
+			items.append(_plain(item, depth))
+		return items
+	if value is Dictionary:
+		# Sorted, because a Dictionary's iteration order is insertion order and a rebuilt board can
+		# legitimately fill the same keys in a different sequence.
+		var keys := (value as Dictionary).keys()
+		keys.sort_custom(func(a, b): return str(a) < str(b))
+		var out := {}
+		for key: Variant in keys:
+			out[str(key)] = _plain(value[key], depth)
+		return out
+	return value
+
+
+# --- the tuning half -----------------------------------------------------------------------------
+
+static func _node_knob_table() -> Array[Dictionary]:
+	var table: Array[Dictionary] = []
+	table.append_array(LookKnobs.KNOBS)
+	table.append_array(GameKnobs.KNOBS)
+	return table
+
+
+static func _node_knobs(host: Node3D) -> Array:
+	var values := []
+	for knob: Dictionary in _node_knob_table():
+		values.append(LookKnobs.read(host, knob))
+	return values
+
+
+# --- diffing -------------------------------------------------------------------------------------
+
+static func _diff_indexed(label: String, table: Array, before: Array, after: Array,
+		out: PackedStringArray) -> void:
+	for i in mini(before.size(), after.size()):
+		if LookKnobs.same_value(before[i], after[i]):
+			continue
+		var knob: Dictionary = table[i] if i < table.size() else {}
+		var name: String = str(knob.get("static", knob.get("prop", "#%d" % i)))
+		out.append("%s %s: %s -> %s" % [label, name, before[i], after[i]])
+
+
+static func _diff_value(path: String, before: Variant, after: Variant, out: PackedStringArray,
+		depth: int) -> void:
+	if depth >= MAX_DEPTH:
+		return
+	if before is Dictionary and after is Dictionary:
+		var keys := {}
+		for k: Variant in (before as Dictionary).keys():
+			keys[k] = true
+		for k: Variant in (after as Dictionary).keys():
+			keys[k] = true
+		for key: Variant in keys:
+			_diff_value("%s.%s" % [path, key], (before as Dictionary).get(key),
+					(after as Dictionary).get(key), out, depth + 1)
+		return
+	if before is Array and after is Array:
+		if (before as Array).size() != (after as Array).size():
+			out.append("%s: %d entries -> %d" % [path, (before as Array).size(), (after as Array).size()])
+			return
+		for i in (before as Array).size():
+			_diff_value("%s[%d]" % [path, i], before[i], after[i], out, depth + 1)
+		return
+	if LookKnobs.same_value(before, after):
+		return
+	out.append("%s: %s -> %s" % [path, _short(before), _short(after)])
+
+
+static func _short(value: Variant) -> String:
+	var text := str(value)
+	return text if text.length() <= 80 else text.substr(0, 77) + "..."
+
+
+static func _sorted_cells(cells: Array[Vector2i]) -> Array:
+	var out := []
+	for cell: Vector2i in cells:
+		out.append(str(cell))
+	out.sort()
+	return out

--- a/tests/support/board_fingerprint.gd.uid
+++ b/tests/support/board_fingerprint.gd.uid
@@ -1,0 +1,1 @@
+uid://dcqksdgq237b7

--- a/tests/support/shared_board.gd
+++ b/tests/support/shared_board.gd
@@ -1,0 +1,140 @@
+# One Battle3D per SUITE instead of one per case (#622, leaves A and D), with the leak check that
+# makes that safe wired in rather than optional.
+#
+# The four calls mirror gdUnit4's four hooks, and a converted suite is four one-liners:
+#
+#   var _board := SharedBoard.new(SCENE_PATH, PROLOG)
+#   func before():      await _board.open(self)
+#   func before_test(): await _board.reset(self)
+#   func after_test():  await _board.check(self)   # resets, THEN diffs
+#   func after():       _board.close()
+#
+# WHY THE CHECK IS NOT OPTIONAL. A leak observed by a LATER case is a flake -- it depends on what
+# that case happens to look at, so it reproduces sometimes and points at the wrong test when it
+# does. check() diffs the whole board against the baseline after EVERY case, so a leak fails at the
+# case that caused it, every run, naming the field. Sharing without it would trade a slow suite for
+# an unreliable one, which is the wrong trade; sharing WITH it is the trade actually on offer.
+#
+# FRESH MODE IS THE ORACLE AND THE ESCAPE HATCH (leaf D). Set IOSIS_FRESH_FIXTURE=1 and every suite
+# using this rebuilds the scene per case exactly as before, at no loss but time. Two things that
+# buys: a converted suite can always be compared against the behaviour it had before conversion
+# (divergence between the modes IS a leak, caught deterministically rather than by luck), and if
+# sharing ever proves unsound the fallback is an environment variable rather than a revert.
+class_name SharedBoard
+extends RefCounted
+
+const FRESH_ENV := "IOSIS_FRESH_FIXTURE"
+
+var scene: Node3D
+var game: Node2D
+
+var _scene_path: String
+var _mission_path: String
+var _pristine: ScenarioData
+var _baseline: Dictionary
+
+
+func _init(scene_path: String, mission_path: String = "") -> void:
+	_scene_path = scene_path
+	_mission_path = mission_path
+
+
+static func fresh_mode() -> bool:
+	return OS.get_environment(FRESH_ENV) != ""
+
+
+# --- the four hooks ------------------------------------------------------------------------------
+
+func open(suite: GdUnitTestSuite) -> void:
+	if fresh_mode():
+		return   # nothing is shared; reset() builds a scene of its own per case
+	await _build(suite)
+	# WARM-UP, then baseline. capture -> apply -> capture is not a fixed point on the FIRST cycle
+	# (WeaponInstance.spaces is lazily grown rather than sized from its template, #624), so the
+	# baseline is taken after one reset rather than before it. Without this every case would report
+	# a leak that is really a representation change, and the check would be worthless on day one.
+	_pristine = game.scenario_manager.capture_scenario("__shared_pristine")
+	await _apply(suite)
+	_baseline = BoardFingerprint.take(scene, game.scenario_manager)
+
+
+func reset(suite: GdUnitTestSuite) -> void:
+	if fresh_mode():
+		await _build(suite)
+		return
+	await _apply(suite)
+
+
+# RESETS FIRST, then diffs -- the ordering is load-bearing and was wrong in the first draft.
+#
+# Diffing the board a case LEFT behind fails every case that legitimately loads a mission or moves a
+# unit, which is most of them; that is the case doing its job, not leaking. What must be true is
+# that the reset door can UNDO whatever the case did. So this resets and then asks whether the
+# board came back -- anything still differing is something clear_board/apply_scenario cannot reach,
+# which is exactly the leak the next case would inherit.
+#
+# Doing it here rather than in before_test is what attributes the leak correctly: after_test still
+# belongs to the case that caused it, while before_test would name its innocent successor.
+#
+# Returns the leak list as well as asserting on it, so a suite that wants to inspect it can.
+func check(suite: GdUnitTestSuite) -> PackedStringArray:
+	if fresh_mode():
+		_teardown()
+		return PackedStringArray()
+	await _apply(suite)
+	var diff := BoardFingerprint.differences(_baseline,
+			BoardFingerprint.take(scene, game.scenario_manager))
+	suite.assert_array(diff).override_failure_message(
+		("this case leaked state into the shared board. Each line is something the next case would "
+		+ "have inherited:\n  %s\n"
+		+ "Either undo it in the case, or -- if it belongs to the board -- make the reset door "
+		+ "cover it rather than teaching the fingerprint to ignore it.") % "\n  ".join(diff)
+	).is_empty()
+	return diff
+
+
+func close() -> void:
+	if fresh_mode():
+		return   # check() already freed each case's scene
+	_teardown()
+
+
+# --- internals -----------------------------------------------------------------------------------
+
+func _build(suite: GdUnitTestSuite) -> void:
+	# The project window size: headless defaults can be tiny, and several presentation reads
+	# (picking, the PiP) are resolution-dependent.
+	suite.get_tree().root.size = Vector2i(1280, 720)
+	PlayerSettings.reset_for_test()
+	scene = (load(_scene_path) as PackedScene).instantiate() as Node3D
+	scene.auto_play = false   # the board is loaded explicitly below, if at all
+	suite.get_tree().root.add_child(scene)
+	await suite.await_idle_frame()
+	game = scene.game
+	if _mission_path != "":
+		scene.load_mission(_mission_path)
+		await suite.await_idle_frame()
+
+
+# The reset RECIPE. apply_scenario begins with clear_board(), so this is the game's own door rather
+# than bespoke cleanup -- which is the point: every case run through it exercises the same reset a
+# mission-to-mission transition will need (#70), instead of a fresh process hiding whether it works.
+#
+# Ending dialog is part of the recipe, not an afterthought: load_mission arms the #182 lesson and
+# apply_scenario is the BOARD door, so without this the first case runs with a timeline live and
+# every later one without.
+func _apply(suite: GdUnitTestSuite) -> void:
+	if _pristine != null:
+		game.scenario_manager.apply_scenario(_pristine)
+	await DialogFixtures.end_all_dialog(suite)
+	await suite.await_idle_frame()
+
+
+func _teardown() -> void:
+	if scene == null:
+		return
+	BoardSpace.clear_staging()
+	scene.get_parent().remove_child(scene)
+	scene.free()
+	scene = null
+	game = null

--- a/tests/support/shared_board.gd.uid
+++ b/tests/support/shared_board.gd.uid
@@ -1,0 +1,1 @@
+uid://vgjgalscdvbu


### PR DESCRIPTION
Leaves **A, B and D** of #622's Mikado stack. Builds on #623 (leaf C2, the law). No existing suite is converted — that is the next leaf.

One `Battle3D` per **suite** instead of one per case, with the leak check wired in rather than optional. Measured on the new smoke suite, identical assertions both ways:

| | shared | fresh |
|---|---|---|
| per case | **79–81 ms** | 825–1138 ms |

## Why a diff rather than "run the next test and see"

A leak observed by a *later* case is a flake — it depends on what that case happens to look at, reproduces sometimes, and blames the wrong test when it does. `BoardFingerprint` diffs the whole board against a baseline after every case, so a leak fails **at the case that caused it, every run, naming the field**. Speed traded for determinism would be the wrong direction; this is the version of the trade worth taking.

Coverage follows #622's taxonomy: the **board** via `capture_scenario`; **tuning** derived from the knob tables rather than listed, so this and the panels cannot drift; and the residue — staging, Dialogic, camera, `game_state`.

Reflection, not serialization: `ResourceSaver` mints `[sub_resource id="..."]` per save, so two saves of identical data differ and every case would report a phantom leak.

## The recipe needed two steps reasoning would have missed

The fingerprint found both on its first run. `apply_scenario` alone did **not** restore:

- **Dialogic stayed armed** from `load_mission` — `apply_scenario` is the *board* door and does not re-arm the lesson, so case 1 would run with a timeline live and every later case without.
- **`WeaponInstance.spaces` moved `0 entries -> 3`** — it is lazily grown rather than sized from its template, so a weapon's form depends on what touched it. Filed as **#624**; warmed around here rather than papered over.

## A design bug of mine, fixed

`check()` **resets before it diffs**, and my first draft had it backwards. Diffing what a case *left behind* fails every case that legitimately loads a mission or moves a unit — that is the case working, not leaking. What must be true is that the reset door can **undo** it. Keeping the call in `after_test` is what blames the case that caused a leak rather than its innocent successor.

## Fresh mode is the oracle and the escape hatch (leaf D)

`IOSIS_FRESH_FIXTURE=1` rebuilds per case exactly as before. Divergence between the modes **is** a leak, caught deterministically — and if sharing ever proves unsound the fallback is an environment variable, not a revert.

The smoke suite passes in **both** modes, and its last case is the demonstration: the previous case's damage is gone in fresh mode because the scene was rebuilt, and in shared mode because the reset door works.

## Verification

- `tests/presentation` + `tests/law` — **691/691, 62/62 suites, 0 orphans** (before these landed).
- The two new suites — **9/9**, and **4/4** again under `IOSIS_FRESH_FIXTURE=1`.

## Estimate correction

#619 and #622 put the saving at ~58% of CI on the assumption the reset is free. It is not, and I over-corrected in the other direction mid-analysis. The measured figure above is a suite whose case *bodies* are trivial, so it isolates fixture cost; a real suite keeps its body time and will see less overall. I would rather land the measurement than another estimate — converting a real suite is what produces the honest number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
