### PR TITLE
#622: SharedBoard holds the heavy scene, so fresh mode stops reloading it per case

### DIFF
--- a/tests/law/test_heavy_scenes_are_preloaded.gd
+++ b/tests/law/test_heavy_scenes_are_preloaded.gd
@@ -38,6 +38,17 @@ const SELF := "res://tests/law/test_heavy_scenes_are_preloaded.gd"
 # of once per case, so the rule -- do not re-read a heavy scene per case -- is satisfied. Sharing
 # also kills the _ready cascade this law cannot touch, so it is the STRONGER fix where a suite has
 # been converted; preloading is the floor for the ones that have not.
+#
+# THAT ARGUMENT HAS A HOLE THIS SCANNER CANNOT SEE, and SharedBoard closes it at its own end rather
+# than here. It holds the path in a VARIABLE, so the literal-load check below never looks at it --
+# and IOSIS_FRESH_FIXTURE=1 makes the same file rebuild PER CASE, which is exactly the pattern this
+# law exists to forbid. Measured: board_mirror fresh 63.9s +/- 0.6, i.e. unmoved by #621, against
+# 12.5s shared. SharedBoard now keeps a process-lifetime PackedScene cache (its `_packed`), which
+# is what a preload does, and fresh fell to 19.4s +/- 0.1. Two consequences worth carrying: the
+# TRUE cost of sharing over preloading is 1.56x rather than the 5.11x the uncached comparison
+# showed, and a load() whose argument is not a literal is a blind spot of this check by
+# construction -- widening the match to catch it would flag every legitimate dynamic load in the
+# suite, so the guard is the reviewer knowing this paragraph exists.
 
 
 func test_no_suite_load_s_a_heavy_scene_per_test() -> void:

--- a/tests/support/shared_board.gd
+++ b/tests/support/shared_board.gd
@@ -122,13 +122,36 @@ func close() -> void:
 
 # --- internals -----------------------------------------------------------------------------------
 
+# HOLD the heavy scene for the life of the PROCESS, which is what a suite's own
+# `const SCENE := preload(...)` does for the suites that keep their own fixture (#621).
+#
+# It matters here for FRESH MODE, and only there: sharing already reads the scene once per suite,
+# but IOSIS_FRESH_FIXTURE=1 rebuilds per case, so a plain load() would drop the last reference to
+# lookdev_meshlib.tres -- 5 MB, 2089 ArrayMesh sub-resources -- and reload it for the next case.
+# That is exactly the regression #621 measured and fixed, re-entered through the back door: this
+# file loads a path held in a VARIABLE, so test_heavy_scenes_are_preloaded's scanner, which looks
+# for a literal load("res://..."), structurally cannot see it. Measured before the cache:
+# board_mirror fresh 63.9s +/- 0.6 against 12.5s +/- 0.05 shared, and the fresh number had not
+# moved at all across #621.
+#
+# The cache is never evicted, which is the point -- a PackedScene is what preload keeps too, and
+# releasing it would put the reload straight back.
+static var _packed_scenes: Dictionary[String, PackedScene] = {}
+
+
+static func _packed(path: String) -> PackedScene:
+	if not _packed_scenes.has(path):
+		_packed_scenes[path] = load(path) as PackedScene
+	return _packed_scenes[path]
+
+
 func _build(suite: GdUnitTestSuite) -> void:
 	# The project window size: headless defaults can be tiny, and several presentation reads
 	# (picking, the PiP) are resolution-dependent.
 	suite.get_tree().root.size = Vector2i(1280, 720)
 	PlayerSettings.reset_for_test()   # also cleared per case by _apply; this is fresh mode's copy
 	Experiments.reset_for_test()
-	scene = (load(_scene_path) as PackedScene).instantiate() as Node3D
+	scene = _packed(_scene_path).instantiate() as Node3D
 	scene.auto_play = false   # the board is loaded explicitly below, if at all
 	suite.get_tree().root.add_child(scene)
 	await suite.await_idle_frame()


### PR DESCRIPTION
`IOSIS_FRESH_FIXTURE=1` rebuilds the scene per case, and `SharedBoard._build` reached it with `load(_scene_path)` — so the 5 MB `lookdev_meshlib.tres` lost its last reference every case and reloaded for the next one. **That is the regression #621 measured and fixed, re-entered through a door its law structurally cannot see**: the scanner matches a literal `load("res://…")`, and this file holds the path in a *variable*.

## Measured (hyperfine, `test_board_mirror`, warmup + repeats)

| | SHARED | FRESH |
|---|---|---|
| before | 12.519 s ± 0.049 | **63.941 s ± 0.596** |
| after | 12.494 s ± 0.222 | **19.449 s ± 0.130** |

Fresh **3.3× faster**. Shared unchanged, as predicted — it only ever loaded once.

## Two consequences beyond the speed

**The true cost of sharing over preloading is 1.56×, not 5.11×.** #626 and #631 both quoted fresh-vs-shared as though it were converted-vs-preloaded. It wasn't: fresh had silently never received #621's benefit, so that comparison was measuring the missing preload, not the fixture sharing. The conversion is still worth what it's worth — roughly 0.1s per case — but **the headline ratio in those two PRs overstated it, and this corrects the record.**

It also explains a confusion from #631: converted and unconverted suites kept measuring closer together than the fresh-mode ratio implied. They were. I was comparing against a baseline that had never been fixed.

**Fresh mode is the documented escape hatch** — *"if sharing ever proves unsound the fallback is an environment variable rather than a revert."* An escape hatch costing 5× more than it needs to is one nobody reaches for.

## The change

A process-lifetime static holding the `PackedScene` — which is what `preload` keeps too — never evicted, because releasing it would put the reload straight back. The suite-facing API is unchanged, so every converted suite keeps handing `SCENE_PATH` in and `test_heavy_scenes_are_preloaded` keeps passing them without an exemption.

That law gains a paragraph recording the hole and **why the check is not widened**: a `load()` whose argument isn't a literal is a blind spot by construction, and matching those would flag every legitimate dynamic load in the suite. The guard is a reviewer knowing the paragraph exists.

## Verification

- `tests/presentation` + `tests/law`: **705/705, 64/64 suites, 0 orphans, exit 0**
- `test_board_mirror` **73/73 in both modes**, 0 orphans
- The benchmark above is the falsification: revert the cache and FRESH returns to ~64s while SHARED does not move.

## Note on method

Every timing I posted before today was a single `date +%s` sample, and one suite measured 5s, 451s and 730s across three of them — each `git checkout` of a test file changes mtimes and forces a re-import. hyperfine's warmup absorbs exactly that. The 5.11× figure was *stable* at σ=0.05 across four runs, which is what made it convincing; precision is not accuracy, and it was reproducibly measuring the wrong comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZHJ7AuFedPCURFKoY9xX6
