### PR TITLE
#613: the Play API answers "what may I do next", not just "what does the board look like"

### DIFF
--- a/docs/play-api.md
+++ b/docs/play-api.md
@@ -59,7 +59,8 @@ view**, not raw JSON — see *State representation*. Command vocabulary:
 | Command | Returns |
 |---|---|
 | `describe_state()` | full board snapshot (rendered view — see below) |
-| `legal_moves(unit_id)` / `legal_targets(unit_id)` | reachable cells / hittable cells + victims |
+| `legal_moves(unit_id)` / `legal_targets(unit_id)` | reachable cells / hittable cells + victims. **Each calls the predicate its own gate calls** — `compute_move_range` for moves, `can_hit_cell_from` + `gather_attack_victims` for aims — so a cell offered can never be one the queue refuses. A second derivation here would be Law #4 with a silent failure mode, and `tests/play/test_affordances.gd` drives both sides to keep them honest |
+| `status()` | whose turn, which squad holds the activation and what it has queued, which squads are spent. Rides every frame rather than being asked for |
 | `squad_up / join / leave / disband` | new squad state |
 | `queue_move(unit_id, dest)` / `queue_attack(unit_id, aim_cell)` | validity + updated plan |
 | `rescue / rally / reload / rev / burrow / guard` | the side-channel main actions, one verb each — the argument-taking ones (`rescue(a, b)`, `guard(a, ward)`) stay separate from the argument-free ones for the reason `game.queue_simple_action` does. Each gates on the same `RulesService` query the menu's row is built from. *(Still missing: `capture` — see Known gaps.)* |
@@ -116,10 +117,36 @@ assigned by `PlaySession` — units have no persistent id today.
 - **Overview** (`describe_state`): ruled board + one-line-per-unit legend + turn / squad status. The default; small.
 - **Focus** (`focus(unit)`): board re-rendered with that unit's **move range** (`+`) and **attack range** (`×`) overlaid; the unit's full stats / weapon / states; its legal actions; and (if squadded) the leader LDR range.
 - **Preview** (`preview`): the **resolved** outcome of the current/hypothetical plan — exact damage, deaths, counters, net board change — as a concise diff, not a re-dump. The deterministic-engine payoff.
-- **Result** (`execute`): the event log (equals the preview, by Law #2) + a fresh overview.
+- **Result** (`execute`): the event log (equals the preview, by Law #2). No overview — see below.
+- **Affordances** (`legal_moves(unit)` / `legal_targets(unit)`): where this unit may go, and which
+  aims hit whom. Cell lists grouped by row (`y=13: 19-23`), a few hundred bytes where the only way
+  to ask used to be `focus`, which renders a 2 KB board to say it.
 
 Micro-commands (`queue_move`, `cancel`) return a one-line ack + plan delta, **not** a full re-render —
-the board is redrawn only on overview / focus / preview / result / turn-change.
+**the board is redrawn only on `overview` and `focus`, both on request** (#613, 2026-08-28).
+
+`result` and `turn-change` used to redraw too, and that was 63% of all output measured over a real
+run: terrain is static, and what a pass changes is a handful of positions and HP, which the event log
+already names. Redrawing on every action also crowded out the state that actually gates the next
+command — see below.
+
+**Every frame carries a status line**, failures included, because a refusal is exactly when it is
+wanted:
+
+```
+[turn=PLAYER  active=sq4(2 queued)  free=sq5,sq6  acted=sq7]
+```
+
+Measured over five logged playthroughs before this existed, a third to a half of every command was
+*rejected* — `move` 55%, `attack` 61% — and the three largest causes were all answerable from this
+line plus the two affordance queries: guessing at reach (62), not knowing which squads were spent or
+which held the activation (43), and executing with nothing queued (34). The rendered board carried
+none of it.
+
+**Batching.** `{"id": N, "cmds": [{...}, {...}]}` runs a list in order and returns one envelope, for
+callers where a round trip costs more than the bytes do. It **stops at the first failure**: a refusal
+is nearly always a wrong belief about turn state, so everything after it rests on the same wrong
+belief.
 
 **Targeting.** Commands use **game coordinates** (no rebasing — one coordinate system kills a whole bug
 class). The board carries x / y rulers; exact targets are confirmed by the affordance overlay plus a

--- a/play/board_builder.gd
+++ b/play/board_builder.gd
@@ -181,4 +181,5 @@ static func apply_scenario(board: Dictionary, scenario: ScenarioData) -> Array[U
 			board.squad_manager.set_has_acted(unit.squad, true)
 
 	board.turn_manager.set_active_faction(scenario.active_faction)
+	board["scenario"] = scenario
 	return spawned

--- a/play/board_view.gd
+++ b/play/board_view.gd
@@ -12,20 +12,31 @@ static func render_overview(session) -> String:
 	var bounds := _content_bounds(session)
 	var lines: Array[String] = []
 	lines.append("Turn: %s" % session._faction_name(session.active_faction()))
-	lines.append(_grid_block(session, bounds, _downed_overlay(session)))
+	lines.append(_grid_block(session, bounds, _overview_overlay(session)))
 	lines.append("")
 	lines.append(_legend(session))
+	var mission_str := _mission_block(session)
+	if mission_str != "":
+		lines.append("")
+		lines.append(mission_str)
 	return "\n".join(lines)
 
-# Mark every downed-but-alive body on the board ("v"). Downed units cling at 1 HP, are out
-# of action, and have been ejected into solo squads — but they still occupy their cell.
-#
-# Watched cells ("!") ride the same channel (#413), because the graphical board telegraphs every
-# live watch to both sides and a headless player has to be able to see the same thing. A body on a
-# watched cell keeps its "v": knowing a unit is down outranks knowing the cell is covered, and the
-# watch is still named in the legend.
-static func _downed_overlay(session) -> Dictionary:
+# Mark every downed-but-alive body on the board ("v"), live watches ("!"),
+# and mission zones ("C" = capture, "E" = extraction) (#413, #612).
+# Precedence: downed "v" > watch "!" > zone "C"/"E".
+static func _overview_overlay(session) -> Dictionary:
 	var overlay := {}
+	for zname in session.zones():
+		var zone: Dictionary = session.zones()[zname]
+		var kind: int = zone.get("kind", ZoneManager.Kind.PATROL)
+		var glyph := ""
+		if kind == ZoneManager.Kind.CAPTURE:
+			glyph = "C"
+		elif kind == ZoneManager.Kind.EXTRACTION:
+			glyph = "E"
+		if glyph != "":
+			for cell in zone.get("cells", []):
+				overlay[cell] = glyph
 	for unit in session.live_units():
 		if unit.watch == null or unit.watch.spent or not unit.watch.is_intact():
 			continue
@@ -156,9 +167,77 @@ static func _legend(session) -> String:
 		lines.append("  " + _unit_line(session, unit))
 		if unit.is_downed():
 			any_downed = true
+	var notes: Array[String] = []
 	if any_downed:
-		lines[0] = "Units:   (v = downed body on board; finish it or rescue it)"
+		notes.append("v = downed body on board; finish it or rescue it")
+	var has_c := false
+	var has_e := false
+	for zname in session.zones():
+		var kind: int = session.zones()[zname].get("kind", ZoneManager.Kind.PATROL)
+		if kind == ZoneManager.Kind.CAPTURE:
+			has_c = true
+		elif kind == ZoneManager.Kind.EXTRACTION:
+			has_e = true
+	if has_c:
+		notes.append("C = capture zone")
+	if has_e:
+		notes.append("E = extract zone")
+	if not notes.is_empty():
+		lines[0] = "Units:   (%s)" % "; ".join(notes)
 	return "\n".join(lines)
+
+static func _mission_block(session) -> String:
+	if session.scenario_data == null:
+		return ""
+	var lines: Array[String] = []
+	var obj_names: Array[String] = []
+	for obj in session.objectives():
+		obj_names.append(MissionRules.Objective.keys()[obj])
+	var title := "ROUT" if obj_names.is_empty() else " + ".join(obj_names)
+	var limit_str := "no limit" if session.round_limit() <= 0 else "limit: %d rounds" % session.round_limit()
+	lines.append("Mission: %s      (round %d, %s)" % [title, session.scenario_data.rounds_elapsed + 1, limit_str])
+	if session.objectives().is_empty():
+		lines.append("  ROUT     defeat all hostile units")
+	else:
+		for obj in session.objectives():
+			match obj:
+				MissionRules.Objective.ROUT:
+					lines.append("  ROUT     defeat all hostile units")
+				MissionRules.Objective.CAPTURE:
+					var any_zone := false
+					for zname in session.zones():
+						var z: Dictionary = session.zones()[zname]
+						if z.get("kind") == ZoneManager.Kind.CAPTURE:
+							lines.append("  CAPTURE  \"%s\"  %s" % [zname, _format_cells(z.get("cells", []))])
+							any_zone = true
+					if not any_zone:
+						lines.append("  CAPTURE  (no zone painted)")
+				MissionRules.Objective.EXTRACT:
+					var any_zone := false
+					for zname in session.zones():
+						var z: Dictionary = session.zones()[zname]
+						if z.get("kind") == ZoneManager.Kind.EXTRACTION:
+							lines.append("  EXTRACT  \"%s\"  %s" % [zname, _format_cells(z.get("cells", []))])
+							any_zone = true
+					if not any_zone:
+						lines.append("  EXTRACT  (no zone painted)")
+	for cond in session.lose_conditions():
+		lines.append("  FAIL IF  %s" % MissionRules.defeat_reason(cond))
+	lines.append("  (progress: not scored headlessly (#46))")
+	return "\n".join(lines)
+
+static func _format_cells(cells: Array) -> String:
+	var list: Array[Vector2i] = []
+	for c in cells:
+		if c is Vector2i:
+			list.append(c)
+	list.sort_custom(func(a: Vector2i, b: Vector2i) -> bool:
+		return a.y < b.y if a.y != b.y else a.x < b.x
+	)
+	var parts: Array[String] = []
+	for c in list:
+		parts.append("(%d,%d)" % [c.x, c.y])
+	return " ".join(parts)
 
 static func _unit_line(session, unit: Unit) -> String:
 	var fac := "P"

--- a/play/board_view.gd
+++ b/play/board_view.gd
@@ -239,6 +239,92 @@ static func _format_cells(cells: Array) -> String:
 		parts.append("(%d,%d)" % [c.x, c.y])
 	return " ".join(parts)
 
+# ---- affordances (#613) ----
+#
+# What a unit may do, in place of making the caller guess a cell and be refused. A move range is a
+# REGION, so it prints grouped by row -- "y=13: 19-23" shows the shape of where you may go, which a
+# flat list of forty (x,y) pairs does not, and costs about half the bytes. Deliberately NOT
+# _format_cells, which stays the spelling for an ENUMERATION (the mission block's zone cells, read
+# off one at a time); the two answer different questions and the split is declared rather than
+# accidental.
+
+static func render_legal_moves(session, handle: String) -> String:
+	var res: Dictionary = session.legal_moves(handle)
+	if not res.ok:
+		return "> ERROR: " + str(res.error)
+	var head := "moves %s from (%d,%d): %d cells" % [res.unit, res.from.x, res.from.y, res.cells.size()]
+	var body := _cell_rows(res.cells)
+	if not res.leashed.is_empty():
+		# Named, because "too far to walk" and "your leader is too far" want different fixes.
+		body += "\n  outside leader range (%d): %s" % [res.leashed.size(), _cell_rows(res.leashed).strip_edges()]
+	return head + "\n" + body
+
+
+static func render_legal_targets(session, handle: String) -> String:
+	var res: Dictionary = session.legal_targets(handle)
+	if not res.ok:
+		return "> ERROR: " + str(res.error)
+	if res.aims.is_empty():
+		return "targets %s from (%d,%d): none" % [res.unit, res.from.x, res.from.y]
+	var lines: Array[String] = ["targets %s from (%d,%d): %d aims" % [res.unit, res.from.x, res.from.y, res.aims.size()]]
+	for aim: Dictionary in res.aims:
+		lines.append("  (%d,%d) hits %s" % [aim.cell.x, aim.cell.y, ", ".join(aim.victims)])
+	return "\n".join(lines)
+
+
+# The turn's own state, on EVERY frame including the failures -- a refusal is exactly when the
+# caller needs to know whose turn it is and what is already spent.
+static func render_status(session) -> String:
+	if session == null:
+		return "[no board]"
+	var st: Dictionary = session.status()
+	var parts: Array[String] = ["turn=" + str(st.faction)]
+	if int(st.active_squad) < 0:
+		parts.append("active=none")
+	else:
+		parts.append("active=sq%d(%d queued)" % [int(st.active_squad), int(st.queued)])
+	if not st.free.is_empty():
+		parts.append("free=" + _squad_list(st.free))
+	if not st.acted.is_empty():
+		parts.append("acted=" + _squad_list(st.acted))
+	return "[" + "  ".join(parts) + "]"
+
+
+static func _squad_list(ids: Array) -> String:
+	var parts: Array[String] = []
+	for i in ids:
+		parts.append("sq%d" % int(i))
+	return ",".join(parts)
+
+
+# Grouped by row, contiguous runs collapsed: "y=13: 19-23 25".
+static func _cell_rows(cells: Array) -> String:
+	var by_row := {}
+	for c in cells:
+		if not (c is Vector2i):
+			continue
+		var row: int = (c as Vector2i).y
+		if not by_row.has(row):
+			by_row[row] = [] as Array[int]
+		by_row[row].append((c as Vector2i).x)
+	var rows := by_row.keys()
+	rows.sort()
+	var lines: Array[String] = []
+	for row in rows:
+		var xs: Array = by_row[row]
+		xs.sort()
+		var runs: Array[String] = []
+		var i := 0
+		while i < xs.size():
+			var j := i
+			while j + 1 < xs.size() and int(xs[j + 1]) == int(xs[j]) + 1:
+				j += 1
+			runs.append(str(xs[i]) if j == i else "%d-%d" % [int(xs[i]), int(xs[j])])
+			i = j + 1
+		lines.append("  y=%d: %s" % [int(row), " ".join(runs)])
+	return "\n".join(lines)
+
+
 static func _unit_line(session, unit: Unit) -> String:
 	var fac := "P"
 	if unit.get_faction() == Team.Faction.ENEMY:

--- a/play/play_bridge.gd
+++ b/play/play_bridge.gd
@@ -118,6 +118,8 @@ func _dispatch(cmd: String, args: Dictionary) -> Dictionary:
 			return {"ok": true, "text": BoardView.render_result(r.get("events", [])) + "\n\n" + BoardView.render_overview(_session)}
 		"endturn":
 			var r = _session.end_turn()
+			if not r.ok:
+				return {"ok": false, "text": "> " + str(r.error) + "\n\n" + BoardView.render_overview(_session)}
 			return {"ok": true, "text": "Turn -> %s\n\n%s" % [str(r.faction), BoardView.render_overview(_session)]}
 		_:
 			return {"ok": false, "text": "unknown cmd: " + cmd}

--- a/play/play_bridge.gd
+++ b/play/play_bridge.gd
@@ -53,8 +53,55 @@ func _poll_loop() -> void:
 	while not _quitting:
 		await process_frame
 		var c := _read_command()
-		if c.has("id") and int(c.id) > _last_id:
+		if not (c.has("id") and int(c.id) > _last_id):
+			continue
+		# BATCH: {"id": N, "cmds": [{"cmd": ..., "args": ...}, ...]} beside the single form.
+		# One round trip instead of one per command, which for an agent driver costs more than the
+		# bytes do -- each is a separate tool call (#613).
+		if c.has("cmds") and c.cmds is Array:
+			await _handle_batch(int(c.id), c.cmds as Array)
+		else:
 			await _handle(int(c.id), str(c.get("cmd", "")), c.get("args", {}))
+
+# STOPS AT THE FIRST FAILURE, and that is the point rather than laziness: the logged runs show a
+# refusal is almost always a wrong belief about the turn's state, so every command after it is
+# built on the same wrong belief. Running them anyway turns one mistake into a compounding mess --
+# which is exactly the pattern behind the 34 "no squad has queued orders" refusals.
+func _handle_batch(id: int, cmds: Array) -> void:
+	var parts: Array[String] = []
+	var ok := true
+	var last := "batch"
+	for i in cmds.size():
+		var entry = cmds[i]
+		if not (entry is Dictionary):
+			parts.append("[%d] > ERROR: not a command object" % i)
+			ok = false
+			break
+		var one := entry as Dictionary
+		last = str(one.get("cmd", ""))
+		print("[bridge] id=%d [%d] cmd=%s" % [id, i, last])
+		var res := await _run_one(last, one.get("args", {}))
+		parts.append("[%d] %s\n%s" % [i, last, res.text])
+		if not res.ok:
+			ok = false
+			if i < cmds.size() - 1:
+				parts.append("> batch stopped at [%d]; %d command(s) not run" % [i, cmds.size() - 1 - i])
+			break
+	_write_state(id, ok, "batch:" + last, "\n\n".join(parts))
+	_last_id = id
+
+
+# The one place a command runs, so the single and batched forms cannot drift.
+func _run_one(cmd: String, args) -> Dictionary:
+	match cmd:
+		"new":
+			return {"ok": true, "text": await _cmd_new()}
+		"load":
+			return {"ok": true, "text": await _cmd_load(str((args as Dictionary).get("path", "")))}
+	if _session == null:
+		return {"ok": false, "text": "no board - send {\"cmd\":\"new\"} or a load command first"}
+	return _dispatch(cmd, args as Dictionary)
+
 
 func _handle(id: int, cmd: String, args: Dictionary) -> void:
 	print("[bridge] id=%d cmd=%s" % [id, cmd])
@@ -67,18 +114,10 @@ func _handle(id: int, cmd: String, args: Dictionary) -> void:
 			_quitting = true
 			quit()
 			return
-		"new":
-			text = await _cmd_new()
-		"load":
-			text = await _cmd_load(str(args.get("path", "")))
 		_:
-			if _session == null:
-				ok = false
-				text = "no board - send {\"cmd\":\"new\"} or a load command first"
-			else:
-				var res := _dispatch(cmd, args)
-				ok = res.ok
-				text = res.text
+			var res := await _run_one(cmd, args)
+			ok = res.ok
+			text = res.text
 	_write_state(id, ok, cmd, text)
 	_last_id = id
 
@@ -90,6 +129,12 @@ func _dispatch(cmd: String, args: Dictionary) -> Dictionary:
 			return {"ok": true, "text": BoardView.render_preview(_session)}
 		"focus":
 			return {"ok": true, "text": BoardView.render_focus(_session, str(args.get("unit", "")))}
+		# The two the doc promised and nothing implemented (#613). They cost a few hundred bytes
+		# where the only previous way to ask was `focus`, which renders a 2 KB board to say it.
+		"legal_moves":
+			return {"ok": true, "text": BoardView.render_legal_moves(_session, str(args.get("unit", "")))}
+		"legal_targets":
+			return {"ok": true, "text": BoardView.render_legal_targets(_session, str(args.get("unit", "")))}
 		"move":
 			var r = _session.queue_move(str(args.get("unit", "")), _xy(args))
 			return {"ok": r.ok, "text": _ack(r) + "\n\n" + BoardView.render_preview(_session)}
@@ -102,25 +147,50 @@ func _dispatch(cmd: String, args: Dictionary) -> Dictionary:
 		"rescue":
 			var r = _session.rescue(str(args.get("unit", "")), str(args.get("target", "")))
 			return {"ok": r.ok, "text": _ack(r) + "\n\n" + BoardView.render_preview(_session)}
+		# The squad verbs used to redraw the whole board to report a one-line change. What they
+		# actually changed -- which squads exist and which are spent -- is what the status line on
+		# every frame now says, so the picture is a separate `overview` when it is wanted.
 		"join":
 			var r = _session.join(str(args.get("unit", "")), str(args.get("leader", "")))
-			return {"ok": r.ok, "text": _ack(r) + "\n\n" + BoardView.render_overview(_session)}
+			return {"ok": r.ok, "text": _ack(r)}
 		"leave":
 			var r = _session.leave(str(args.get("unit", "")))
-			return {"ok": r.ok, "text": _ack(r) + "\n\n" + BoardView.render_overview(_session)}
+			return {"ok": r.ok, "text": _ack(r)}
 		"disband":
 			var r = _session.disband(str(args.get("unit", "")))
-			return {"ok": r.ok, "text": _ack(r) + "\n\n" + BoardView.render_overview(_session)}
+			return {"ok": r.ok, "text": _ack(r)}
+		# The six verbs PlaySession has always implemented and _dispatch never exposed -- which is
+		# why a driver asking for `burrow` got `unknown cmd` for a verb the docs list (#613).
+		"guard":
+			var r = _session.guard(str(args.get("unit", "")), str(args.get("target", "")))
+			return {"ok": r.ok, "text": _ack(r) + "\n\n" + BoardView.render_preview(_session)}
+		"overwatch":
+			var r = _session.overwatch(str(args.get("unit", "")), _xy(args))
+			return {"ok": r.ok, "text": _ack(r) + "\n\n" + BoardView.render_preview(_session)}
+		"rally":
+			var r = _session.rally(str(args.get("unit", "")))
+			return {"ok": r.ok, "text": _ack(r) + "\n\n" + BoardView.render_preview(_session)}
+		"reload":
+			var r = _session.reload(str(args.get("unit", "")))
+			return {"ok": r.ok, "text": _ack(r) + "\n\n" + BoardView.render_preview(_session)}
+		"rev":
+			var r = _session.rev(str(args.get("unit", "")))
+			return {"ok": r.ok, "text": _ack(r) + "\n\n" + BoardView.render_preview(_session)}
+		"burrow":
+			var r = _session.burrow(str(args.get("unit", "")))
+			return {"ok": r.ok, "text": _ack(r) + "\n\n" + BoardView.render_preview(_session)}
 		"execute":
 			var r = _session.execute()
 			if not r.ok:
 				return {"ok": false, "text": "> ERROR: " + str(r.error)}
-			return {"ok": true, "text": BoardView.render_result(r.get("events", [])) + "\n\n" + BoardView.render_overview(_session)}
+			# The event log IS the payload of a pass; the board picture that used to follow it was
+			# 45% of all output and repeated terrain nothing had changed (#613).
+			return {"ok": true, "text": BoardView.render_result(r.get("events", []))}
 		"endturn":
 			var r = _session.end_turn()
 			if not r.ok:
-				return {"ok": false, "text": "> " + str(r.error) + "\n\n" + BoardView.render_overview(_session)}
-			return {"ok": true, "text": "Turn -> %s\n\n%s" % [str(r.faction), BoardView.render_overview(_session)]}
+				return {"ok": false, "text": "> " + str(r.error)}
+			return {"ok": true, "text": "Turn -> %s" % str(r.faction)}
 		_:
 			return {"ok": false, "text": "unknown cmd: " + cmd}
 
@@ -168,10 +238,17 @@ func _write_state(id: int, ok: bool, cmd: String, text: String) -> void:
 	if f == null:
 		push_error("[bridge] cannot open state file")
 		return
-	f.store_string("@@ id=%d ok=%d cmd=%s @@\n\n%s\n" % [id, (1 if ok else 0), cmd, text])
+	# The status line rides EVERY frame, failures included -- a refusal is precisely when the caller
+	# needs to know whose turn it is, which squad holds the activation and what is already spent.
+	# Written here rather than per dispatch arm so no arm can forget it (#613).
+	# Composed ONCE and used for both sinks: the frame log is the record of what the caller was
+	# shown, so a status line the log did not carry would make every byte measurement over
+	# playrun/frames/ a measurement of something nobody read.
+	var body := BoardView.render_status(_session) + "\n\n" + text
+	f.store_string("@@ id=%d ok=%d cmd=%s @@\n\n%s\n" % [id, (1 if ok else 0), cmd, body])
 	f.close()
 	if _frames != null:
-		_frames.record(id, ok, cmd, text)
+		_frames.record(id, ok, cmd, body)
 
 # ---- helpers ----
 

--- a/play/play_session.gd
+++ b/play/play_session.gd
@@ -118,6 +118,90 @@ func terrain_at(cell: Vector2i) -> Dictionary:
 	# headless RULES, which is exactly the Law #2 failure the Play API exists to catch.
 	return {"exists": true, "walkable": _board().is_walkable(cell), "cost": cost, "type": kind_name.to_lower()}
 
+# ---- affordances: what may this unit do RIGHT NOW (#613) ----
+#
+# WHY THESE EXIST. Driving the bridge, a third to a half of every command came back refused --
+# `move` 55%, `attack` 61% -- because the only way to find out where a unit could go was to guess a
+# cell and be told no. The rendered board says where everything IS; it never said what is LEGAL.
+#
+# EACH ONE CALLS THE GATE IT IS ANSWERING FOR, and that is the whole design rather than an
+# implementation note. A second reachability walk here would be a second answer to "can this unit
+# stand there" (Law #4), and the way it fails is silent and exact: the API starts offering a cell
+# queue_move refuses, which is the bug these exist to remove, reintroduced one layer up.
+# tests/play/test_affordances.gd drives both sides and asserts they agree cell for cell.
+
+func legal_moves(handle: String) -> Dictionary:
+	var unit := unit_by_handle(handle)
+	var gate := _controllable(unit, handle)
+	if not gate.ok:
+		return gate
+	# THE set queue_move indexes -- not a copy of it. Both come back as Dictionaries keyed by cell
+	# (which is why the gate spells it `.has(dest)`), so the keys ARE the answer.
+	var range_info := RulesService.compute_move_range(unit, _board())
+	var cells: Array[Vector2i] = []
+	cells.assign(range_info.reachable.keys())
+	# Reported separately rather than merged: these are reachable on foot and refused by cohesion,
+	# and "your leader is too far" is a different fix from "that is too far to walk".
+	var leashed: Array[Vector2i] = []
+	leashed.assign(range_info.squad_unreachable.keys())
+	return {"ok": true, "unit": handle, "from": unit.movement.cell, "cells": cells, "leashed": leashed}
+
+
+func legal_targets(handle: String) -> Dictionary:
+	var unit := unit_by_handle(handle)
+	var gate := _controllable(unit, handle)
+	if not gate.ok:
+		return gate
+	if not unit.has_equipped_weapon():
+		return {"ok": false, "error": "%s has no equipped weapon" % handle}
+	var origin := unit.get_projected_destination()
+	var aiming := unit.get_fired_attack()
+	var board := _board()
+	var out: Array[Dictionary] = []
+	# The candidate set is the union over four facings -- what the red overlay draws -- and
+	# can_hit_cell_from is what narrows it to the aim actually available. Both of queue_attack's
+	# gates are applied here in its own order, so a cell offered can never be refused.
+	for aim: Vector2i in Reach.get_all_attack_cells_from(unit, origin, aiming):
+		if not Reach.can_hit_cell_from(unit, origin, aim, aiming, board):
+			continue
+		var victims := RulesService.gather_attack_victims(unit, \
+				Reach.get_affected_cells_from(unit, origin, aim, aiming), board, aiming)
+		if victims.is_empty():
+			continue   # queue_attack refuses an aim that hits nobody; so does this
+		var names: Array[String] = []
+		for v: Unit in victims:
+			names.append(handle_for(v))
+		out.append({"cell": aim, "victims": names})
+	return {"ok": true, "unit": handle, "from": origin, "aims": out}
+
+
+# The turn's own state, which the rendered board has never carried: whose turn it is, which squad
+# holds the activation, what it has queued, and which squads are spent. 43 of the refusals were
+# "another squad is already active" / "already acted" / "not the active faction" and 34 more were
+# "no squad has queued orders" -- every one of them answerable from here, and from state that
+# already exists. Nothing is stored; this is a read.
+func status() -> Dictionary:
+	var active: Squad = squad_manager.active_squad
+	var acted: Array[int] = []
+	var free: Array[int] = []
+	for squad: Squad in squad_manager.squads:
+		if squad.members.is_empty():
+			continue
+		if squad.members[0].get_faction() != turn_manager.active_faction():
+			continue
+		if squad.has_acted:
+			acted.append(_squad_id(squad))
+		else:
+			free.append(_squad_id(squad))
+	return {
+		"faction": _faction_name(active_faction()),
+		"active_squad": -1 if active == null else _squad_id(active),
+		"queued": 0 if active == null else active.action_queue.size(),
+		"acted": acted,
+		"free": free,
+	}
+
+
 # ---- commands (mutating) — all flow through the real SquadManager (Law #3) ----
 
 func _controllable(unit: Unit, handle: String) -> Dictionary:

--- a/play/play_session.gd
+++ b/play/play_session.gd
@@ -14,6 +14,7 @@ var turn_manager: TurnManager
 var overlay_manager: OverlayManager
 var terrain_states: TerrainStateManager   # twin of game.terrain_states; null on a board built without one
 var board_heights: BoardHeights           # twin of game.board_heights (#257); null board reads flat
+var scenario_data: ScenarioData           # authored scenario metadata (#612); null on fresh new boards
 
 var _handle_by_unit := {}      # Unit -> String (stable display handle)
 var _next_player := 0
@@ -32,6 +33,9 @@ func _init(board: Dictionary) -> void:
 	overlay_manager = board.overlay_manager
 	terrain_states = board.get("terrain_states")
 	board_heights = board.get("board_heights")
+	scenario_data = board.get("scenario")
+	if scenario_data != null and scenario_data.contested:
+		_mission_contested = true
 	for unit in live_units():
 		_register(unit)
 
@@ -565,7 +569,25 @@ func _apply_attack(atk: AttackAction, events: Array[String]) -> void:
 		if weapon != null:
 			weapon.consume_readiness_for(atk.fired_attack as WeaponAttackData)
 
-# ---- mission outcome (#96) ----
+# ---- mission metadata & outcome (#96, #612) ----
+
+func objectives() -> Array[MissionRules.Objective]:
+	var result: Array[MissionRules.Objective] = []
+	if scenario_data != null:
+		result.assign(scenario_data.objectives)
+	return result
+
+func zones() -> Dictionary:
+	return scenario_data.zones if scenario_data != null else {}
+
+func round_limit() -> int:
+	return scenario_data.round_limit if scenario_data != null else 0
+
+func lose_conditions() -> Array[MissionRules.LoseCondition]:
+	var result: Array[MissionRules.LoseCondition] = []
+	if scenario_data != null:
+		result.assign(scenario_data.lose_conditions)
+	return result
 
 # The headless twin of MissionController: the SAME MissionRules call the game makes, with the
 # same caller-held `contested` latch (see MissionRules.evaluate -- a live read could never end a

--- a/tests/play/test_affordances.gd
+++ b/tests/play/test_affordances.gd
@@ -1,0 +1,173 @@
+# legal_moves / legal_targets / status (#613) -- the queries that let a driver ask what is legal
+# instead of guessing a cell and being refused.
+#
+# WHY THE HEADLINE CASES ARE AGREEMENT PROPERTIES RATHER THAN EXAMPLES. Measured over five logged
+# playthroughs, a third to a half of every command came back rejected: `move` 55%, `attack` 61%.
+# These queries exist to remove that, and they only do so while they answer with the SAME predicate
+# the queue gates on. A second reachability walk here would fail silently and exactly -- the API
+# would start offering a cell queue_move refuses, which is the original bug one layer up (Law #4).
+# So the cases below drive BOTH sides and require them to agree cell for cell, in both directions:
+# everything offered is accepted, and everything withheld is refused.
+extends GdUnitTestSuite
+
+const BoardBuilder := preload("res://play/board_builder.gd")
+const PlaySession := preload("res://play/play_session.gd")
+const BoardView := preload("res://play/board_view.gd")
+
+const PLAYER := Team.Faction.PLAYER
+const ENEMY := Team.Faction.ENEMY
+
+var _board: Dictionary
+var _session
+
+
+func before_test() -> void:
+	_board = BoardBuilder.build(self)
+	auto_free(_board.root)
+	BoardBuilder.paint_rect(_board.grid, Rect2i(-2, -2, 12, 12))
+	var p := BoardBuilder.spawn(_board, _data("P1", PLAYER), Vector2i(0, 0))   # -> A
+	var e := BoardBuilder.spawn(_board, _data("E1", ENEMY), Vector2i(2, 0))    # -> a
+	BoardBuilder.arm(p, 6)
+	BoardBuilder.arm(e, 4)
+	_session = PlaySession.new(_board)
+
+
+func _data(name: String, fac: Team.Faction) -> UnitData:
+	return UnitFactory.create_unit_data(Stats.STAT_DEFAULTS.duplicate(), name, fac)
+
+
+# ==============================================================================
+#  The agreement properties
+# ==============================================================================
+
+func test_every_cell_legal_moves_offers_is_one_queue_move_accepts() -> void:
+	var offered: Dictionary = _session.legal_moves("A")
+	assert_bool(offered.ok).is_true()
+	assert_int(offered.cells.size()).override_failure_message(
+		"the fixture unit can reach nowhere, so this case proves nothing").is_greater(0)
+
+	# One at a time, cancelling between, so each is judged from the same starting position.
+	var refused: Array[String] = []
+	for cell: Vector2i in offered.cells:
+		var r: Dictionary = _session.queue_move("A", cell)
+		if not r.ok:
+			refused.append("%s: %s" % [str(cell), str(r.error)])
+		_session.cancel("A")
+	assert_array(refused).override_failure_message(
+		("legal_moves offered cells queue_move then refused, which is the drift these queries "
+		+ "exist to prevent:\n  %s") % "\n  ".join(refused)).is_empty()
+
+
+func test_and_every_cell_it_withholds_is_one_queue_move_refuses() -> void:
+	# The other direction, and the one a too-SMALL answer would slip past: a query that offered
+	# nothing would pass the case above vacuously.
+	var offered: Dictionary = _session.legal_moves("A")
+	var allowed := {}
+	for cell: Vector2i in offered.cells:
+		allowed[cell] = true
+
+	var wrongly_refused: Array[String] = []
+	for y in range(-2, 10):
+		for x in range(-2, 10):
+			var cell := Vector2i(x, y)
+			if allowed.has(cell) or cell == Vector2i(0, 0):
+				continue   # (0,0) is the unit's own cell: refused as "already at", not as unreachable
+			var r: Dictionary = _session.queue_move("A", cell)
+			if r.ok:
+				wrongly_refused.append(str(cell))
+			_session.cancel("A")
+	assert_array(wrongly_refused).override_failure_message(
+		("queue_move accepted cells legal_moves never offered, so the query is blind to part of "
+		+ "the range: %s") % ", ".join(wrongly_refused)).is_empty()
+
+
+func test_every_aim_legal_targets_offers_is_one_queue_attack_accepts() -> void:
+	_session.queue_move("A", Vector2i(1, 0))   # step adjacent to 'a' so there is something to hit
+	var offered: Dictionary = _session.legal_targets("A")
+	assert_bool(offered.ok).is_true()
+	assert_int(offered.aims.size()).override_failure_message(
+		"no aim was offered, so this case proves nothing").is_greater(0)
+
+	var refused: Array[String] = []
+	for aim: Dictionary in offered.aims:
+		var r: Dictionary = _session.queue_attack("A", aim.cell)
+		if not r.ok:
+			refused.append("%s: %s" % [str(aim.cell), str(r.error)])
+		else:
+			_session.cancel("A")
+			_session.queue_move("A", Vector2i(1, 0))   # cancel drops the move too; put it back
+	assert_array(refused).override_failure_message(
+		"legal_targets offered aims queue_attack then refused:\n  %s" % "\n  ".join(refused)).is_empty()
+
+
+func test_a_named_victim_is_the_unit_actually_standing_there() -> void:
+	# The aim list carries victims so a driver can choose a target without a second round trip;
+	# a handle that named the wrong unit would be worse than no handle at all.
+	_session.queue_move("A", Vector2i(1, 0))
+	var offered: Dictionary = _session.legal_targets("A")
+	var found := false
+	for aim: Dictionary in offered.aims:
+		if aim.cell == Vector2i(2, 0):
+			assert_array(aim.victims).contains(["a"])
+			found = true
+	assert_bool(found).override_failure_message(
+		"the enemy's own cell was not among the offered aims").is_true()
+
+
+# ==============================================================================
+#  Status -- the turn state the rendered board never carried
+# ==============================================================================
+
+func test_status_names_the_faction_the_active_squad_and_what_is_queued() -> void:
+	var idle: Dictionary = _session.status()
+	assert_str(str(idle.faction)).is_equal("PLAYER")
+	assert_int(int(idle.active_squad)).override_failure_message(
+		"nothing is queued yet, so no squad should hold the activation").is_equal(-1)
+	assert_int(int(idle.queued)).is_equal(0)
+
+	_session.queue_move("A", Vector2i(1, 0))
+	var armed: Dictionary = _session.status()
+	assert_int(int(armed.active_squad)).override_failure_message(
+		"a queued order did not show up as an active squad").is_not_equal(-1)
+	assert_int(int(armed.queued)).is_greater(0)
+
+
+func test_status_lists_only_the_active_faction_s_squads() -> void:
+	# The enemy's squads are not the caller's business on the player's turn, and listing them is
+	# how "free=" stops meaning "squads you may still order".
+	var st: Dictionary = _session.status()
+	var enemy: Unit = _session.unit_by_handle("a")
+	var enemy_id: int = _session._squad_id(enemy.squad)
+	assert_bool(st.free.has(enemy_id) or st.acted.has(enemy_id)).override_failure_message(
+		"an ENEMY squad appeared in the PLAYER turn's status").is_false()
+
+
+func test_the_rendered_status_says_the_same_thing_it_is_derived_from() -> void:
+	_session.queue_move("A", Vector2i(1, 0))
+	var line := BoardView.render_status(_session)
+	var st: Dictionary = _session.status()
+	assert_str(line).contains("turn=PLAYER")
+	assert_str(line).override_failure_message(
+		"the rendered line does not name the squad status() reports as active"
+		).contains("active=sq%d" % int(st.active_squad))
+
+
+# ==============================================================================
+#  The refusals a driver actually hit
+# ==============================================================================
+
+func test_asking_about_a_unit_you_may_not_command_answers_why() -> void:
+	# Both queries route through the same _controllable gate the mutating verbs use, so the reason
+	# a query refuses and the reason an order refuses are the same sentence.
+	var r: Dictionary = _session.legal_moves("a")   # enemy, on the player's turn
+	assert_bool(r.ok).is_false()
+	assert_str(str(r.error)).contains("active faction")
+
+
+func test_a_spent_squad_is_refused_by_the_query_as_well_as_the_order() -> void:
+	_session.queue_move("A", Vector2i(1, 0))
+	_session.execute()
+	var r: Dictionary = _session.legal_moves("A")
+	assert_bool(r.ok).override_failure_message(
+		"a spent squad was still offered moves").is_false()
+	assert_str(str(r.error)).contains("already acted")

--- a/tests/play/test_affordances.gd.uid
+++ b/tests/play/test_affordances.gd.uid
@@ -1,0 +1,1 @@
+uid://t13ojswyg42m

--- a/tests/play/test_bridge_exposes_every_verb.gd
+++ b/tests/play/test_bridge_exposes_every_verb.gd
@@ -1,0 +1,105 @@
+# Every command PlaySession implements has a bridge arm that reaches it (#613).
+#
+# WHY THIS IS A LAW. PlaySession grew guard/overwatch/rally/reload/rev/burrow and _dispatch was
+# never widened, so the bridge exposed 12 of 18 verbs -- silently, because nothing fails when a
+# verb is merely unreachable. It surfaced when a driver playing Level_1 asked for `burrow`, a verb
+# docs/play-api.md lists, and got `unknown cmd`. That is the whole failure mode: the session is
+# correct, the doc is correct, and the one line joining them is missing.
+#
+# It is a SPELLING check over the bridge's source, for the same reason the preload law is: the
+# bridge is a SceneTree script that owns the process and polls a file, so there is no seam to call
+# _dispatch through from a suite. Reading the text is what is available, and it is enough -- what
+# can rot is an arm going missing, and that is visible in the text.
+extends GdUnitTestSuite
+
+const BRIDGE := "res://play/play_bridge.gd"
+const SESSION := "res://play/play_session.gd"
+
+# Session methods that are NOT player commands, each with the reason it is not one. A method added
+# here without a reason is the loophole this list would otherwise become.
+const NOT_COMMANDS := {
+	"preview": "dispatched, but named differently in the session (preview() is the query)",
+	"execute": "dispatched",
+	"end_turn": "dispatched as `endturn`",
+	"legal_moves": "dispatched",
+	"legal_targets": "dispatched",
+	"status": "rides every frame rather than being asked for",
+	"cancel": "dispatched",
+	"join": "dispatched",
+	"leave": "dispatched",
+	"disband": "dispatched",
+	"rescue": "dispatched",
+	"queue_move": "dispatched as `move`",
+	"queue_attack": "dispatched as `attack`",
+	"objectives": "read by the view, not ordered",
+	"zones": "read by the view, not ordered",
+	"round_limit": "read by the view, not ordered",
+	"lose_conditions": "read by the view, not ordered",
+	"mission_outcome": "read by the view, not ordered",
+	"mission_tag": "read by the view, not ordered",
+	"terrain_at": "read by the view, not ordered",
+	"live_units": "read by the view, not ordered",
+	"handle_for": "read by the view, not ordered",
+	"unit_by_handle": "read by the view, not ordered",
+	"active_faction": "read by the view, not ordered",
+}
+
+
+func _source(path: String) -> String:
+	var text := FileAccess.get_file_as_string(path)
+	assert_str(text).override_failure_message("could not read %s" % path).is_not_empty()
+	return text
+
+
+# The verbs a player can order: public session methods returning a result Dictionary, minus the
+# declared non-commands above.
+func _session_verbs() -> PackedStringArray:
+	var out: PackedStringArray = []
+	var rx := RegEx.create_from_string("(?m)^func ([a-z][a-z_]*)\\(")
+	for m: RegExMatch in rx.search_all(_source(SESSION)):
+		var name := m.get_string(1)
+		if name.begins_with("_") or NOT_COMMANDS.has(name):
+			continue
+		out.append(name)
+	return out
+
+
+func test_every_session_verb_has_a_bridge_arm() -> void:
+	var bridge := _source(BRIDGE)
+	var missing: Array[String] = []
+	for verb: String in _session_verbs():
+		if not bridge.contains('"%s"' % verb):
+			missing.append(verb)
+	assert_array(missing).override_failure_message(
+		("PlaySession implements these and the bridge cannot reach them, so a caller asking for "
+		+ "one gets `unknown cmd` for a verb the docs list: %s\n"
+		+ "Add a _dispatch arm, or -- if it genuinely is not a player command -- add it to "
+		+ "NOT_COMMANDS with the reason.") % ", ".join(missing)).is_empty()
+
+
+func test_the_six_that_were_missing_are_reachable() -> void:
+	# Named explicitly rather than left to the law above, because these are the ones a real run hit
+	# and a regression here should say so by name.
+	var bridge := _source(BRIDGE)
+	var gone: Array[String] = []
+	for verb: String in ["guard", "overwatch", "rally", "reload", "rev", "burrow"]:
+		if not bridge.contains('"%s"' % verb):
+			gone.append(verb)
+	assert_array(gone).override_failure_message(
+		"verbs that #613 wired are unreachable again: %s" % ", ".join(gone)).is_empty()
+
+
+func test_the_scan_actually_found_verbs() -> void:
+	# Non-vacuity: let the regex rot, or NOT_COMMANDS swallow everything, and the law above passes
+	# over an empty list.
+	assert_int(_session_verbs().size()).override_failure_message(
+		"the verb scan matched nothing -- the regex or NOT_COMMANDS has rotted").is_greater(5)
+	# ...and NOT_COMMANDS must describe methods that EXIST; a stale entry is an exemption guarding
+	# nothing, and worse, one that could hide a verb added later under the same name.
+	var session := _source(SESSION)
+	var stale: Array[String] = []
+	for name: String in NOT_COMMANDS:
+		if not session.contains("func %s(" % name):
+			stale.append(name)
+	assert_array(stale).override_failure_message(
+		"declared in NOT_COMMANDS but no longer a session method: %s" % ", ".join(stale)).is_empty()

--- a/tests/play/test_bridge_exposes_every_verb.gd.uid
+++ b/tests/play/test_bridge_exposes_every_verb.gd.uid
@@ -1,0 +1,1 @@
+uid://b6gk84ies0fu1

--- a/tests/play/test_play_session.gd
+++ b/tests/play/test_play_session.gd
@@ -251,3 +251,56 @@ func test_join_and_leave_squad() -> void:
 	var left: Dictionary = sess.leave(mate_h)
 	assert_bool(left.ok).is_true()
 	assert_bool(mate.has_squad()).is_false()
+
+# #612: Scenario objectives, zones and lose conditions are retained and surfaced in the overview.
+func test_scenario_objectives_and_zones_surface_in_overview() -> void:
+	var src: Dictionary = BoardBuilder.build(self, "MissionRoot")
+	auto_free(src.root)
+	BoardBuilder.paint_rect(src.grid, Rect2i(0, 0, 8, 8))
+	var scenario := ScenarioData.new()
+	scenario.tile_data = src.grid.tile_map_data
+	scenario.active_faction = PLAYER
+	scenario.scenario_name = "test_mission"
+	scenario.objectives.assign([MissionRules.Objective.EXTRACT, MissionRules.Objective.CAPTURE])
+	scenario.zones = {
+		"CapPoint": {
+			"kind": ZoneManager.Kind.CAPTURE,
+			"cells": [Vector2i(2, 2), Vector2i(2, 3)],
+		},
+		"ExitPoint": {
+			"kind": ZoneManager.Kind.EXTRACTION,
+			"cells": [Vector2i(5, 5)],
+		},
+	}
+	scenario.round_limit = 8
+	scenario.lose_conditions.assign([MissionRules.LoseCondition.ROUND_LIMIT])
+	var entry := ScenarioUnitEntry.new()
+	entry.unit_data = _data("Runner", PLAYER)
+	entry.cell = Vector2i(1, 1)
+	scenario.unit_entries.append(entry)
+
+	var dst: Dictionary = BoardBuilder.build(self, "MissionDst")
+	auto_free(dst.root)
+	var spawned: Array = await BoardBuilder.apply_scenario(dst, scenario)
+	assert_int(spawned.size()).is_equal(1)
+
+	var sess = PlaySession.new(dst)
+	assert_object(sess.scenario_data).is_same(scenario)
+	assert_int(sess.objectives().size()).is_equal(2)
+	assert_int(sess.round_limit()).is_equal(8)
+	assert_int(sess.lose_conditions().size()).is_equal(1)
+	assert_bool(sess.zones().has("CapPoint")).is_true()
+
+	var text: String = BoardView.render_overview(sess)
+	assert_str(text).contains("Mission: EXTRACT + CAPTURE")
+	assert_str(text).contains("limit: 8 rounds")
+	assert_str(text).contains("CAPTURE  \"CapPoint\"  (2,2) (2,3)")
+	assert_str(text).contains("EXTRACT  \"ExitPoint\"  (5,5)")
+	assert_str(text).contains("FAIL IF  Time ran out.")
+	assert_str(text).contains("progress: not scored headlessly (#46)")
+	# Grid overlay marks capture 'C' and extraction 'E'
+	assert_str(text).contains(".C")
+	assert_str(text).contains(".E")
+	assert_str(text).contains("C = capture zone")
+	assert_str(text).contains("E = extract zone")
+


### PR DESCRIPTION
**Based on `agy-playtest`**, so it carries #612's mission readout — the baseline runs had it, and the re-test needs to compare like with like.

## What the logs said

I filed #613 after driving the bridge myself: 88% of output was redrawn boards. Five runs from a different model (Gemini on `Level_1`) confirm that generalises — **70–94% redraw** — and surface something the issue missed.

**A third to a half of every command was rejected.**

| run | frames | failed |
|---|---|---|
| 122325 | 477 | 144 (30%) |
| 115811 | 333 | 168 (50%) |
| 120445 | 261 | 143 (54%) |

`move` 55%, `attack` 61%, `execute` 44%. One run called `load` **23 times** — restarting the level rather than recovering. Grouped by cause:

| n | error |
|---|---|
| 62 | `cannot reach (X,Y)` / `cannot hit (X,Y) from (X,Y)` |
| 43 | `another squad is already active` / `already acted` / `not the active faction` |
| 34 | `no squad has queued orders` |

## Both problems have one root cause

Grep a rendered frame for `acted`, `active` or `queued`: nothing comes back. The 3 KB board carries positions, HP, weapons and zones and **no activation state at all** — so a driver had to hold all of it in memory across hundreds of calls, with 3 KB of redraw between each. The render was expensive *and* omitted exactly what the API validates against.

So this isn't "send fewer bytes". It's **send the bytes that answer the next question**.

## Changes

- **`legal_moves` / `legal_targets`** — promised in `docs/play-api.md` since the API was designed, never implemented. **Each calls the predicate its own gate calls** (`compute_move_range`; `can_hit_cell_from` + `gather_attack_victims`), because a second derivation fails silently and exactly: the API would start offering a cell `queue_move` refuses, which is the bug being fixed reintroduced one layer up (Law #4).
- **A status line on every frame**, failures included, since a refusal is when it's most wanted:
  `[turn=PLAYER  active=sq4(2 queued)  free=sq5,sq6  acted=sq7]`
  Written in `_write_state` so no dispatch arm can forget it. Nothing new is stored — every field is a read of existing state.
- **`execute` / `endturn` / `join` / `leave` / `disband` stop redrawing** — 63% of all output, repeating terrain nothing changed. `overview` stays, on request.
- **Batching** — `{"id": N, "cmds": [...]}`, one round trip instead of one per command. **Stops at the first failure**: a refusal is nearly always a wrong belief about turn state, so everything after it rests on the same wrong belief.
- **The six verbs `PlaySession` implements and `_dispatch` never exposed** — `guard`, `overwatch`, `rally`, `reload`, `rev`, `burrow`. The bridge reached 12 of 18; `unknown cmd: burrow` for a documented verb is one of the failures above.

## Measured, driving the real bridge on Level_1 afterwards

| | before | after |
|---|---|---|
| `endturn` | 3057 B | **96 B** (32×) |
| `execute` | 1807 B | ~250 B in-batch |
| "where can this unit go" | 2.2 KB (`focus`) | **~300 B** |

Cell lists group by row with runs collapsed (`y=8: 22-25`), so a range reads as a *shape*. Deliberately not `_format_cells`, which stays the spelling for an enumeration (zone cells, read one at a time) — the two answer different questions and the split is declared.

## Verification

- `tests/play` **59/59**.
- **Falsified in both directions**, because a one-directional agreement test passes vacuously on an empty answer: a mutant offering one cell too many reds `test_every_cell_legal_moves_offers_is_one_queue_move_accepts` *and nothing else*; a mutant withholding one reds `test_and_every_cell_it_withholds_is_one_queue_move_refuses` *and nothing else*.
- `test_bridge_exposes_every_verb.gd` is the law that would have caught `burrow`: every session verb needs a dispatch arm or a declared reason it isn't a command.
- Batch stop-on-failure driven live: `> batch stopped at [1]; 1 command(s) not run`.

Two bugs of mine were caught by these before they could ship: `reachable`/`squad_unreachable` are Dictionaries keyed by cell, not Arrays (which is why the gate spells it `.has()`), and the verb law's own non-vacuity case caught a regex escaping error on its first run.

## Next

The point of this is an A/B: a fresh Gemini run on the same level, measured with the same script over `playrun/frames/`. `frame_log.gd` is deliberately untouched so both runs read identically. **If the re-test shows the driver calling `overview` after every `execute`, the redraw has simply moved and dropping it was wrong** — that's the result worth watching for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZHJ7AuFedPCURFKoY9xX6
