### PR TITLE
#620 follow-up: rebalance the shards -- presentation no longer needs three of five

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,14 @@ on:
     branches: [main]
     paths-ignore: ['docs/**', '**.md']
 
-# THE TWO HAND-MAINTAINED SHARD LISTS, AND THE ONLY PLACE THEY ARE WRITTEN. The pres-rest
-# shard subtracts exactly these, so "pres-rest runs what pres-a and pres-b do not" is true by
-# CONSTRUCTION, not by remembering to edit two places. Balance only: moving a suite between
-# pres-a, pres-b and pres-rest changes wall clock, never coverage.
+# THE ONE HAND-MAINTAINED SHARD LIST, AND THE ONLY PLACE IT IS WRITTEN. pres-rest subtracts
+# exactly these, so "pres-rest runs what pres-a does not" is true by CONSTRUCTION rather than by
+# remembering to edit two places. Balance only: moving a suite between pres-a and pres-rest
+# changes wall clock, never coverage.
+#
+# Re-measured 2026-08-28 after #621/#622 halved the suite. presentation fell 294s -> 136s, so
+# three presentation shards became two, and the tree's OTHER areas -- one shard carrying 94s --
+# became the critical path instead. ui+flow got their own shard out of it.
 #
 # ALWAYS FULL res:// PATHS ENDING IN .gd. gdUnit4's -i does a SUBSTRING match on the test's
 # source_file (GdUnitTestCIRunner.is_skipped), so a bare name like `test_camera` would
@@ -35,15 +39,10 @@ on:
 # terminator is what makes an entry unable to match a longer sibling filename.
 env:
   PRES_A: >-
-    res://tests/presentation/test_board_mirror.gd
-    res://tests/presentation/test_camera_rig.gd
-    res://tests/presentation/test_unit_mirror.gd
-    res://tests/presentation/test_camera_start.gd
-  PRES_B: >-
-    res://tests/presentation/test_overlay_mirror.gd
+    res://tests/presentation/test_camera_follow.gd
     res://tests/presentation/test_input_bridge.gd
-    res://tests/presentation/test_board_overlays.gd
-    res://tests/presentation/test_board_picker.gd
+    res://tests/presentation/test_overlay_mirror.gd
+    res://tests/presentation/test_board_mirror.gd
 
 jobs:
   test:
@@ -55,7 +54,7 @@ jobs:
       # to the first failure turns one debugging pass into several.
       fail-fast: false
       matrix:
-        shard: [pres-a, pres-b, pres-rest, dev, rest]
+        shard: [pres-a, pres-rest, dev, ui-flow, rest]
 
     steps:
       - uses: actions/checkout@v4
@@ -112,18 +111,24 @@ jobs:
           set +e
 
           targets=""
-          # WHICH SUITES THIS SHARD OWNS. pres-a and pres-b name their suites; every other
-          # shard is defined by SUBTRACTION, so a file nobody assigned still runs somewhere:
-          # a new presentation suite lands in pres-rest, a new dev suite in dev, and an
-          # entirely new AREA FOLDER in rest. A RENAMED suite drops out of both the -a list
-          # and the matching -i, so it reappears in pres-rest rather than vanishing.
+          # WHICH SUITES THIS SHARD OWNS. pres-a names its suites; every other shard is defined
+          # by SUBTRACTION, so a file nobody assigned still runs somewhere: a new presentation
+          # suite lands in pres-rest, a new dev suite in dev, a new ui/flow suite in ui-flow, and
+          # an entirely new AREA FOLDER in rest. A RENAMED suite drops out of both the -a list and
+          # the matching -i, so it reappears in pres-rest rather than vanishing.
+          #
+          # rest EXCLUDES four areas now rather than two. That list is the only thing to keep in
+          # step with the matrix: an area given its own shard must also be subtracted here, or it
+          # runs twice -- which is slow, not silent, and the case-count sum in the step summary is
+          # what shows it.
           case "${{ matrix.shard }}" in
             pres-a)    for s in $PRES_A; do targets="$targets -a $s"; done ;;
-            pres-b)    for s in $PRES_B; do targets="$targets -a $s"; done ;;
             pres-rest) targets="-a res://tests/presentation"
-                       for s in $PRES_A $PRES_B; do targets="$targets -i $s"; done ;;
+                       for s in $PRES_A; do targets="$targets -i $s"; done ;;
             dev)       targets="-a res://tests/dev" ;;
-            rest)      targets="-a res://tests -i res://tests/presentation/ -i res://tests/dev/" ;;
+            ui-flow)   targets="-a res://tests/ui -a res://tests/flow" ;;
+            rest)      targets="-a res://tests"
+                       for d in presentation dev ui flow; do targets="$targets -i res://tests/$d/"; done ;;
             *)         echo "::error::Unknown shard '${{ matrix.shard }}'"; exit 1 ;;
           esac
 


### PR DESCRIPTION
Follow-up to #620. The split was still balanced against the suite's pre-#621 shape.

## Why it drifted

#621 and #622 halved the work (495s -> 300s), but not evenly: `presentation` fell **294s -> 136s**
while the rest of the tree stayed put. So three of five shards were sharing what one area now
costs, and a single shard carried 94s. Measured on main at `d802944`:

| shard | suite time | job |
|---|---|---|
| `pres-a` | 27.2s | 60s |
| `pres-b` | 35.5s | 71s |
| `pres-rest` | 72.9s | 112s |
| `dev` | 70.1s | 105s |
| **`rest`** | **93.9s** | **143s** ← critical path |

## What changes

| shard | contents | suite time |
|---|---|---|
| `pres-a` | 4 named suites | 71.6s |
| `pres-rest` | presentation catch-all (25 suites) | 64.0s |
| `dev` | `tests/dev` | 70.1s |
| `ui-flow` | `tests/ui` + `tests/flow` | 65.3s |
| `rest` | everything else | 28.7s |

Projected makespan **~110s against 143s**. `dev` at 70.1s is the floor; beating it means naming dev
suites too, which buys ~10s for a third hand-maintained list and is deliberately not taken.

**This is less config than it replaces** -- ONE hand-maintained list instead of two.

The heavies were re-picked from measured times, and that mattered: `test_board_mirror` is **16.6s
now, not 61.1s**, because #622's SharedBoard conversion moved it. The old `PRES_A` was pinning
suites that had stopped being heavy.

## The safety property is unchanged

Every shard but `pres-a` is still defined by **subtraction**, so a file nobody assigned still runs:
new presentation suite -> `pres-rest`, new dev suite -> `dev`, new ui/flow suite -> `ui-flow`, new
**area folder** -> `rest`.

One new thing to keep in step: `rest` now excludes **four** areas rather than two. An area given
its own shard must also be subtracted there or it runs twice -- which is slow, not silent, and the
case-count sum in the step summary is what shows it. Called out in a comment at the site.

## What this deliberately does NOT do

**Per-shard fixed cost is 38.3s measured, and the Import step alone is 20s of it.** Five shards
spend 192s on setup against 300s of testing -- overhead is **39% of CI compute**, and is now a
bigger lever than balance. Caching `.godot/` would cut 20s off the makespan at *any* shard count,
more than this whole rebalance buys. It is not here because a stale import **fails green**, and
this repo is demonstrably sensitive there (the `project.godot` guard exists because import rewrites
it). That wants its own ticket and a cache key over the asset tree.

`rest` also carries ~10s more overhead than its siblings, because `-a res://tests` discovers all
272 suites before excluding four areas. Measured and accepted: that is the price of the
subtraction-safety property.

The theoretically optimal 5-way split is **98s**, and it is not taken -- it gets there by
scattering ~40 individually-named suites across five mixed lists, trading the property that makes
this config safe for 12 seconds.

## Verification

**The five shard case counts must sum to what main reports at the merge-base** -- lost coverage
cannot fail a test. Main was **2686** at `d802944`. Each shard echoes its count to the step summary.

Expect this to need one more pass as #622 converts the remaining heavy presentation suites
(`test_camera_follow` 21.3s, `test_input_bridge` 17.0s, `test_overlay_mirror` 16.7s are still
per-case) -- the split is periodic maintenance, not a one-time setup.
