### PR TITLE
#665: headless play gets an opponent, and endturn says what it did

### DIFF
--- a/Classes/ai/AIController.gd
+++ b/Classes/ai/AIController.gd
@@ -41,21 +41,52 @@ func set_ai_factions(factions: Array[Team.Faction]) -> void:
 	for faction in factions:
 		_enabled[faction] = true
 
+# WHICH SQUADS a faction still has to act with. Static and game-free because the headless Play
+# API takes an AI turn too (#665), and "which squads act" must have ONE answer -- a second walk
+# would drift the moment either side grew a skip condition (Law #4). What genuinely differs
+# between the two callers is PRESENTATION (camera, pacing) and EXECUTION (animated orders versus
+# the headless resolve), and those stay at the callers where they belong.
+#
+# The caller must STILL revalidate inside its loop: acting with one squad can kill another's
+# leader or disband it outright, so this is the starting list, not a promise about later.
+static func actable_squads(faction: Team.Faction, squad_manager: SquadManager) -> Array[Squad]:
+	var out: Array[Squad] = []
+	for squad: Squad in squad_manager.squads.duplicate():
+		if is_squad_actable(squad, faction):
+			out.append(squad)
+	return out
+
+
+static func is_squad_actable(squad: Squad, faction: Team.Faction) -> bool:
+	if not is_instance_valid(squad) or squad.has_acted:
+		return false
+	if squad.leader == null or squad.leader.get_faction() != faction:
+		return false
+	return squad.leader.is_active()
+
+
+# ONE squad's DECISION -- the archetype call, and the stale-pick reset that has to precede it.
+# No camera, no pacing, no execution: the caller owns those. Orders still reach the board only
+# through SquadManager.queue_action inside the archetype, so Law #3 is unaffected by the split.
+static func plan_squad(squad: Squad, board: BoardContext, squad_manager: SquadManager) -> void:
+	for member in squad.get_members():
+		member.active_attack = null   # fresh pick each turn -- a stale winner from last turn would skew reach queries (mirrors _begin_attack's reset)
+	AIArchetype.resolve(squad.archetype).call(squad, board, squad_manager)
+
+
 func take_faction_turn(faction: Team.Faction, board: BoardContext) -> void:
-	for squad in game.squad_manager.squads.duplicate():
+	for squad in actable_squads(faction, game.squad_manager):
 		# The mission can end mid-turn -- this squad's pass may have wiped the player. Stop
 		# issuing orders behind the end-of-mission card (#96).
 		if game.mission_controller.is_over():
 			return
-		if not is_instance_valid(squad) or squad.has_acted:
-			continue
-		if squad.leader.get_faction() != faction or not squad.leader.is_active():
+		# Revalidated per iteration, not merely filtered once above: the squad that just acted
+		# may have downed this one's leader.
+		if not is_squad_actable(squad, faction):
 			continue
 
 		await game.camera_controller.pan_to(squad.get_leader())
-		for member in squad.get_members():
-			member.active_attack = null   # fresh pick each turn -- a stale winner from last turn would skew reach queries (mirrors _begin_attack's reset)
-		AIArchetype.resolve(squad.archetype).call(squad, board, game.squad_manager)
+		plan_squad(squad, board, game.squad_manager)
 		# The plan is on screen now -- queueing repaints the queue panel, path arrows, ghosts and
 		# target markers synchronously -- so hold before resolving it (#118). Skipped when the squad
 		# only holds position: there is nothing to read, and dead air per squad is the complaint.

--- a/docs/play-api.md
+++ b/docs/play-api.md
@@ -143,10 +143,42 @@ line plus the two affordance queries: guessing at reach (62), not knowing which 
 which held the activation (43), and executing with nothing queued (34). The rendered board carried
 none of it.
 
-**Batching.** `{"id": N, "cmds": [{...}, {...}]}` runs a list in order and returns one envelope, for
-callers where a round trip costs more than the bytes do. It **stops at the first failure**: a refusal
-is nearly always a wrong belief about turn state, so everything after it rests on the same wrong
-belief.
+**Batching — and this is how you should drive the bridge, not a feature to reach for occasionally.**
+`{"id": N, "cmds": [{...}, {...}]}` runs a list in order and returns one envelope. It **stops at the
+first failure**: a refusal is nearly always a wrong belief about turn state, so everything after it
+rests on the same wrong belief.
+
+Use `play/send.sh`, which does the write-and-poll:
+
+```bash
+play/send.sh overview
+play/send.sh move '{"unit":"A","x":22,"y":7}'
+play/send.sh --batch '[{"cmd":"legal_moves","args":{"unit":"A"}},{"cmd":"preview"}]'
+```
+
+**Why this matters more than convenience (#666).** The protocol is write-then-poll, and every
+playtest driver measured so far wrote its own poller in Python and ran it in a loop — 69 of 72 shell
+calls in one logged run, 54 of 61 in another. The single run that batched aggressively needed
+**three** shell commands and no Python at all. The scripting tracks round-trip count and nothing
+else. An agent that must run arbitrary `python3` cannot be given a narrow permission allowlist, so an
+unattended playtest needs blanket approval — which removes the guard that stops a session that is
+supposed to be *playing* the game from editing it. One batch per turn, through `send.sh`, keeps the
+whole allowlist to two entries.
+
+**The opponent acts (#665).** `endturn` runs the incoming faction's AI when the board declares it in
+`ScenarioData.ai_factions`, and reports what it did as an event log — the same account `execute`
+gives of your own pass:
+
+```
+Turn -> PLAYER
+  b moves to (22, 16)
+  d moves to (18, 15)
+  Thug6 revs up
+```
+
+Before this, `end_turn` advanced the faction and nothing else: the enemy stood still for the whole
+match. Playtest reports read like real engagements because the counters in them are derived from the
+driver's *own* attacks during resolution, never an enemy taking a turn.
 
 **Targeting.** Commands use **game coordinates** (no rebasing — one coordinate system kills a whole bug
 class). The board carries x / y rulers; exact targets are confirmed by the affordance overlay plus a

--- a/play/play_bridge.gd
+++ b/play/play_bridge.gd
@@ -190,7 +190,21 @@ func _dispatch(cmd: String, args: Dictionary) -> Dictionary:
 			var r = _session.end_turn()
 			if not r.ok:
 				return {"ok": false, "text": "> " + str(r.error)}
-			return {"ok": true, "text": "Turn -> %s" % str(r.faction)}
+			# WHAT THE OPPONENT DID (#664/#665). #613 stopped redrawing the board here, and the
+			# measured consequence was drivers buying a 3 KB overview after every hand-off -- the
+			# pre-registered guard caught it at 1.12 overviews per execute. The cause was not the
+			# missing picture: it was that an AI turn mutated the board and said nothing, so there
+			# was no way to learn what happened except to look at everything.
+			#
+			# The answer is the one `execute` already proved sufficient -- an EVENT LOG. Across
+			# both treated runs, zero batches called `overview` after an execute, because the log
+			# accounts for the pass. The same account, for the enemy's pass, costs a few hundred
+			# bytes against a board redraw.
+			var moves: Array = r.get("ai_events", [])
+			if moves.is_empty():
+				return {"ok": true, "text": "Turn -> %s\n  (nothing happened)" % str(r.faction)}
+			return {"ok": true, "text": "Turn -> %s\n%s"
+					% [str(r.faction), BoardView.render_result(moves)]}
 		_:
 			return {"ok": false, "text": "unknown cmd: " + cmd}
 

--- a/play/play_session.gd
+++ b/play/play_session.gd
@@ -722,4 +722,64 @@ func end_turn() -> Dictionary:
 		turn_manager.end_turn(board.present_factions())
 	var faction := turn_manager.active_faction()
 	squad_manager.reset_faction_actions(faction)
-	return {"ok": true, "faction": _faction_name(faction)}
+
+	# THE OPPONENT ACTS (#665). Until this existed, a headless "playthrough" was played against a
+	# stationary board: end_turn advanced the faction and nothing else, so every enemy sat still
+	# for the whole match while the reports read like real engagements -- the counters in them are
+	# derived from the DRIVER's own attacks during resolution, never an enemy taking a turn.
+	#
+	# Which factions are AI is not a new flag: ScenarioData.ai_factions already declares it per
+	# board (#150), and both shipped missions declare ENEMY. A board built without a scenario (the
+	# test fixtures) declares nobody and is unaffected.
+	#
+	# Loops, because several AI factions can follow one another, and re-reads the faction each pass
+	# rather than assuming one hand-off.
+	var log: Array[String] = []
+	while _is_ai_faction(turn_manager.active_faction()):
+		var acting := turn_manager.active_faction()
+		log.append_array(_take_ai_turn(acting))
+		if mission_tag() != "":
+			break
+		turn_manager.end_turn(_board().present_factions())
+		var next := turn_manager.active_faction()
+		if next == acting:
+			break   # nobody else to hand to; do not spin
+		squad_manager.reset_faction_actions(next)
+	faction = turn_manager.active_faction()
+	return {"ok": true, "faction": _faction_name(faction), "ai_events": log}
+
+
+func _is_ai_faction(faction: Team.Faction) -> bool:
+	return scenario_data != null and scenario_data.ai_factions.has(faction)
+
+
+# One AI faction's whole turn, through the SAME decision the game uses -- AIController's statics,
+# not a headless copy of them (Law #4). What differs here is only what is missing: no camera pan,
+# no pacing beat, and execute() rather than the animated OrderExecutor.
+func _take_ai_turn(faction: Team.Faction) -> Array[String]:
+	var events: Array[String] = []
+	for squad: Squad in AIController.actable_squads(faction, squad_manager):
+		if mission_tag() != "":
+			break
+		# Revalidated per squad for the same reason the game revalidates: the squad that just
+		# acted may have downed this one's leader.
+		if not AIController.is_squad_actable(squad, faction):
+			continue
+		AIController.plan_squad(squad, _board(), squad_manager)
+		if squad_manager.active_squad != squad:
+			# The archetype queued nothing at all (no reachable enemy, nothing fireable). Mark the
+			# squad spent so the faction's turn terminates -- the game reaches the same state via
+			# _end_squad_turn, and without it a hold-only squad would be offered again forever.
+			squad_manager.set_has_acted(squad, true)
+			continue
+		var res := execute()
+		if res.ok:
+			for e in res.get("events", []):
+				events.append(str(e))
+		else:
+			# An AI plan the resolver refuses is a bug worth surfacing, not a silent skip -- the
+			# game's own answer to this (#103) is that an AI squad refused there must still end its
+			# turn, or the identical plan is re-offered every turn forever.
+			events.append("%s squad could not act: %s" % [_faction_name(faction), str(res.error)])
+			squad_manager.set_has_acted(squad, true)
+	return events

--- a/play/send.sh
+++ b/play/send.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Send one command (or a batch) to the headless play bridge and print the reply.
+#
+#     play/send.sh overview
+#     play/send.sh move '{"unit":"A","x":22,"y":7}'
+#     play/send.sh --batch '[{"cmd":"legal_moves","args":{"unit":"A"}},{"cmd":"preview"}]'
+#
+# WHY THIS SHIPS (#666). The bridge is a write-then-poll protocol: write command.json, then wait
+# for state.txt to show your id. That is fine a dozen times and unbearable seventy times, so every
+# playtest driver so far wrote its own poller in Python and ran it in a loop -- 69 of 72 shell
+# calls in one logged run, 54 of 61 in another. The one run that batched aggressively needed three
+# shell commands total and no Python at all.
+#
+# An agent that must run arbitrary python3 cannot be given a narrow permission allowlist, so an
+# unattended playtest needs blanket approval -- which removes the guard that keeps a session that
+# is supposed to be PLAYING the game from editing it. The permission problem and the interface
+# problem are the same problem, and this is the interface half: with this script the whole
+# allowlist is two entries, launching the bridge and running this.
+#
+# Prefer --batch. A turn is usually one batch, and round-trip count is what drove the scripting.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN="$ROOT/playrun"
+CMD="$RUN/command.json"
+STATE="$RUN/state.txt"
+TIMEOUT_S="${SEND_TIMEOUT:-30}"
+
+[ -d "$RUN" ] || { echo "no $RUN -- is the bridge running?" >&2; exit 1; }
+
+# The next id, read from whatever the bridge last answered. Ids must increase or the bridge
+# ignores the command as stale.
+last=$(grep -oE 'id=[0-9]+' "$STATE" 2>/dev/null | tail -1 | cut -d= -f2)
+id=$(( ${last:-0} + 1 ))
+
+if [ "${1:-}" = "--batch" ]; then
+  [ $# -ge 2 ] || { echo "usage: send.sh --batch '<json array of {cmd,args}>'" >&2; exit 1; }
+  printf '{"id":%d,"cmds":%s}' "$id" "$2" > "$CMD"
+else
+  [ $# -ge 1 ] || { echo "usage: send.sh <cmd> ['<json args>']  |  send.sh --batch '<json array>'" >&2; exit 1; }
+  args="${2:-{\}}"
+  printf '{"id":%d,"cmd":"%s","args":%s}' "$id" "$1" "$args" > "$CMD"
+fi
+
+# Poll for OUR id specifically. Matching on "id=$id " with the trailing space is what stops id=1
+# matching the reply to id=12.
+deadline=$(( $(date +%s) + TIMEOUT_S ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if grep -q "id=$id " "$STATE" 2>/dev/null; then
+    cat "$STATE"
+    exit 0
+  fi
+  sleep 0.15
+done
+echo "TIMEOUT after ${TIMEOUT_S}s waiting for id=$id (bridge died? check its stdout)" >&2
+exit 1

--- a/tests/play/test_headless_opponent.gd
+++ b/tests/play/test_headless_opponent.gd
@@ -1,0 +1,125 @@
+# The headless board has an OPPONENT (#665).
+#
+# Until this shipped, PlaySession.end_turn advanced the faction and did nothing else: no AI, no
+# clock tick, nothing. A "playthrough" was played against a stationary board for the whole match,
+# and the playtest reports read like real engagements because the counters in them are derived from
+# the DRIVER's own attacks during resolution -- Law #2's counter machinery working correctly, and
+# never an enemy taking a turn. Two consecutive endturn frames from a logged run, back when endturn
+# still redrew the board, were byte-identical across the hand-off.
+#
+# The cases below are about the WIRE, which is the part that was missing: the decision itself is
+# AIController's and is already covered by tests/ai/. What is new is that the headless session
+# reaches it at all, and stops when it should.
+extends GdUnitTestSuite
+
+const BoardBuilder := preload("res://play/board_builder.gd")
+const PlaySession := preload("res://play/play_session.gd")
+
+const PLAYER := Team.Faction.PLAYER
+const ENEMY := Team.Faction.ENEMY
+
+var _board: Dictionary
+var _session
+
+
+func before_test() -> void:
+	_board = BoardBuilder.build(self)
+	auto_free(_board.root)
+	BoardBuilder.paint_rect(_board.grid, Rect2i(-2, -2, 16, 16))
+	var p := BoardBuilder.spawn(_board, _data("P1", PLAYER), Vector2i(0, 0))     # -> A
+	var e := BoardBuilder.spawn(_board, _data("E1", ENEMY), Vector2i(8, 0))      # -> a, far away
+	BoardBuilder.arm(p, 6)
+	BoardBuilder.arm(e, 4)
+	_session = PlaySession.new(_board)
+
+
+func _data(name: String, fac: Team.Faction) -> UnitData:
+	return UnitFactory.create_unit_data(Stats.STAT_DEFAULTS.duplicate(), name, fac)
+
+
+func _declare_ai(factions: Array) -> void:
+	# ai_factions is the board's own declaration (#150), not a new flag. A fixture board has no
+	# ScenarioData, so one is attached here exactly as a loaded mission would carry it.
+	var data := ScenarioData.new()
+	var list: Array[Team.Faction] = []
+	for f in factions:
+		list.append(f)
+	data.ai_factions = list
+	_session.scenario_data = data
+
+
+# ==============================================================================
+#  The wire
+# ==============================================================================
+
+func test_a_declared_ai_faction_actually_moves_on_its_turn() -> void:
+	_declare_ai([ENEMY])
+	var enemy: Unit = _session.unit_by_handle("a")
+	var before: Vector2i = enemy.movement.cell
+
+	var res: Dictionary = _session.end_turn()
+
+	assert_bool(res.ok).is_true()
+	assert_vector(enemy.movement.cell).override_failure_message(
+		("the enemy did not move on its own turn -- this is the exact state #665 found: end_turn "
+		+ "advanced the faction and the opponent sat still")).is_not_equal(before)
+
+
+func test_the_hand_off_comes_back_to_the_player() -> void:
+	# The AI turn is run INSIDE end_turn and handed on, so one call returns the driver to its own
+	# turn rather than leaving it on the enemy's.
+	_declare_ai([ENEMY])
+	var res: Dictionary = _session.end_turn()
+	assert_str(str(res.faction)).override_failure_message(
+		"end_turn left the board on a faction the driver cannot command").is_equal("PLAYER")
+
+
+func test_what_the_opponent_did_is_reported() -> void:
+	# The events are the whole point of running it: an AI turn that mutated the board silently
+	# would be the #664 problem with extra steps.
+	_declare_ai([ENEMY])
+	var res: Dictionary = _session.end_turn()
+	assert_array(res.get("ai_events", [])).override_failure_message(
+		"the enemy acted and said nothing about it").is_not_empty()
+
+
+func test_a_faction_the_board_does_not_declare_ai_stays_still() -> void:
+	# The inverse, and the guard on every existing fixture: a board that declares nobody -- which
+	# is every test board built by BoardBuilder -- must behave exactly as it did before #665.
+	_declare_ai([])
+	var enemy: Unit = _session.unit_by_handle("a")
+	var before: Vector2i = enemy.movement.cell
+	_session.end_turn()
+	assert_vector(enemy.movement.cell).override_failure_message(
+		"an undeclared faction took an AI turn").is_equal(before)
+
+
+func test_a_board_with_no_scenario_data_at_all_is_unaffected() -> void:
+	# BoardBuilder boards carry no ScenarioData. Reading ai_factions off null must not crash.
+	_session.scenario_data = null
+	var enemy: Unit = _session.unit_by_handle("a")
+	var before: Vector2i = enemy.movement.cell
+	var res: Dictionary = _session.end_turn()
+	assert_bool(res.ok).is_true()
+	assert_vector(enemy.movement.cell).is_equal(before)
+
+
+func test_the_ai_turn_terminates_rather_than_re_offering_a_squad() -> void:
+	# #103's lesson, headless: a squad whose archetype queues nothing must still be marked spent,
+	# or the faction's turn never ends. Driven by ending several turns in a row -- if a squad were
+	# re-offered forever the first call would not return at all.
+	_declare_ai([ENEMY])
+	for i in 3:
+		var res: Dictionary = _session.end_turn()
+		assert_bool(res.ok).override_failure_message(
+			"turn %d did not complete" % i).is_true()
+	# The invariant is that the board stops somewhere the driver can act FROM -- not that it stops
+	# on PLAYER. It legitimately stops on the enemy once the mission is over, because end_turn
+	# refuses to hand off a finished board (that rule predates #665). Asserting PLAYER outright is
+	# what this case did first and it failed on a real VICTORY, which is the content-dependence
+	# tests/README #9 warns about: the fixture is one unit against a rushdown and the counter-kill
+	# arrives on turn 3.
+	var faction := str(_session.status().faction)
+	assert_bool(faction == "PLAYER" or _session.mission_tag() != "").override_failure_message(
+		("the board stopped on %s with the mission still running -- the hand-off is stuck"
+		% faction)).is_true()

--- a/tests/play/test_headless_opponent.gd.uid
+++ b/tests/play/test_headless_opponent.gd.uid
@@ -1,0 +1,1 @@
+uid://ckxb8c717oklf


### PR DESCRIPTION
Closes #665, #664, #666. Three findings from the controlled A/B, in the order they were found — each one uncovered by fixing the one before it.

## 1. There was no opponent (#665)

`play/` never wired `AIController`. `PlaySession.end_turn` advanced the faction and called `reset_faction_actions` — no AI, no clock tick, nothing. **Every enemy stood still for the entire match.**

Verified rather than argued: two consecutive `endturn` frames from a logged run, taken while `endturn` still redrew the board, are byte-identical across the ENEMY→PLAYER hand-off.

What made it invisible is that the playtest reports don't read that way:

> *"Ross moved into melee with the Drill (8 dmg)... Ross took a 6 dmg counter from `b` (down to 14 HP)."*

Every counter there is Law #2's machinery working correctly on the driver's **own** attack. None of it is an enemy acting. I believed those were engagements until I diffed the boards.

`AIController` gains two statics — `actable_squads()` and `plan_squad()` — and `take_faction_turn` is rewritten in terms of them, so *which squads act* and *what a squad decides* have **one** answer across the game and the headless session. What genuinely differs stays at the callers: presentation (camera, pacing) and execution (animated `OrderExecutor` vs the headless resolve). Which factions are AI needs no new flag: `ScenarioData.ai_factions` already declares it per board (#150), and both shipped missions declare ENEMY.

It works — a real hand-off now reports:

```
Turn -> PLAYER
  b moves to (22, 16)     d moves to (18, 15)
  c moves to (22, 18)     Thug6 revs up
  g moves to (16, 9)      ...
```

## 2. The guard from #613 was right, and the fix was an event log (#664)

`overview`-per-`execute` went 0.25 (baseline) → **1.12** (treated), past the 0.67 line I pre-registered as *"the redraw MOVED rather than went away"*.

The sequences said where. **Zero** batches in either treated run called `overview` after an `execute` — the event log is a sufficient account of a pass — and every one followed `endturn`, because an AI turn mutated the board in silence. So `endturn` now returns what `execute` returns.

**A whole turn plus a ten-unit enemy advance is 542 bytes**, against the 3,057-byte board redraw it replaces — and the redraw never said what the enemy did.

My first diagnosis of this was wrong and is corrected on the issue: I wrote that the enemy turn "resolved invisibly" when it did not resolve at all.

## 3. Drivers script because the bridge makes them poll (#666)

| run | arm | shell calls | `python3` |
|---|---|---|---|
| A-1 | pre-#613 | 72 | 69 |
| A-2 | pre-#613 | 61 | 54 |
| **B-1** | #613 | **3** | **0** |
| B-2 | #613 | 43 | 32 |

B-1 played eight turns in three shell commands and drove everything else with plain file read/write. The others wrote pollers, because write-then-poll is fine a dozen times and unbearable seventy. **The scripting tracks round-trip count and nothing else.**

That's a permissions problem wearing an interface problem's clothes: an agent that must run arbitrary `python3` can't be given a narrow allowlist, so an unattended playtest needs blanket approval — removing the guard that stops a session meant to be *playing* the game from editing it. `play/send.sh` ships the write-and-poll so the allowlist is two entries, and `docs/play-api.md` now teaches batch-first instead of presenting batching as an optional feature.

## Verification

- `tests/play` **65/65**.
- **Falsified**: reverting `end_turn` to pre-#665 reds `test_a_declared_ai_faction_actually_moves_on_its_turn`, alone.
- Driven live on `Level_1` through `send.sh`, including a full enemy advance.

**Two of the new cases had to be rewritten mid-build** because they asserted content rather than the seam: the fixture is one unit against a rushdown, the counter-kill lands on turn 3, and "the board ends on PLAYER" is false for a legitimate reason (`end_turn` refuses to hand off a finished mission). The invariant is that it ends somewhere the driver can act from *unless the mission is over*. `tests/README` #9's razor, met the hard way.

## What this means for the next A/B

The comparison we were about to run would have measured a byte displacement on a game with no opponent. It's worth running now. Note the pre-#613 arm (`exp/613-baseline`) is no longer a fair control for anything involving turns, since the opponent only exists on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZHJ7AuFedPCURFKoY9xX6
