### PR TITLE
#419 follow-up: the test script's missing .uid, which dirties every tree

### DIFF
--- a/tests/squad/test_end_of_turn_rows.gd.uid
+++ b/tests/squad/test_end_of_turn_rows.gd.uid
@@ -1,0 +1,1 @@
+uid://c2tbsxop7yk7y


### PR DESCRIPTION
One file, one line. Follow-up defect from #679.

`tests/squad/test_end_of_turn_rows.gd` shipped without its `.uid` sidecar, so Godot mints one the first time it opens the project and **every tree that checks `main` out goes dirty** — which is the completion half of the dirty-tree rule (*"no issue is complete if it can still leave the tree dirty"*). It was the only tracked `.gd` in the repo without a sidecar; I swept the whole tree rather than fixing the one I knew about.

The committed value is the uid Godot already minted, so a tree that already has the file sees no change when this lands.

## Cause, because it is not obvious and will recur

The `--import` pass that minted `Classes/actions/TileHitAction.gd.uid` ran **before** the test file was written — I imported to register the new `class_name`, then wrote the tests. And the headless gdUnit4 runs never mint uids, so nothing for the rest of the branch's life would have created it. `git status` was clean at every commit, and CI was green, because the file simply did not exist anywhere in my worktree.

**The rule worth carrying: a new `.gd` needs an import pass AFTER it is written, not just after a new `class_name`.** The existing note in `CLAUDE.md` ties importing to `class_name` registration, which is what I followed and is why this slipped through.

## Verification

Content-only change to a metadata sidecar — no code path touches it. CI is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
