### PR TITLE
Record how to run a playtest experiment, and ship the harness that does it

### DIFF
--- a/docs/play-api.md
+++ b/docs/play-api.md
@@ -165,6 +165,9 @@ unattended playtest needs blanket approval — which removes the guard that stop
 supposed to be *playing* the game from editing it. One batch per turn, through `send.sh`, keeps the
 whole allowlist to two entries.
 
+**Running a playtest experiment** — isolating an unattended session, what to measure, and the
+several ways an obvious setup produces a wrong answer: [`playtest-experiments.md`](playtest-experiments.md).
+
 **The opponent acts (#665).** `endturn` runs the incoming faction's AI when the board declares it in
 `ScenarioData.ai_factions`, and reports what it did as an event log — the same account `execute`
 gives of your own pass:

--- a/docs/playtest-experiments.md
+++ b/docs/playtest-experiments.md
@@ -1,0 +1,178 @@
+# Running playtest experiments
+
+**Canon checked through #765 (2026-09-05).**
+
+How to have an AI agent play Iosis through the headless bridge, unattended, and get a measurement
+you can believe. Written after seven runs across three arms, and it is mostly a list of ways the
+obvious approach quietly produces a wrong answer.
+
+The API itself is [`play-api.md`](play-api.md). This is about *operating* it.
+
+The harness is [`tools/playtest/`](../tools/playtest/): `run.sh` (one run, isolated and archived),
+`analyze.sh` (the metrics), `extract-transcript.sh` (the agent's own account), `prompt.md` (the
+shared prompt).
+
+---
+
+## The shape of a run
+
+```bash
+export IOSIS_PLAYTEST_WT=~/iosis-worktrees/playtest      # a THROWAWAY worktree
+export IOSIS_PLAYTEST_PROJECT=<agy project id>           # pins the session to it
+export IOSIS_PLAYTEST_ARM=C                              # names the arm in the archive
+tools/playtest/run.sh 1
+tools/playtest/analyze.sh
+```
+
+Each run archives frames, the agent transcript, its conversation db, and a manifest naming the
+commit. A run takes 3–7 minutes and ~3% of a five-hour Gemini budget.
+
+---
+
+## Isolation: the agent binds to a PROJECT, not to cwd
+
+**This cost a run.** `agy -p` launched from the worktree played in the *main checkout* instead,
+and the harness archived zero frames while reporting success. `--project` with a JSON in
+`~/.gemini/config/projects/<id>.json` binding `folderUri` to the worktree is what pins it:
+
+```json
+{ "id": "<uuid>", "name": "/path/to/worktree",
+  "projectResources": { "resources": [ { "gitFolder": {
+     "folderUri": "file:///path/to/worktree", "allowWrite": true } } ] } }
+```
+
+`allowWrite` must be true — the bridge protocol writes `playrun/command.json` inside the repo.
+So the isolation is *the worktree is disposable*, not *the agent cannot write*. Verify a new pin
+with a one-line `pwd` prompt before spending a real run on it; `run.sh` also fails loudly when it
+finds no frames, because silently archiving nothing is how this hid the first time.
+
+**`/playrun/` is gitignored**, so switching branches does NOT clear it. Frames from the previous
+run survive into the next and mix into the analysis. `run.sh` clears it; skipping that step
+invalidates the arm.
+
+---
+
+## The prompt is a variable, and a bigger one than the code
+
+The first five (observational) runs were prompted *"…has a headless mode that AI agents like you
+can play. Would you like to give it a spin?"* — no goal, no stopping rule. They rejected **30–54%**
+of their own commands.
+
+A controlled prompt — *play as well as you can, read the docs first, stop after 8 player turns* —
+produced **4%** on the same build.
+
+So: **arms must share a prompt, and a prompt without a stopping rule produces runs of
+incomparable length** (those five ranged 84–477 frames). Never treat exploratory sessions as a
+baseline for a measured one. And do not name new commands in the prompt: if a fresh session cannot
+find an affordance from `play-api.md` alone, the affordance shipped inert, and prompting around
+that measures your prompt instead.
+
+---
+
+## Pre-register the metrics, then distrust your own collector
+
+Fix the metrics before either arm runs. Then assume the collector is wrong, because mine was,
+twice, and both times in the direction that flattered the change:
+
+- **It counted my own archived transcripts as game output.** `find -name '*.txt'` swept up the
+  `transcript.txt` that the archiver had just written beside the frames. Bytes read 4x high.
+- **The guard went blind when the interface changed.** `overview`-per-`execute` was counted from
+  filenames; batching then named a frame for its LAST command, so an `overview` *inside* a batch
+  stopped being visible and the pre-registered falsifier silently read zero. Count from frame
+  CONTENT, not names.
+
+A guard that cannot fail is worse than no guard, and neither of these announced itself.
+
+### What the columns mean
+
+| | |
+|---|---|
+| `REJECT` | refused commands. **Rises when the opponent is real** — plans go stale between turns. |
+| `B/TURN` | bytes per player turn. Normalised; raw totals are not comparable across run lengths. |
+| `OV/EXEC` | explicit `overview` per `execute`. The guard on any change that removes a redraw: if it climbs, the redraw **moved** rather than went away. |
+| `AFFORD` | `legal_moves`/`legal_targets` calls. Zero means an affordance shipped inert. |
+| `PY` | `python3` invocations — see below. |
+
+---
+
+## `python3` usage is an interface metric, not a hygiene one
+
+| arm | shell calls | of which `python3` |
+|---|---|---|
+| pre-#613 | 72, 61 | 69, 54 |
+| #613 | 3, 43 | 0, 32 |
+| #665 (`send.sh` shipped) | — | **0, 0, 0** |
+
+The bridge is write-then-poll. That is fine a dozen times and unbearable seventy, so an agent
+writes a poller and loops it — **the scripting tracks round-trip count and nothing else.** It
+matters because an agent that must run arbitrary code cannot be given a narrow permission
+allowlist, so an unattended run needs blanket approval, which removes the guard that stops a
+session meant to be *playing* the game from editing it. Batching and `play/send.sh` took it to
+zero; the allowlist is now *launch the bridge* and *run send.sh*.
+
+**Treat a rise in `PY` as an interface regression.**
+
+---
+
+## What you may and may not compare
+
+Only compare arms that differ in **interface**. Three arms exist and only two are comparable:
+
+| arm | what it is |
+|---|---|
+| A | pre-#613 |
+| B | #613 — affordances, batching, no automatic redraw |
+| C | #665 — same interface, **plus an opponent that actually acts** |
+
+A↔B is an interface comparison. **B↔C is not**: the enemy was a no-op before #665, so an agent has
+a strictly harder game in C, and any difference confounds "interface changed" with "game got
+harder". C is a *new baseline* for future interface work, not the other side of an A/B.
+
+Reference values, three C runs: `REJECT` 12–20%, `B/TURN` 6.4–9.9k, `OV/EXEC` 0.62–1.42,
+`AFFORD` 17–24, `PY` 0.
+
+---
+
+## Two runs per arm is directional, not significant
+
+Between-run variance on a single build ran **2% to 54%** rejection in the observational set. Two
+runs cannot resolve a difference smaller than that. Say "directional" in the writeup and mean it.
+The one metric that separated cleanly at n=2 was bytes/turn, where the two baseline runs landed
+within 1.5% of each other — variance is per-metric, so check it per-metric.
+
+---
+
+## Watching a run, and reading it afterwards
+
+Live, read-only:
+
+```bash
+cat $IOSIS_PLAYTEST_WT/playrun/state.txt          # the board, as the agent last saw it
+```
+
+**Never write `playrun/command.json` while a session is live** — that injects a command into its
+conversation and corrupts the run.
+
+Afterwards, the frames are *what it did* and the transcript is *what it was trying to do*. Both
+are needed and they answer different questions. Transcripts are protobuf blobs in SQLite;
+`extract-transcript.sh` pulls the readable half — the prompt, every tool call with its JSON
+arguments, the model's running status summaries, and its final written report.
+
+**Read the report.** Agents diagnose interface faults precisely and unprompted. Across these runs
+they found: the six session verbs the bridge never dispatched, a refusal message that reports a
+guessed reason (#662), weapon readiness missing from the legend (#663), and a bash expansion bug
+in `send.sh` that they root-caused from the source (#765).
+
+---
+
+## Assorted, each learned the hard way
+
+- **macOS has no `timeout`.** `agy --print-timeout` is the bound.
+- **A run that ends on the enemy's turn is not stuck** — `end_turn` refuses to hand off a finished
+  mission, so a won or lost board legitimately stops there.
+- **Do not assert on content.** A fixture of one unit against a rushdown loses on turn 3; "the
+  board ends on PLAYER" is false for a good reason. The invariant is *it ends somewhere the driver
+  can act from unless the mission is over*. `tests/README.md` #9's razor applies to run analysis as
+  much as to tests.
+- **Check the tree after every run**, even with the prompt forbidding edits. `run.sh` records
+  `worktree_dirty` and reverts.

--- a/tools/playtest/analyze.sh
+++ b/tools/playtest/analyze.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# ./analyze.sh              -- every saved run, then the arm comparison
+# ./analyze.sh runs/A-1     -- one run
+#
+# Metrics fixed BEFORE either arm ran (see below). A run may hold SEVERAL frame dirs, because a
+# session that restarts the bridge starts a new one -- Gemini restarted 23 times in one baseline
+# session -- so a run is aggregated across all of them rather than being its first dir.
+row() {
+  local D="$1" L="$2"
+  # ONLY the frame log. `save` archives transcript.txt beside it, and counting that as output
+  # inflated BYTES by 4x on the first run analysed -- the metric would have been measuring my own
+  # archiving rather than what the bridge sent.
+  local F=$(find "$D" -path '*frames*' -name '*.txt' 2>/dev/null)
+  [ -z "$F" ] && return
+  local tot=$(grep -h "^@@" $F 2>/dev/null | wc -l | tr -d ' ')
+  local bad=$(grep -h "^@@" $F 2>/dev/null | grep -c "ok=0")
+  local all=$(cat $F 2>/dev/null | wc -c | tr -d ' ')
+  local turns=$(grep -lh "Turn -> PLAYER" $F 2>/dev/null | wc -l | tr -d ' ')
+  # Counted from the CONTENT, not the filename. Batching broke the filename version silently: a
+  # batch is named for its LAST command, so an `overview` inside one is invisible to a glob -- and
+  # this is the pre-registered guard, so a blind guard is worse than none.
+  local ovs=$(cat $F 2>/dev/null | grep -cE "^\[[0-9]+\] overview|cmd=overview")
+  local exs=$(cat $F 2>/dev/null | grep -cE "^\[[0-9]+\] execute|cmd=execute")
+  local aff=$(cat $F 2>/dev/null | grep -cE "^\[[0-9]+\] legal_(moves|targets)|cmd=legal_")
+  # python3 invocations, the #666 metric: an agent that must run arbitrary code cannot be given a
+  # narrow allowlist, and the count tracks round trips rather than taste.
+  local py="-"
+  [ -f "$D/conversation.db" ] && py=$(sqlite3 "$D/conversation.db" "select hex(step_payload) from steps where step_type=15;" 2>/dev/null | xxd -r -p 2>/dev/null | strings -n 8 | grep -oE '"CommandLine":"[^"]{0,60}' | grep -c python)
+  printf '%-14s %6s %7s%% %6s %9s %8s %9s %7s %6s\n' "$L" "$tot" \
+    "$([ "$tot" -gt 0 ] && echo $((bad*100/tot)) || echo 0)" "$turns" "$all" \
+    "$([ "$turns" -gt 0 ] && echo $((all/turns)) || echo -)" \
+    "$([ "$exs" -gt 0 ] && echo "scale=2;$ovs/$exs" | bc || echo -)" "$aff" "$py"
+}
+hdr() { printf '%-14s %6s %8s %6s %9s %8s %9s %7s %6s\n' RUN FRAMES REJECT TURNS BYTES B/TURN OV/EXEC AFFORD PY; }
+if [ -n "$1" ]; then hdr; row "$1" "$(basename $1)"; exit 0; fi
+hdr
+for d in "${IOSIS_PLAYTEST_OUT:-$HOME/iosis-playtest}"/runs/*-*; do [ -d "$d" ] && row "$d" "$(basename $d)"; done
+echo
+echo "PRIMARY is REJECT (baseline 30-54%).  GUARD is OV/EXEC: baseline 0.67 -- if arm B"
+echo "approaches or exceeds that, the redraw MOVED rather than went away and #613 should be"
+echo "reconsidered.  AFFORD counts arm B's discovery of the new queries; 0 means the feature"
+echo "shipped inert however good it is."

--- a/tools/playtest/extract-transcript.sh
+++ b/tools/playtest/extract-transcript.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# extract-transcript.sh <conversation.db> <out.txt>
+# agy stores a session as protobuf blobs in SQLite. Not fully decodable without the schema, but the
+# parts that matter for a playtest post-mortem come out as readable strings: the prompt it was
+# given, every tool call with its JSON arguments, and the model's own running status summaries --
+# which is where "what it was TRYING to do" lives, the half the frame log cannot show.
+DB="$1"; OUT="$2"
+[ -f "$DB" ] || { echo "no such db: $DB"; exit 1; }
+{
+  echo "=== transcript extracted from $(basename "$DB") on $(date -u +%FT%TZ)"
+  echo "=== steps: $(sqlite3 "$DB" 'select count(*) from steps;')"
+  echo
+  sqlite3 "$DB" "select idx, step_type, hex(step_payload) from steps order by idx;" \
+  | while IFS='|' read -r idx type hex; do
+      text=$(echo "$hex" | xxd -r -p 2>/dev/null | strings -n 20 \
+             | grep -vE '^\$|^"\$|^bot-|sessionID|^[A-Za-z0-9+/]{30,}=*$' | head -40)
+      [ -z "$text" ] && continue
+      echo "--- step $idx (type $type)"
+      echo "$text"
+      echo
+    done
+} > "$OUT"
+echo "wrote $OUT ($(wc -l < "$OUT" | tr -d ' ') lines)"

--- a/tools/playtest/prompt.md
+++ b/tools/playtest/prompt.md
@@ -1,0 +1,26 @@
+You are playtesting a tactical RPG through a headless text bridge. Play as well as you can.
+
+The game is a Godot project at the repo root. Read `docs/play-api.md` first — it describes the
+bridge, the command vocabulary and the board rendering. Everything you can do is documented there.
+
+To start the bridge:
+
+    /Applications/Godot.app/Contents/MacOS/Godot --headless --path . -s play/play_bridge.gd
+
+It polls `playrun/command.json` and writes each response to `playrun/state.txt`. Send a command by
+writing JSON with a monotonically increasing `id`, then read `state.txt` back once that `id` appears:
+
+    {"id": 1, "cmd": "load", "args": {"path": "res://Scenarios/missions/Level_1.tres"}}
+
+YOUR TASK
+
+Play `res://Scenarios/missions/Level_1.tres` as the PLAYER faction. Try to win.
+
+STOP when either of these is true:
+  - the mission ends (you win or lose), or
+  - you have completed 8 PLAYER turns.
+
+Then stop and write a short report: what you were trying to do, what worked, and anything about the
+interface that made playing harder than it needed to be.
+
+Do not modify any files in the repository. You are playing the game, not developing it.

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# One unattended playtest run, in an ISOLATED worktree.
+#     IOSIS_PLAYTEST_WT=... IOSIS_PLAYTEST_PROJECT=... tools/playtest/run.sh <n>
+#
+# Read docs/playtest-experiments.md before using this. The traps it records cost real runs.
+set -u
+# --- config (override by env) -----------------------------------------------------------------
+# WT   the worktree the session plays in. NOT your working checkout: an unattended agent runs with
+#      permissions auto-approved, so the blast radius should be a tree you can throw away.
+# PROJ the agy project id pinning the session to WT. See docs/playtest-experiments.md -- agy binds
+#      to a PROJECT, not to cwd, and getting this wrong silently plays in the wrong repo.
+WT="${IOSIS_PLAYTEST_WT:?set IOSIS_PLAYTEST_WT to the playtest worktree}"
+PROJ="${IOSIS_PLAYTEST_PROJECT:?set IOSIS_PLAYTEST_PROJECT to the agy project id}"
+HERE="${IOSIS_PLAYTEST_OUT:-$HOME/iosis-playtest}"
+ARM="${IOSIS_PLAYTEST_ARM:-C}"
+# agy binds to a PROJECT, not to cwd. Run 1 proved that the hard way: launched from the worktree,
+# it played in the main checkout instead and this script archived zero frames. The project below
+# pins folderUri to the worktree; ~/.gemini/config/projects/<id>.json is its definition.
+N="$1"
+OUT="$HERE/runs/$ARM-$N"
+[ -d "$OUT" ] && { echo "$ARM-$N already exists"; exit 1; }
+
+cd "$WT" || exit 1
+# The worktree is the blast radius. A session that ignores "do not modify files" damages a
+# throwaway checkout, never the working tree -- and this asserts it started clean so a dirty tree
+# afterwards is attributable to THIS run.
+git checkout -q . 2>/dev/null; git clean -qfd 2>/dev/null
+rm -rf playrun/frames/* playrun/state.txt playrun/command.json 2>/dev/null
+pkill -f "play_bridge" 2>/dev/null; sleep 1
+
+echo "=== $ARM-$N starting $(date -u +%FT%TZ) @ $(git rev-parse --short HEAD)"
+START=$(date +%s)
+# No outer `timeout`: macOS has no such binary (that cost run 1, harmlessly -- rc=127, nothing
+# launched, no budget spent). agy enforces its own bound with --print-timeout.
+agy -p "$(cat "$(dirname "$0")/prompt.md")" --project "$PROJ" \
+  --dangerously-skip-permissions --print-timeout 20m > "$HERE/.$ARM$N.stdout" 2>&1
+RC=$?
+END=$(date +%s)
+pkill -f "play_bridge" 2>/dev/null
+
+mkdir -p "$OUT"
+cp -R playrun/frames "$OUT/" 2>/dev/null
+# The isolation check, and it FAILS LOUD rather than archiving nothing quietly: zero frames here
+# means the session played somewhere else, which is the whole thing the project pin prevents.
+if [ "$(ls "$OUT/frames" 2>/dev/null | wc -l | tr -d ' ')" = "0" ]; then
+  echo "!! NO FRAMES in the worktree -- the session did not play here. Check the project pin."
+  echo "   look for frames elsewhere -- a session that ignored the pin played in another checkout."
+fi
+cp "$HERE/.$ARM$N.stdout" "$OUT/agent-stdout.txt" 2>/dev/null
+DIRTY=$(git status --porcelain | head -20)
+{ echo "arm=$ARM"; echo "run=$N"; echo "commit=$(git rev-parse --short HEAD)";
+  echo "seconds=$((END-START))"; echo "agy_rc=$RC";
+  echo "frame_dirs=$(ls "$OUT/frames" 2>/dev/null | wc -l | tr -d ' ')";
+  echo "worktree_dirty=$([ -z "$DIRTY" ] && echo no || echo YES)"; } > "$OUT/manifest.txt"
+[ -n "$DIRTY" ] && { echo "$DIRTY" > "$OUT/worktree-changes.txt"; echo "!! the session modified files (recorded, then reverted)"; }
+git checkout -q . 2>/dev/null; git clean -qfd 2>/dev/null
+
+DB=$(ls -t ~/.gemini/antigravity-cli/conversations/*.db 2>/dev/null | head -1)
+if [ -n "$DB" ] && [ "$(stat -f %m "$DB")" -gt "$START" ]; then
+  cp "$DB" "$OUT/conversation.db"
+  "$(dirname "$0")/extract-transcript.sh" "$DB" "$OUT/transcript.txt" >/dev/null 2>&1
+  echo "transcript=$(basename "$DB")" >> "$OUT/manifest.txt"
+fi
+echo "=== $ARM-$N done in $((END-START))s (rc=$RC)"; cat "$OUT/manifest.txt" | sed 's/^/  /'


### PR DESCRIPTION
Seven runs across three arms produced a working method for measuring the headless API against real agents — and a longer list of ways the obvious setup quietly gives a wrong answer. Both were living in a scratch directory outside the repo, which is no use to whoever runs the next one.

## `tools/playtest/`

The harness, generalised off the hardcoded paths it grew with: `run.sh` (one isolated, archived run), `analyze.sh` (the metrics), `extract-transcript.sh` (the agent's own account), `prompt.md` (the shared prompt).

## `docs/playtest-experiments.md`

The operating guide. It's mostly traps, because each one cost a run or a wrong conclusion:

- **`agy` binds to a PROJECT, not to cwd.** A session launched from the worktree played in the main checkout, and the harness reported success while archiving zero frames. Pinning needs a project JSON with `folderUri`; the runner now fails loudly instead of hiding it.
- **`/playrun/` is gitignored**, so switching branches doesn't clear it and the previous arm's frames mix into the next.
- **The prompt is a bigger variable than the code.** *"Give it a spin"* rejected **30–54%** of its own commands; *"play as well as you can, stop at 8 turns"* rejected **4%** on the same build. Arms must share a prompt, and it must not name the affordances being tested — if a session can't find them from the docs, they shipped inert.
- **Pre-register the metrics, then distrust the collector.** Mine was wrong twice, both times flattering the change: it counted its own archived transcripts as game output, and the pre-registered guard went blind when batching renamed the frames it counted. A guard that can't fail is worse than none.
- **`python3` usage is an interface metric**, not hygiene. It tracks round-trip count — and an agent that must run arbitrary code can't be given a narrow permission allowlist, which is why an unattended run needed blanket approval. Batching plus `send.sh` took it 69 → 0.
- **B and C are not comparable.** C added an opponent, so any difference confounds "interface changed" with "game got harder". C is a new baseline, not the other side of an A/B.
- **Two runs per arm is directional, not significant.** Between-run variance on a single build ran 2% to 54%.

It also records the reference values a future arm gets compared against, and what the agents found on their own initiative across the runs: the six undispatched session verbs, a refusal message reporting a guessed reason (#662), weapon readiness missing from the legend (#663), and the `send.sh` expansion bug they root-caused from the source (#765).

## Why this is a doc and not a comment

The method is only worth what its traps are worth, and every one of them is silent: a wrong project pin archives nothing while reporting success, a stale frame log mixes arms, a blind guard reads zero. None of them fail loudly, and all of them produce a number that looks fine.

Docs-only, so CI skips it by design (`paths-ignore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZHJ7AuFedPCURFKoY9xX6
