### PR TITLE
#735: a mission names a Roster, and a Roster is who it offers

### DIFF
--- a/Classes/dev/BoardLint.gd
+++ b/Classes/dev/BoardLint.gd
@@ -47,6 +47,7 @@ static func check(game) -> Array[Dictionary]:
 	_check_placement(game, board, found)
 	_check_cohesion(game, found)
 	_check_look_preset(game, found)
+	_check_roster(game, found)
 	_check_dialog(game, board, found)
 	_check_repaired_content(found)
 
@@ -196,6 +197,25 @@ static func _check_look_preset(game, found: Array[Dictionary]) -> void:
 	_add(found, Severity.DEGRADES,
 		"This board names look preset '%s', which no longer exists -- it opens with the default look."
 			% preset)
+
+
+# A named roster that no longer resolves (#735). BLOCKS, where the look preset directly above is
+# DEGRADES, and the difference is the whole reason they are separate rules: a board with no look
+# wears the default and plays exactly as authored, while a board whose pool cannot be found has no
+# pool -- the pre-mission phase would offer nobody. Substituting some other roster would hand the
+# player a different mission, so RosterCatalog.resolve has no default to fall back to.
+#
+# saved_rosters() rather than resolve(), for _check_look_preset's reason one rule up: resolve's job
+# is to push_error, and a lint must not have side effects. It is also the same question the
+# Properties dropdown asks, so a name the row offers is always a name this accepts.
+static func _check_roster(game, found: Array[Dictionary]) -> void:
+	var scenario_manager: ScenarioManager = game.scenario_manager
+	var roster: String = scenario_manager.current_roster
+	if roster == "" or RosterCatalog.saved_rosters().has(roster):
+		return
+	_add(found, Severity.BLOCKS,
+		("This board names roster '%s', which does not exist -- the pre-mission phase has no units "
+		+ "to offer.") % roster)
 
 
 # #397, the two checks deferred from #390. Both read the SAME stores the director reads

--- a/Classes/dev/ScenarioTool.gd
+++ b/Classes/dev/ScenarioTool.gd
@@ -23,10 +23,14 @@ var _lose_boxes := {}        # MissionRules.LoseCondition -> CheckBox
 var _lose_warning: Label
 var _round_limit_spin: SpinBox
 var _look_row: HBoxContainer
+var _roster_row: HBoxContainer
 var _camera_row: HBoxContainer
 var _report_box: VBoxContainer
 
 const NO_LOOK_LABEL := "(none - default)"
+# Not "(none - default)" like the look above: there is no default roster to fall back to, and a
+# board with no roster is the ordinary board rather than a degraded one (#735).
+const NO_ROSTER_LABEL := "(none - no pre-mission)"
 
 # The report's three voices. Red is the same literal _refresh_objective_warning uses below -- the
 # live objective warning and a BLOCKS finding say the same kind of thing and must look the same.
@@ -45,6 +49,7 @@ func init(p_scenario_manager: ScenarioManager, p_game, header: ScenarioHeader) -
 	_build_lose_conditions()
 	_build_check_section()
 	refresh_look_row()
+	refresh_roster_row()   # between the two: each row pins itself to index 0, so this is the order
 	refresh_camera_row()   # last, so it lands above the look row and stays there on every rebuild
 	# A LOAD is the one thing that makes a report describe a board that is no longer on screen, and
 	# board_loaded is the only signal that means exactly that -- the header's file_changed also
@@ -73,6 +78,35 @@ func refresh_look_row() -> void:
 	_look_row = DevWidgets.add_option(self, "Look preset", options,
 		current if current != "" else NO_LOOK_LABEL, _on_look_picked)
 	move_child(_look_row, 0)
+
+
+# Which roster this board offers (#735). The look row's shape exactly, and for the same reason:
+# a NAME resolved against a folder, so the dropdown lists the folder and a stale name stays
+# selectable rather than silently reading as "(none)".
+#
+# No live side-effect twin to the look row's apply_preset call: nothing reads a roster until #737,
+# and there is nothing on screen a pick could change.
+func refresh_roster_row() -> void:
+	if _roster_row != null:
+		remove_child(_roster_row)
+		_roster_row.queue_free()
+	var options: Array[String] = [NO_ROSTER_LABEL]
+	options.append_array(RosterCatalog.saved_rosters())
+	var current: String = scenario_manager.current_roster
+	if current != "" and not options.has(current):
+		options.append(current)
+	_roster_row = DevWidgets.add_option(self, "Roster", options,
+		current if current != "" else NO_ROSTER_LABEL, _on_roster_picked)
+	DevWidgets.apply_tooltip(_roster_row, DevWidgets.wrap_tooltip(
+		"Who the player may bring into this mission, and the loose gear on offer. "
+		+ "(none) means this board has no pre-mission phase: it keeps its authored cast and "
+		+ "starts at turn 1."))
+	move_child(_roster_row, 0)
+
+
+func _on_roster_picked(picked: String) -> void:
+	scenario_manager.current_roster = "" if picked == NO_ROSTER_LABEL else picked
+	_mark()
 
 
 func _on_look_picked(picked: String) -> void:
@@ -168,6 +202,7 @@ func refresh_on_show() -> void:
 	refresh_objectives()
 	refresh_lose_conditions()   # ...and what loses it (#101)
 	refresh_look_row()   # a board load changes which preset this board wears
+	refresh_roster_row()   # ...and who it offers (#735)
 	refresh_camera_row()   # ...and where it opens (#234)
 
 

--- a/Classes/flow/Roster.gd
+++ b/Classes/flow/Roster.gd
@@ -1,0 +1,39 @@
+extends Resource
+class_name Roster
+
+# Who a mission OFFERS, and what loose gear it offers them (#735, the foundation of #731's
+# pre-mission phase). A mission names one of these; the player picks from it, up to the mission's
+# cap, and places the picks in the deployment zone. Nothing reads a roster to spawn from yet --
+# that is #737/#738. Rosters are PLURAL and per-mission on purpose (dev, 2026-09-04): the same
+# characters can carry different state in different missions, which is the balance-testing lever.
+#
+# A roster entry IS a ScenarioUnitEntry, deliberately, and that is the whole design. #731 ruling 1
+# made `cell`/`squad_id`/`is_leader` OUTPUTS of the pre-mission phase, so an entry that has not been
+# deployed yet is just that resource with those three unset -- and at commit the board's
+# unit_entries is this list with them filled in. Reusing it also inherits #177's reference/snapshot
+# fork for free: an entry with state_saved=false points at a character file whose starting kit is
+# the whole answer, which is exactly what an unauthored roster member should be.
+#
+# The alternative -- factoring the persistent block out into a shared nested resource -- was
+# rejected on migration cost: 13 .tres embed ScenarioUnitEntry as sub-resources, plus every user://
+# save slot, and Godot drops properties a resource no longer declares SILENTLY. All of them would
+# read as defaults with no error anywhere (CLAUDE.md's retyping trap; predates_corner_heights()
+# exists because of it).
+#
+# The cost of that reuse is that a roster file can express nonsense -- a roster member mid-Crisis,
+# or holding a Guard on a unit that is not on any board. RosterLint is what pays it.
+#
+# No display_name: a roster's identity is its FILENAME, the way a LookPreset's is. RosterCatalog
+# keys on it, the Properties dropdown lists it, and ScenarioData stores that name. One name, one
+# place to disagree with.
+
+@export var entries: Array[ScenarioUnitEntry] = []
+
+# Loose gear this mission's roster starts with. Same element type as ScenarioUnitEntry.inventory
+# and UnitData.starting_inventory, and the same authoring source: standalone .tres out of
+# Resources/Weapons/WeaponVariants/, Resources/Armor/ and the rune variants. Granted to a unit as a
+# copy_equippable() copy at deploy time, never shared -- the rule starting_inventory already states.
+#
+# Loose MODS are not here and cannot be: WeaponModData extends Resource, not Item, so it has no
+# icon, no description, and structurally cannot sit in an inventory. #732 carries both halves.
+@export var stash: Array[EquippableData] = []

--- a/Classes/flow/Roster.gd.uid
+++ b/Classes/flow/Roster.gd.uid
@@ -1,0 +1,1 @@
+uid://cwhromthxtouo

--- a/Classes/flow/RosterCatalog.gd
+++ b/Classes/flow/RosterCatalog.gd
@@ -1,0 +1,45 @@
+extends Object
+class_name RosterCatalog
+
+# "Which rosters exist, and what does this NAME point at?" (#735). Deliberately shaped like
+# LookKnobs' preset lookup rather than like UnitCatalog/ArmorCatalog, and the difference matters:
+# ResourceCatalog.by_name keys by the resource's own display_name, and its comment says outright
+# that two resources sharing a name COLLAPSE into one entry. A roster is addressed by the name a
+# scenario stores, so a collapse would silently hand a mission the wrong pool. Filename IS the
+# identity here, exactly as it is for a look preset -- so a roster carries no display_name at all.
+const ROSTER_DIR := "res://Resources/Rosters/"
+
+# The dropdown's source and the lint's source: one question, so a name the Properties row offers is
+# always a name the lint accepts. Through ResourceDir, never DirAccess -- an exported build returns
+# packed names and every catalog that bypasses it silently empties (CLAUDE.md).
+static func saved_rosters() -> Array[String]:
+	var names: Array[String] = []
+	for file: String in ResourceDir.files_with_extension(ROSTER_DIR, ".tres"):
+		names.append(file.trim_suffix(".tres"))
+	return names
+
+static func roster_path(name: String) -> String:
+	return "%s%s.tres" % [ROSTER_DIR, name]
+
+# The one side-effecting reader: it push_errors and returns null, the way LookKnobs.resolve
+# push_errors and falls back. Nothing in a lint may call this (BoardLint's own rule) -- a lint asks
+# saved_rosters() instead.
+#
+# There is no default-roster fallback, and that asymmetry with LookKnobs is deliberate: a board
+# with no look wears the default look and plays fine, while a board whose pool cannot be found has
+# no pool. Substituting some other roster would hand the player a different mission; null is the
+# honest answer, and BoardLint flags the board that produced it as BLOCKS.
+static func resolve(name: String) -> Roster:
+	if name == "":
+		return null   # the ordinary case: this board has no pre-mission phase
+	var path := roster_path(name)
+	if not ResourceLoader.exists(path):
+		push_error("Roster '%s' does not exist (%s)." % [name, path])
+		return null
+	# load_tolerant, not load: a roster references UnitData and EquippableData files, so it is
+	# exactly the #596 dangling-chain shape -- one deleted weapon three files down refuses the
+	# WHOLE roster, and the repair pass is what gets it back.
+	var roster := ContentRepair.load_tolerant(path) as Roster
+	if roster == null:
+		push_error("Roster '%s' did not load as a Roster (%s)." % [name, path])
+	return roster

--- a/Classes/flow/RosterCatalog.gd.uid
+++ b/Classes/flow/RosterCatalog.gd.uid
@@ -1,0 +1,1 @@
+uid://bfmfj38ocxiw3

--- a/Classes/flow/RosterLint.gd
+++ b/Classes/flow/RosterLint.gd
@@ -1,0 +1,132 @@
+extends Object
+class_name RosterLint
+
+# "Is this roster file authored the way a roster can actually be read?" (#735) -- AttackLint's and
+# WeaponTemplateLint's shape, and BoardLint's discipline: BORROW the rule rather than restate one.
+#
+# It exists because Roster reuses ScenarioUnitEntry wholesale (see Roster.gd for why), which buys
+# zero migration and costs the ability to express nonsense: a roster member mid-Crisis, one holding
+# a Guard on a unit that is on no board, one whose empty snapshot silently strips the character's
+# own kit. None of that is reachable through a UI -- rosters are hand-authored in the inspector
+# until #731's deferred dev tab -- so nothing else would ever say a word about it.
+#
+# Every fault here is an AUTHORING mistake and every one of them is SILENT in play, which is the
+# only reason a lint is the right tool. Its CI caller is tests/dev/test_roster_lint.gd.
+
+# Same two tiers as BoardLint, same meanings, and no third: BLOCKS = the roster is not the roster
+# you authored; DEGRADES = it loads and offers units, but one of them is not what you meant.
+# Nothing here is BLOCKS today -- a roster that LOADS is always offerable, and a roster that does
+# not load is BoardLint's question, asked of the board that names it.
+enum Severity { BLOCKS, DEGRADES }
+
+
+# One row per fault: {"severity": Severity, "text": String}. Empty means nothing found.
+static func check(roster: Roster) -> Array[Dictionary]:
+	var found: Array[Dictionary] = []
+	if roster == null:
+		return found   # "no roster" is not a defective roster; BoardLint owns the missing-file case
+
+	for i in roster.entries.size():
+		var entry: ScenarioUnitEntry = roster.entries[i]
+		if entry == null:
+			_add(found, Severity.DEGRADES, "Entry %d is empty and will be skipped." % (i + 1))
+			continue
+		_check_one_job(entry, i, found)
+		_check_hollow_snapshot(entry, i, found)
+		_check_battle_state(entry, i, found)
+	return found
+
+
+# #731 ruling 10: one job at a time binds at the ROSTER, not at UnitInstance.jobs (capping the
+# model would break enemies, whose held jobs are their readable kit) and not at the picker (which
+# would silently drop the second job of anyone authored with two).
+#
+# Reads the EFFECTIVE list, which is not always the entry's own: apply_unit_state REPLACES
+# inst.jobs with the entry's copy, but only when state_saved -- a reference entry never gets there,
+# and the jobs it ends up with are the ones _seed_starting_kit added from UnitData.starting_jobs.
+static func effective_jobs(entry: ScenarioUnitEntry) -> Array[String]:
+	if entry.state_saved:
+		return entry.jobs
+	if entry.unit_data == null:
+		return []
+	return entry.unit_data.starting_jobs
+
+
+static func _check_one_job(entry: ScenarioUnitEntry, index: int, found: Array[Dictionary]) -> void:
+	var jobs := effective_jobs(entry)
+	if jobs.size() <= 1:
+		return
+	_add(found, Severity.DEGRADES,
+		"%s holds %d jobs (%s) -- a roster unit carries one, and the pre-mission picker shows one."
+			% [_label(entry, index), jobs.size(), ", ".join(jobs)])
+
+
+# The inspector's default for state_saved is TRUE, which makes this the easiest mistake in the
+# file to make and the hardest to see: add a character, leave the tick, and apply_unit_state runs
+# with an empty snapshot -- inventory.fill(null), unequip_weapon(), inst.jobs = [] -- REPLACING
+# whatever _seed_starting_kit granted. The unit deploys naked and jobless, with no error anywhere.
+# A reference entry (state_saved = false) is what "just this character, as authored" means.
+static func _check_hollow_snapshot(entry: ScenarioUnitEntry, index: int, found: Array[Dictionary]) -> void:
+	if not entry.state_saved:
+		return
+	var captured: bool = not entry.stats.is_empty() \
+		or entry.current_hp != -1 \
+		or entry.current_will != -1 \
+		or not entry.inventory.is_empty() \
+		or not entry.jobs.is_empty() \
+		or not entry.weapon_proficiency.is_empty() \
+		or not entry.aura.is_empty() \
+		or entry.affinity_saved \
+		or not entry.limb_states.is_empty()
+	if captured:
+		return
+	_add(found, Severity.DEGRADES,
+		("%s is a snapshot that captured nothing, so it deploys with NO kit and NO jobs -- the "
+		+ "character's own starting kit is replaced by the empty snapshot. Did you mean a "
+		+ "reference entry (untick state_saved)?") % _label(entry, index))
+
+
+# Battle-scoped fields (#87) mean nothing in a roster: a roster unit is on no board, has taken no
+# turn, and is holding no Guard on anyone. They round-trip because a roster entry IS a
+# ScenarioUnitEntry; setting one is an authoring accident, and apply_unit_state would replay it
+# onto a freshly deployed unit at the start of a mission.
+static func _check_battle_state(entry: ScenarioUnitEntry, index: int, found: Array[Dictionary]) -> void:
+	var set_fields: Array[String] = []
+	if entry.lifecycle_state != Unit.LifecycleState.ACTIVE:
+		set_fields.append("lifecycle_state")
+	if entry.in_crisis:
+		set_fields.append("in_crisis")
+	if entry.crisis_surge_pending:
+		set_fields.append("crisis_surge_pending")
+	if entry.downed_turns_remaining != -1:
+		set_fields.append("downed_turns_remaining")
+	if entry.rally_count != 0:
+		set_fields.append("rally_count")
+	if not entry.element_states.is_empty():
+		set_fields.append("element_states")
+	if not entry.stat_effects.is_empty():
+		set_fields.append("stat_effects")
+	if not entry.weapon_battle_states.is_empty():
+		set_fields.append("weapon_battle_states")
+	if entry.guard_ward_index != -1:
+		set_fields.append("guard_ward_index")
+	if not entry.watch_cells.is_empty():
+		set_fields.append("watch_cells")
+	if entry.squad_has_acted:
+		set_fields.append("squad_has_acted")
+	if set_fields.is_empty():
+		return
+	_add(found, Severity.DEGRADES,
+		("%s carries battle state a roster unit cannot have (%s) -- it would be replayed onto the "
+		+ "unit the moment it deploys.") % [_label(entry, index), ", ".join(set_fields)])
+
+
+# Names the character when it can, since that is what the author is looking for in the inspector.
+static func _label(entry: ScenarioUnitEntry, index: int) -> String:
+	if entry.unit_data != null and entry.unit_data.display_name != "":
+		return entry.unit_data.display_name
+	return "Entry %d" % (index + 1)
+
+
+static func _add(found: Array[Dictionary], severity: Severity, text: String) -> void:
+	found.append({"severity": severity, "text": text})

--- a/Classes/flow/RosterLint.gd.uid
+++ b/Classes/flow/RosterLint.gd.uid
@@ -1,0 +1,1 @@
+uid://ccvlq4ppolbmq

--- a/Classes/flow/ScenarioData.gd
+++ b/Classes/flow/ScenarioData.gd
@@ -47,6 +47,18 @@ class_name ScenarioData
 # unit_data. Empty = the default look. Resolved by LookKnobs.resolve, applied by battle3d.
 @export var look_preset := ""
 
+# Which Roster this mission offers (#735) -- who the player may bring into it, and the loose gear
+# they may bring. A NAME resolved against RosterCatalog.ROSTER_DIR, never a Roster reference, for
+# the two reasons stated for look_preset directly above; the filename IS a roster's identity, so
+# there is no display_name to disagree with it.
+#
+# EMPTY = this board has no pre-mission phase, which is what every scenario saved before #735 is:
+# it keeps its authored cast and boots straight into turn 1. That fallback is why adding this
+# breaks nothing -- the objectives: [] shape. A named roster that no longer resolves is a BLOCKS
+# finding in BoardLint rather than a silent fallback: substituting a different pool would hand the
+# player a different mission.
+@export var roster := ""
+
 # Where the camera OPENS on this board (#234). Null = derive it -- battle3d frames the player's own
 # units, which is the right default and the wrong authored answer for a handcrafted level. Authored
 # is AUTHORITATIVE; the derivation is the fallback for a board that says nothing (Law #4, same shape

--- a/Classes/flow/ScenarioManager.gd
+++ b/Classes/flow/ScenarioManager.gd
@@ -66,6 +66,13 @@ var current_look_preset := ""
 # store/writer shape as the look right above -- apply_scenario sets it, clear_board zeroes it, the
 # dev Scenario tab captures into it, capture_scenario reads it back out.
 var current_camera_start: CameraPose = null
+
+# Which roster the CURRENT board offers (#735), by name; "" = no pre-mission phase. Same store and
+# same four writers as the look right above -- apply_scenario sets it from the loaded board,
+# clear_board zeroes it, the dev Scenario tab writes it when you pick one, capture_scenario reads
+# it back out. Nothing resolves it to a Roster yet; #737 is the first reader.
+var current_roster := ""
+
 # The #182 lesson content, same seam: authored scenario content that is not board state. THE store
 # — ScenarioDirector reads these LIVE (never copies), capture_scenario writes them back out, and
 # clear_board empties them so a sandbox spawn cannot inherit the last mission's lesson.
@@ -166,6 +173,7 @@ func capture_scenario(scenario_name: String, authored := false) -> ScenarioData:
 	scenario.round_limit = game.mission_controller.round_limit
 	scenario.ai_factions = game.ai_controller.ai_factions()   # #150: who the computer plays here
 	scenario.look_preset = current_look_preset               # #253 part 2: the look it wears
+	scenario.roster = current_roster                         # #735: who it offers, if anyone
 	scenario.camera_start = current_camera_start             # #234: where it opens, if authored
 	scenario.dialog_beats = current_dialog_beats.duplicate()       # #182/#397: Update must not wipe
 	scenario.tutorial_steps = current_tutorial_steps.duplicate()   # the lesson it cannot see on the board
@@ -248,6 +256,7 @@ func apply_scenario(scenario: ScenarioData) -> void:
 	# correctly applies nothing.
 	current_look_preset = scenario.look_preset
 	current_camera_start = scenario.camera_start   # #234, same signal, same reason: read from board_loaded
+	current_roster = scenario.roster              # #735: nothing reads it before #737, but the store is board state
 
 	var leaders_by_squad_id := {}
 	var members_by_squad_id := {}
@@ -367,6 +376,10 @@ func clear_board():
 	current_look_preset = ""
 	# And the camera start (#234): a sandbox spawn must not open on the last mission's authored shot.
 	current_camera_start = null
+	# And the roster (#735), for exactly the look preset's reason and with a sharper consequence:
+	# Sandbox lands here with no ScenarioData, so without this a sandbox board would keep offering
+	# the last mission's pool -- and the next Save As would write that name into a fixture.
+	current_roster = ""
 	# And the lesson (#182/#397): content follows its board out.
 	current_dialog_beats = []
 	current_tutorial_steps = []

--- a/Resources/Rosters/Company.tres
+++ b/Resources/Rosters/Company.tres
@@ -1,0 +1,68 @@
+[gd_resource type="Resource" script_class="Roster" format=3]
+
+[ext_resource type="Script" path="res://Classes/flow/Roster.gd" id="1_roster"]
+[ext_resource type="Script" path="res://Classes/flow/ScenarioUnitEntry.gd" id="2_entry"]
+[ext_resource type="Resource" path="res://Resources/Units/Aldin.tres" id="3_aldin"]
+[ext_resource type="Resource" path="res://Resources/Units/Aster.tres" id="4_aster"]
+[ext_resource type="Resource" path="res://Resources/Units/Bram.tres" id="5_bram"]
+[ext_resource type="Resource" path="res://Resources/Units/Celest.tres" id="6_celest"]
+[ext_resource type="Resource" path="res://Resources/Units/Dorian.tres" id="7_dorian"]
+[ext_resource type="Resource" path="res://Resources/Units/Isaac.tres" id="8_isaac"]
+[ext_resource type="Resource" path="res://Resources/Units/Noemie.tres" id="9_noemie"]
+[ext_resource type="Resource" path="res://Resources/Units/Rebecca.tres" id="10_rebecca"]
+[ext_resource type="Resource" path="res://Resources/Units/Ross.tres" id="11_ross"]
+[ext_resource type="Resource" path="res://Resources/Units/Torv.tres" id="12_torv"]
+
+[sub_resource type="Resource" id="Resource_aldin"]
+script = ExtResource("2_entry")
+unit_data = ExtResource("3_aldin")
+state_saved = false
+
+[sub_resource type="Resource" id="Resource_aster"]
+script = ExtResource("2_entry")
+unit_data = ExtResource("4_aster")
+state_saved = false
+
+[sub_resource type="Resource" id="Resource_bram"]
+script = ExtResource("2_entry")
+unit_data = ExtResource("5_bram")
+state_saved = false
+
+[sub_resource type="Resource" id="Resource_celest"]
+script = ExtResource("2_entry")
+unit_data = ExtResource("6_celest")
+state_saved = false
+
+[sub_resource type="Resource" id="Resource_dorian"]
+script = ExtResource("2_entry")
+unit_data = ExtResource("7_dorian")
+state_saved = false
+
+[sub_resource type="Resource" id="Resource_isaac"]
+script = ExtResource("2_entry")
+unit_data = ExtResource("8_isaac")
+state_saved = false
+
+[sub_resource type="Resource" id="Resource_noemie"]
+script = ExtResource("2_entry")
+unit_data = ExtResource("9_noemie")
+state_saved = false
+
+[sub_resource type="Resource" id="Resource_rebecca"]
+script = ExtResource("2_entry")
+unit_data = ExtResource("10_rebecca")
+state_saved = false
+
+[sub_resource type="Resource" id="Resource_ross"]
+script = ExtResource("2_entry")
+unit_data = ExtResource("11_ross")
+state_saved = false
+
+[sub_resource type="Resource" id="Resource_torv"]
+script = ExtResource("2_entry")
+unit_data = ExtResource("12_torv")
+state_saved = false
+
+[resource]
+script = ExtResource("1_roster")
+entries = Array[ExtResource("2_entry")]([SubResource("Resource_aldin"), SubResource("Resource_aster"), SubResource("Resource_bram"), SubResource("Resource_celest"), SubResource("Resource_dorian"), SubResource("Resource_isaac"), SubResource("Resource_noemie"), SubResource("Resource_rebecca"), SubResource("Resource_ross"), SubResource("Resource_torv")])

--- a/tests/dev/test_board_lint.gd
+++ b/tests/dev/test_board_lint.gd
@@ -183,6 +183,33 @@ func test_a_look_preset_that_no_longer_exists_degrades_the_board() -> void:
 	_assert_silent(BoardLint.Severity.DEGRADES, "no longer exists")
 
 
+func test_a_roster_that_does_not_exist_blocks_the_board() -> void:
+	# BLOCKS where the look preset one case up is DEGRADES, and the tier is the finding: a board
+	# with no look wears the default and plays exactly as authored, while a board whose pool cannot
+	# be found has no pool to offer. Only BLOCKS reds CI, so filing this at the wrong tier would
+	# leave every shipped roster-naming mission unswept.
+	_spawn(Team.Faction.PLAYER, 0)
+	game.scenario_manager.current_roster = "NoSuchRosterEverExisted"
+	_assert_reports(BoardLint.Severity.BLOCKS, "NoSuchRosterEverExisted")
+
+	# Non-vacuous against a roster that DOES resolve -- otherwise this passes on any non-empty name.
+	var real: Array[String] = RosterCatalog.saved_rosters()
+	if real.is_empty():   # content-absent: warn, never fail (tests/README.md rule 9)
+		push_warning("no rosters are shipped, so the resolving twin cannot be shown")
+		return
+	game.scenario_manager.current_roster = real[0]
+	_assert_silent(BoardLint.Severity.BLOCKS, "does not exist")
+
+
+func test_a_board_naming_no_roster_says_nothing_about_rosters() -> void:
+	# The ordinary board, and the case that would catch a rule that forgot its empty-name guard --
+	# every scenario shipped before #735 names no roster, so a missing early-return would BLOCK
+	# every one of them at once.
+	_spawn(Team.Faction.PLAYER, 0)
+	game.scenario_manager.current_roster = ""
+	_assert_silent(BoardLint.Severity.BLOCKS, "roster")
+
+
 func test_findings_that_block_play_are_listed_first() -> void:
 	# The order IS part of what the report says, so it belongs to the rule and not to the panel.
 	# Built degrades-first so a lint that merely preserved call order would fail this.

--- a/tests/dev/test_roster_lint.gd
+++ b/tests/dev/test_roster_lint.gd
@@ -1,0 +1,150 @@
+# RosterLint's teeth (#735), plus the sweep over every shipped roster.
+#
+# Nothing here pins authored content (tests/README.md #9): the sweep asserts a PROPERTY every
+# roster must hold, and the fixture cases build their own rosters in memory so a rule's teeth do
+# not depend on what happens to be authored today.
+extends GdUnitTestSuite
+
+const CAST := "res://tests/support/CastFixture.tres"
+
+
+func _entry(state_saved: bool) -> ScenarioUnitEntry:
+	var entry := ScenarioUnitEntry.new()
+	entry.unit_data = load(CAST)
+	entry.state_saved = state_saved
+	return entry
+
+
+# A reference entry is the shape a roster member normally has: point at the character file and let
+# its starting kit be the whole answer.
+func _reference_roster() -> Roster:
+	var roster := Roster.new()
+	roster.entries = [_entry(false)]
+	return roster
+
+
+func _texts(findings: Array[Dictionary]) -> String:
+	var out: Array[String] = []
+	for finding: Dictionary in findings:
+		out.append(finding["text"])
+	return "\n".join(out)
+
+
+func test_a_plain_reference_roster_is_clean() -> void:
+	assert_array(RosterLint.check(_reference_roster())).is_empty()
+
+
+func test_no_roster_is_not_a_defective_roster() -> void:
+	# BoardLint owns "this board names a roster that isn't there"; a null here is just absence.
+	assert_array(RosterLint.check(null)).is_empty()
+
+
+# --- The hollow snapshot: the easiest mistake in the file and the hardest to see ---
+
+func test_a_snapshot_that_captured_nothing_is_found() -> void:
+	# state_saved defaults TRUE in the inspector, so this is what "add a character and leave the
+	# tick" produces. apply_unit_state would then fill the inventory with nulls, unequip, and set
+	# jobs to [] -- replacing the character's own starting kit with the empty snapshot.
+	var roster := Roster.new()
+	roster.entries = [_entry(true)]
+	var findings := RosterLint.check(roster)
+	assert_int(findings.size()).override_failure_message(_texts(findings)).is_equal(1)
+	assert_int(findings[0]["severity"]).is_equal(RosterLint.Severity.DEGRADES)
+	assert_str(findings[0]["text"]).contains("state_saved")
+
+
+func test_a_snapshot_that_captured_something_is_clean() -> void:
+	# The rule is "captured NOTHING", not "is a snapshot" -- a roster entry carrying real per-mission
+	# state is the whole point of rosters being plural (#731's balance-testing lever).
+	var entry := _entry(true)
+	entry.stats = {Stats.Stat.STR: 9}
+	var roster := Roster.new()
+	roster.entries = [entry]
+	assert_array(RosterLint.check(roster)).is_empty()
+
+
+# --- One job at a time, bound at the roster (#731 ruling 10) ---
+
+func test_two_jobs_on_a_snapshot_entry_are_found() -> void:
+	var entry := _entry(true)
+	entry.stats = {Stats.Stat.STR: 9}   # so the hollow-snapshot rule stays quiet and this case is alone
+	entry.jobs = ["a", "b"]
+	var findings := RosterLint.check(_roster_of(entry))
+	assert_int(findings.size()).override_failure_message(_texts(findings)).is_equal(1)
+	assert_int(findings[0]["severity"]).is_equal(RosterLint.Severity.DEGRADES)
+	assert_str(findings[0]["text"]).contains("2 jobs")
+
+
+func test_the_effective_list_is_the_character_file_for_a_reference_entry() -> void:
+	# The teeth of effective_jobs: a reference entry's own `jobs` is empty and never applied --
+	# apply_unit_state only runs when state_saved -- so the jobs it deploys with are the ones
+	# _seed_starting_kit adds from UnitData.starting_jobs. Reading entry.jobs here would report a
+	# two-job character as clean.
+	var entry := _entry(false)
+	var data: UnitData = entry.unit_data.duplicate()   # never mutate the shared cached fixture
+	data.starting_jobs = ["a", "b"]
+	entry.unit_data = data
+	var findings := RosterLint.check(_roster_of(entry))
+	assert_int(findings.size()).override_failure_message(_texts(findings)).is_equal(1)
+	assert_str(findings[0]["text"]).contains("2 jobs")
+
+
+func test_one_job_is_clean_in_both_entry_shapes() -> void:
+	var snapshot := _entry(true)
+	snapshot.stats = {Stats.Stat.STR: 9}
+	snapshot.jobs = ["a"]
+	assert_array(RosterLint.check(_roster_of(snapshot))).is_empty()
+
+	var reference := _entry(false)
+	var data: UnitData = reference.unit_data.duplicate()
+	data.starting_jobs = ["a"]
+	reference.unit_data = data
+	assert_array(RosterLint.check(_roster_of(reference))).is_empty()
+
+
+# --- Battle state, which a unit on no board cannot have ---
+
+func test_battle_state_on_a_roster_entry_is_found_and_named() -> void:
+	var entry := _entry(true)
+	entry.stats = {Stats.Stat.STR: 9}
+	entry.in_crisis = true
+	entry.rally_count = 2
+	var findings := RosterLint.check(_roster_of(entry))
+	assert_int(findings.size()).override_failure_message(_texts(findings)).is_equal(1)
+	assert_str(findings[0]["text"]).contains("in_crisis")
+	assert_str(findings[0]["text"]).contains("rally_count")
+
+
+func test_an_empty_entry_is_found_rather_than_crashing() -> void:
+	var roster := Roster.new()
+	roster.entries = [null]
+	var findings := RosterLint.check(roster)
+	assert_int(findings.size()).is_equal(1)
+	assert_str(findings[0]["text"]).contains("empty")
+
+
+# --- The sweep over what actually ships ---
+
+func test_every_shipped_roster_is_authored_cleanly() -> void:
+	# Non-vacuity first, and it is not decoration: files_with_extension returns [] for a folder that
+	# does not exist, so without this the sweep below passes over nothing and proves nothing. Same
+	# guard test_attack_lint.gd carries for the same reason.
+	var names := RosterCatalog.saved_rosters()
+	assert_bool(names.is_empty()).override_failure_message(
+		"no rosters found in %s -- the sweep below would pass over nothing"
+			% RosterCatalog.ROSTER_DIR).is_false()
+
+	var problems: Array[String] = []
+	for name: String in names:
+		var roster := RosterCatalog.resolve(name)
+		assert_object(roster).override_failure_message(
+			"roster '%s' is listed but did not load" % name).is_not_null()
+		for finding: Dictionary in RosterLint.check(roster):
+			problems.append("%s: %s" % [name, finding["text"]])
+	assert_array(problems).is_empty()
+
+
+func _roster_of(entry: ScenarioUnitEntry) -> Roster:
+	var roster := Roster.new()
+	roster.entries = [entry]
+	return roster

--- a/tests/dev/test_roster_lint.gd.uid
+++ b/tests/dev/test_roster_lint.gd.uid
@@ -1,0 +1,1 @@
+uid://c2y0kbc2mhpt7

--- a/tests/flow/test_roster_binding.gd
+++ b/tests/flow/test_roster_binding.gd
@@ -1,0 +1,153 @@
+# A mission names a roster (#735): the ScenarioData field, its store on ScenarioManager, and the
+# four writers of that store. Nothing reads a roster to spawn from yet -- #737 is the first reader,
+# and until then this binding IS the feature.
+#
+# Real game scene (test_cast_references.gd's shape, same reason): capture_scenario and
+# apply_scenario only exist together on a real ScenarioManager.
+extends GdUnitTestSuite
+
+const MAIN_SCENE := "res://Scenes/Main.tscn"
+const CAST := "res://tests/support/CastFixture.tres"
+const SCRATCH := "user://__roster_roundtrip_735.tres"
+
+var _main: Node
+var game: Node2D
+var sm: ScenarioManager
+
+
+func before_test() -> void:
+	_main = (load(MAIN_SCENE) as PackedScene).instantiate()
+	_main.name = "Main"
+	get_tree().root.add_child(_main)
+	await await_idle_frame()
+	game = _main.get_node("GameContainer/GameView/Game")
+	game.scenario_manager.clear_board()
+	game.game_state = game.GameState.IDLE
+	sm = game.scenario_manager
+	await await_idle_frame()
+
+
+func after_test() -> void:
+	await await_idle_frame()
+	get_tree().root.remove_child(_main)
+	_main.free()
+	if FileAccess.file_exists(SCRATCH):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(SCRATCH))
+
+
+# --- The store's four writers (ScenarioManager.gd's stated contract) ---
+
+func test_capture_writes_the_named_roster_onto_the_scenario() -> void:
+	sm.current_roster = "Company"
+	var snap := sm.capture_scenario("roster_capture")
+	assert_str(snap.roster).is_equal("Company")
+
+
+func test_apply_reads_the_named_roster_back_into_the_store() -> void:
+	sm.current_roster = "Company"
+	var snap := sm.capture_scenario("roster_apply")
+	sm.current_roster = "something else entirely"
+	sm.apply_scenario(snap)
+	await await_idle_frame()
+	assert_str(sm.current_roster).is_equal("Company")
+
+
+func test_clear_board_zeroes_the_store() -> void:
+	# The third writer, and the one nothing else would catch. tests/law/test_board_scoped_state.gd
+	# governs `static var`s in Classes/board and Classes/presentation; current_roster is an instance
+	# var on ScenarioManager, which that law never scans.
+	#
+	# What it prevents: load a roster mission, hit Sandbox (which lands in clear_board with no
+	# ScenarioData at all), Save As -- and the fixture you just saved names the last mission's pool.
+	sm.current_roster = "Company"
+	sm.clear_board()
+	assert_str(sm.current_roster).is_equal("")
+
+
+func test_a_sandbox_capture_after_a_roster_mission_names_nobody() -> void:
+	# The same rule asserted at the surface it actually breaks at, rather than at the store: this is
+	# the fault a reader would recognise, and it stays true even if the reset later moves.
+	sm.current_roster = "Company"
+	sm.clear_board()
+	var snap := sm.capture_scenario("sandbox_after_roster")
+	assert_str(snap.roster).is_equal("")
+
+
+# --- Roster-less boards are the ones that already exist ---
+
+func test_a_board_naming_no_roster_round_trips_as_empty() -> void:
+	var snap := sm.capture_scenario("no_roster")
+	assert_str(snap.roster).is_equal("")
+	sm.apply_scenario(snap)
+	await await_idle_frame()
+	assert_str(sm.current_roster).is_equal("")
+
+
+func test_every_shipped_scenario_names_a_roster_that_resolves() -> void:
+	# The binding's own integrity, asked of what ships -- the sibling of BoardLint's live-board
+	# rule, in the file-shaped form a lint structurally cannot ask (test_board_lint.gd's split).
+	var paths := sm.get_saved_scenarios()
+	assert_bool(paths.is_empty()).override_failure_message(
+		"no scenarios found -- the sweep would pass over nothing").is_false()
+	var problems: Array[String] = []
+	for path: String in paths:
+		var scenario: ScenarioData = ContentRepair.load_tolerant(path)
+		if scenario == null or scenario.roster == "":
+			continue
+		if not RosterCatalog.saved_rosters().has(scenario.roster):
+			problems.append("%s names roster '%s', which does not exist" % [path, scenario.roster])
+	assert_array(problems).is_empty()
+
+
+# --- The catalog ---
+
+func test_the_shipped_roster_resolves_and_carries_entries() -> void:
+	var names := RosterCatalog.saved_rosters()
+	assert_array(names).contains(["Company"])
+	var roster := RosterCatalog.resolve("Company")
+	assert_object(roster).is_not_null()
+	assert_bool(roster.entries.is_empty()).override_failure_message(
+		"the shipped roster offers nobody").is_false()
+	for entry: ScenarioUnitEntry in roster.entries:
+		assert_object(entry.unit_data).override_failure_message(
+			"a roster entry resolves to no character file").is_not_null()
+
+
+func test_an_absent_name_resolves_to_null_rather_than_a_substitute() -> void:
+	# Deliberately unlike LookKnobs.resolve, which falls back to the default preset: a board with no
+	# look plays as authored, a board with no POOL does not. Substituting some other roster would
+	# hand the player a different mission, so null is the honest answer and BoardLint flags it.
+	assert_object(RosterCatalog.resolve("no such roster")).is_null()
+
+
+func test_the_empty_name_is_absence_and_not_an_error() -> void:
+	assert_object(RosterCatalog.resolve("")).is_null()
+
+
+# --- The serialization boundary ---
+
+func test_a_roster_survives_a_real_save_and_load() -> void:
+	# Through an actual .tres write/read rather than in memory, the
+	# test_saved_subresource_is_never_provenance idiom: a roster holds ScenarioUnitEntry
+	# sub-resources, and entries are exactly where a typed-array round trip can go wrong.
+	var reference := ScenarioUnitEntry.new()
+	reference.unit_data = load(CAST)
+	reference.state_saved = false
+
+	var snapshot := ScenarioUnitEntry.new()
+	snapshot.unit_data = load(CAST)
+	snapshot.state_saved = true
+	snapshot.stats = {Stats.Stat.STR: 7}
+	snapshot.jobs = ["a"]
+
+	var roster := Roster.new()
+	roster.entries = [reference, snapshot]
+
+	assert_int(ResourceSaver.save(roster, SCRATCH)).is_equal(OK)
+	var loaded := ResourceLoader.load(SCRATCH, "", ResourceLoader.CACHE_MODE_IGNORE) as Roster
+	assert_object(loaded).is_not_null()
+	assert_int(loaded.entries.size()).is_equal(2)
+	assert_bool(loaded.entries[0].state_saved).is_false()
+	assert_bool(loaded.entries[1].state_saved).is_true()
+	assert_int(loaded.entries[1].stats[Stats.Stat.STR]).is_equal(7)
+	assert_array(loaded.entries[1].jobs).contains(["a"])

--- a/tests/flow/test_roster_binding.gd.uid
+++ b/tests/flow/test_roster_binding.gd.uid
@@ -1,0 +1,1 @@
+uid://cv1sbesya37ax


### PR DESCRIPTION
Closes #735. First child of #731 — the data foundation the rest of the pre-mission phase stacks on.

Nothing reads a roster to spawn from yet (#737 is the first reader), so this ships inert except at the authoring surface: a Properties row that points a board at a roster, and two lints that catch a roster the board cannot use.

## What landed

**`Roster`** (`Classes/flow/Roster.gd`) — `entries: Array[ScenarioUnitEntry]` + `stash: Array[EquippableData]`. No `display_name`: a roster's identity is its filename, exactly as a `LookPreset`'s is.

**A roster entry IS a `ScenarioUnitEntry`.** #731 ruling 1 made `cell`/`squad_id`/`is_leader` outputs of the pre-mission phase, so an undeployed entry is that resource with those three unset, and at commit the board's `unit_entries` is this list with them filled in. Factoring the persistent block into a shared nested resource was the alternative and was rejected on migration cost: **13 `.tres` embed `ScenarioUnitEntry` as sub-resources plus every `user://` save**, and Godot drops properties a resource no longer declares *silently* — they would all load as defaults with nothing saying so. The cost of the reuse is that a roster file can express nonsense; `RosterLint` is what pays it.

**`RosterCatalog`** — shaped like `LookKnobs`' preset lookup, **not** like `UnitCatalog`. `ResourceCatalog.by_name` keys by `display_name` and its own comment says two resources sharing a name collapse; for a name a scenario stores, a collapse silently hands a mission the wrong pool. `resolve()` has no default to fall back to, deliberately — a board with no look wears the default and plays as authored, a board with no pool has no pool. It uses `ContentRepair.load_tolerant`, since a roster references `UnitData` and `EquippableData` files and is exactly the #596 dangling-chain shape.

**`ScenarioData.roster`** — a NAME, `""` = no pre-mission phase, which is what every scenario already is. Four writers, the `current_look_preset` contract: `capture_scenario` writes it, `apply_scenario` reads it, the Properties row sets it, and **`clear_board` zeroes it** — without that last one a Sandbox spawn inherits the last mission's pool and the next Save As writes it into a fixture.

**The lint, split by scope.** `BoardLint` gains one rule — this board names a roster that does not resolve → **BLOCKS**, because a roster-naming board with no resolvable pool is not the mission its author meant. It reads the name list and never `resolve()`, per that file's own rule that a lint must not have side effects. `RosterLint` owns the facts about a roster *file*: more than one job (#731 ruling 10, reading the **effective** list — a reference entry takes `UnitData.starting_jobs`), a snapshot that captured nothing, and battle-scoped state.

**`Resources/Rosters/Company.tres`** — the ten player-faction characters as reference entries, empty stash. Placeholder; rename or recast freely.

## How to check this

**What to do.** Open any mission, Scenario ▸ Properties. There is a new **Roster** row showing `(none - no pre-mission)`. Pick `Company`, press Update, then F2. Hit **Check board**. Now rename `Resources/Rosters/Company.tres` in the FileSystem dock and hit Check board again. Rename it back.

**What you should see.** The row keeps saying `Company` across the F2 reset. Check board is clean while the file exists, and reports one red ⛔ naming the missing roster once it doesn't. Nothing else on screen changes — no mission plays differently, because nothing reads a roster until #737.

**What a failure looks like.** The row resetting to `(none)` after F2 means the load path dropped it. A finding that comes up amber rather than red means it landed at the wrong tier — only BLOCKS reds CI, so a DEGRADES rule here would leave every shipped roster-naming mission unswept. And if picking a roster on one board then hitting Sandbox leaves the row still saying `Company`, `clear_board` isn't resetting.

**What the tests already cover.** `tests/flow/test_roster_binding.gd` (11 cases) pins all four writers including the `clear_board` reset, the round trip through a real `ResourceSaver`/`ResourceLoader` pair, and a sweep asserting every shipped scenario names a roster that resolves. `tests/dev/test_roster_lint.gd` (10) pins each rule's teeth and sweeps every shipped roster. `tests/dev/test_board_lint.gd` gains the BLOCKS case and its roster-less twin.

Four mutants run, all caught: deleting the `clear_board` reset, making `effective_jobs` ignore the reference-entry branch, filing the BoardLint rule at DEGRADES, and dropping its empty-name guard — that last one was caught by the suite's *first* case, since it BLOCKS every board that exists.

**What the suite cannot see:** it never opens the Properties page, so the row itself — that it appears, sits between Look preset and Camera start, and refreshes on a board load — is only checked by hand. That's the whole of the manual check above.

Scoped runs: `flow` (249) and `dev` (430), both green; `flow` re-run after rebasing onto your `content authoring` commit, since the new fixture joins the scenario sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
