### PR TITLE
#659 follow-up: the .uid sidecar the commit forgot, and the guard for it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,25 @@ jobs:
             git checkout -- project.godot
           fi
 
+      # AN IMPORT MUST NOT PRODUCE FILES THE COMMIT WAS MISSING (#659 follow-up). Godot mints a
+      # .uid sidecar beside every script the first time it imports one, so a commit that adds a
+      # .gd without its sidecar leaves every clone -- the dev's included -- going dirty by itself
+      # the moment the editor opens. That is the "a dirty tree is a ticket defect at both ends"
+      # rule, and nothing was watching for it: the guard above diffs project.godot alone, which
+      # is a TRACKED file, while a missing sidecar arrives UNTRACKED and shows up in neither
+      # `git diff` nor the test run (the import has already created it by the time gdUnit4 looks,
+      # so an on-disk assertion would pass vacuously in exactly the case it exists to catch).
+      #
+      # Fails rather than warns, unlike its neighbour: this one's cause is always the PR in hand.
+      - name: Guard against sidecars the commit forgot
+        run: |
+          untracked="$(git ls-files --others --exclude-standard)"
+          if [ -n "$untracked" ]; then
+            echo "::error::The import created files that are not committed. A .gd needs its .uid sidecar committed beside it, or every fresh checkout goes dirty on first open. Add these and push:"
+            echo "$untracked"
+            exit 1
+          fi
+
       # THE VERDICT IS gdUnit4'S, NOT THE PROCESS'S -- mirrors tests/run_tests.ps1 (#93).
       # Godot can die with SIGSEGV while tearing the engine down, AFTER every test has run and
       # been counted, which reports failure on a clean pass. Today the full-tree run happens not

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,22 +99,29 @@ jobs:
             git checkout -- project.godot
           fi
 
-      # AN IMPORT MUST NOT PRODUCE FILES THE COMMIT WAS MISSING (#659 follow-up). Godot mints a
-      # .uid sidecar beside every script the first time it imports one, so a commit that adds a
-      # .gd without its sidecar leaves every clone -- the dev's included -- going dirty by itself
-      # the moment the editor opens. That is the "a dirty tree is a ticket defect at both ends"
-      # rule, and nothing was watching for it: the guard above diffs project.godot alone, which
-      # is a TRACKED file, while a missing sidecar arrives UNTRACKED and shows up in neither
-      # `git diff` nor the test run (the import has already created it by the time gdUnit4 looks,
-      # so an on-disk assertion would pass vacuously in exactly the case it exists to catch).
+      # AN IMPORT MUST NOT PRODUCE SIDECARS THE COMMIT WAS MISSING (#659 follow-up). Godot mints a
+      # .uid beside every script (and a .import beside every asset) the first time it imports one,
+      # so a commit that adds a .gd without its sidecar leaves every clone -- the dev's included --
+      # going dirty by itself the moment the editor opens. That is the "a dirty tree is a ticket
+      # defect at both ends" rule, and nothing was watching for it: the guard above diffs
+      # project.godot alone, which is a TRACKED file, while a missing sidecar arrives UNTRACKED and
+      # shows up in neither `git diff` nor the test run (the import has already created it by the
+      # time gdUnit4 looks, so an on-disk assertion would pass vacuously in exactly the case it
+      # exists to catch).
+      #
+      # SCOPED TO THE SIDECAR SUFFIXES, not to "anything untracked", which is what the first cut
+      # said and it reddened instantly: this job downloads the engine to godot-bin/ INSIDE the
+      # working tree, so a bare `git ls-files --others` reports the Godot binary on every run. The
+      # narrow form is the better rule anyway -- it names the thing being guarded, and cannot be
+      # broken again by whatever the workflow drops in the tree next.
       #
       # Fails rather than warns, unlike its neighbour: this one's cause is always the PR in hand.
       - name: Guard against sidecars the commit forgot
         run: |
-          untracked="$(git ls-files --others --exclude-standard)"
-          if [ -n "$untracked" ]; then
-            echo "::error::The import created files that are not committed. A .gd needs its .uid sidecar committed beside it, or every fresh checkout goes dirty on first open. Add these and push:"
-            echo "$untracked"
+          missing="$(git ls-files --others --exclude-standard -- '*.uid' '*.import')"
+          if [ -n "$missing" ]; then
+            echo "::error::The import created sidecars that are not committed. A .gd needs its .uid (and an asset its .import) committed beside it, or every fresh checkout goes dirty on first open. Add these and push:"
+            echo "$missing"
             exit 1
           fi
 

--- a/docs/design/grill-queue.md
+++ b/docs/design/grill-queue.md
@@ -2,7 +2,7 @@
 
 **Status: LIVING LIST (created 2026-07-05 at the dev's request).** The curated queue of design decisions awaiting a grill session — *not* an exhaustive dump of every open fork (each design doc keeps its own). Claude maintains this; when a session completes, its entry moves to **Done** with the date and where the canon landed. Detailed context for the A-items: [coherence-audit-2026-07-05.md](coherence-audit-2026-07-05.md).
 
-**Canon checked through #565 (2026-08-26).**
+**Canon checked through #687 (2026-09-02).**
 
 ## Next up — meaty sessions
 
@@ -18,7 +18,7 @@
 
 ## Quick hits — single-decision scale
 
-*(empty — quick hit 16 resolved 2026-08-09, see Done)*
+17. **The action queue's shape** — [#685](https://github.com/Phaazoid/Godoiosis/issues/685), filed out of [#659](https://github.com/Phaazoid/Godoiosis/issues/659) with the dev's own addendum: *"the action queue could use a visual redesign in general. It's a very old shape - one I hand created pretty early on."* The ticket is a LOOK, so it owes a grill before any plan rather than one built off inferred taste. Not a blank sheet: the CONTENT vocabulary is settled canon ([visual-clarity.md](visual-clarity.md) — volley grouping, derived/indented rows, the `hp->hp` readout, drag-reorder as the order's answer), the clipping has a diagnosis (the panel's containers do not hold their own children), and two filed tickets constrain whatever shape it lands on: [#462](https://github.com/Phaazoid/Godoiosis/issues/462) (which step of a running pass the queue is on) and [#119](https://github.com/Phaazoid/Godoiosis/issues/119) (scrolling back through past queues).
 
 ## Parked — real sessions with prerequisites
 

--- a/tests/ui/test_ui_scales_with_the_window.gd.uid
+++ b/tests/ui/test_ui_scales_with_the_window.gd.uid
@@ -1,0 +1,1 @@
+uid://diev6f1c0uf3w


### PR DESCRIPTION
Follow-up to #684 (merged). Two files and a workflow step.

## The defect

#684 added `tests/ui/test_ui_scales_with_the_window.gd` **without its `.uid` sidecar.** The import that would have minted it ran *before* that file was written — correctly, so `GameSurface`'s `class_name` would register — and never ran again before the commit.

It was the only `.gd` in the repo outside `addons/` without a tracked sidecar, and the symptom is the one you ruled a ticket defect at both ends: **your tree went dirty by itself** the moment the editor opened it. Committed at the exact uid your editor already minted (`uid://diev6f1c0uf3w`), so the untracked copy sitting in your tree now goes **clean on pull** rather than conflicting.

## Why nothing caught it

- The post-import guard already in the workflow diffs `project.godot` — a **tracked** file. A missing sidecar arrives **untracked**, so `git diff` never sees it.
- A gdUnit assertion could not have caught it either: CI imports before tests run, so the file exists by the time anything looks. It would pass vacuously in exactly the case it existed for.

So the guard is a CI step on `git ls-files --others --exclude-standard`, placed after the import and before the test run. It **fails** rather than warns, unlike its neighbour — that one's cause is an addon upgrade unrelated to whichever PR happens to hit it, while this one's cause is always the PR in hand.

**Falsified both ways** in a fresh worktree off `main`:

| | result |
|---|---|
| import on `origin/main`, sidecar absent | regenerates **exactly** that one file, nothing else — so this would have reddened #684 |
| same, once the sidecar is staged | silent — no false positive on a clean tree |

## Also

`docs/design/grill-queue.md` gains #685 (the action queue's redesign). That list aggregates from many source docs and its documented failure mode is going stale from *other* tickets' work — a ticket that explicitly owes a grill has to appear on it. Numbered **17**, not 16: quick hit 16 is a resolved item and reusing the number would read as a reopen. Marker bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
