### PR TITLE
#666: send.sh sent invalid JSON for a no-argument command

### DIFF
--- a/play/send.sh
+++ b/play/send.sh
@@ -37,7 +37,13 @@ if [ "${1:-}" = "--batch" ]; then
   printf '{"id":%d,"cmds":%s}' "$id" "$2" > "$CMD"
 else
   [ $# -ge 1 ] || { echo "usage: send.sh <cmd> ['<json args>']  |  send.sh --batch '<json array>'" >&2; exit 1; }
-  args="${2:-{\}}"
+  # NOT `args="${2:-{\}}"`. Bash keeps the backslash, so the default expands to the literal `{\}`,
+  # Godot's JSON.parse_string rejects it, the bridge never answers that id, and this script hangs
+  # until it times out. Found by a playtest agent on the first unattended run -- and I had already
+  # hit and fixed this exact expansion in a throwaway copy of this script earlier the same day,
+  # then reintroduced it when writing the version that ships.
+  args="${2:-}"
+  [ -z "$args" ] && args='{}'
   printf '{"id":%d,"cmd":"%s","args":%s}' "$id" "$1" "$args" > "$CMD"
 fi
 


### PR DESCRIPTION
`play/send.sh` shipped in #667 with a bash expansion bug: `args="${2:-{\}}"` keeps the backslash, so any command sent **without arguments** produced

```json
{"id":1,"cmd":"overview","args":{\}}
```

Godot's `JSON.parse_string` rejects it, the bridge never answers that id, and `send.sh` polls until it times out — so it presents as a **hang**, which is the worst failure shape for a script an unattended agent depends on.

## How it was found

The first unattended playtest agent hit it, read the script, and diagnosed the expansion itself rather than working around it:

> *"In single-command mode, line 40 uses `args="${2:-{\}}"`. In bash, this expands to literal `{\}` rather than `{}`, causing Godot's `JSON.parse_string` to fail with a syntax error and causing `send.sh` to hang indefinitely awaiting a response."*

I had already hit and fixed this exact expansion in a throwaway copy of the script earlier the same day, then reintroduced it when writing the version that ships.

## Verified, not inspected

My first attempt to demonstrate it was wrong — I set `$2`, so the default never fired and the buggy line looked fine. Correctly:

```
$ bash -c 'set -- overview; args="${2:-{\}}"; echo "[$args]"'
[{\}]                                          # and json.loads rejects it
```

The reason is recorded at the line so nobody re-derives the golf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZHJ7AuFedPCURFKoY9xX6
