### PR TITLE
#754: the tear-out stages the blast's whole footprint

### DIFF
--- a/Classes/actions/AttackAction.gd
+++ b/Classes/actions/AttackAction.gd
@@ -13,6 +13,11 @@ var resolved: ResolvedOutcome      # set by PlanResolver each pass (R8) — sour
 var attack_range: Array[Vector2i] = []
 var origin_cell: Vector2i
 var target_cell: Vector2i
+# The cells the blast fired over, occupied or not -- stamped when the resolve builds the volley
+# (create_volley), empty on an authored AIM. The tear-out stages exactly this (#754): every member
+# shares ONE aim cell, so reading target_cell alone left a line's far victims and the ground under
+# the beam on the board while the camera sat on the diorama.
+var footprint: Array[Vector2i] = []
 var target_texture: Texture2D
 var target_name := "Target"
 var is_secondary_hit := false
@@ -241,12 +246,13 @@ static func declare(attacker: Unit, origin: Vector2i, aim_cell: Vector2i) -> Att
 	action.fired_attack = attacker.get_fired_attack()
 	return action
 
-static func create_volley(attacker: Unit, origin: Vector2i, aim_cell: Vector2i, victims: Array[Unit], fired_attack: AttackData = null) -> Array[AttackAction]:
+static func create_volley(attacker: Unit, origin: Vector2i, aim_cell: Vector2i, victims: Array[Unit], fired_attack: AttackData, footprint: Array[Vector2i]) -> Array[AttackAction]:
 	var volley_actions: Array[AttackAction] = []
 
 	for victim in victims:
 		var attack := AttackAction.create(attacker, origin, victim, aim_cell)
 		attack.fired_attack = fired_attack
+		attack.footprint = footprint
 		attack.is_secondary_hit = not volley_actions.is_empty()
 		volley_actions.append(attack)
 

--- a/Classes/actions/CounterAttackAction.gd
+++ b/Classes/actions/CounterAttackAction.gd
@@ -35,7 +35,7 @@ func get_action_icon() -> Texture2D:
 	var lethal := lethality_icon(resolved)
 	return lethal if lethal != null else COUNTER_ATTACK_ICON
 
-static func create_counter_volley(counter_unit: Unit, origin: Vector2i, victims: Array[Unit], source: AttackAction) -> Array[CounterAttackAction]:
+static func create_counter_volley(counter_unit: Unit, origin: Vector2i, victims: Array[Unit], source: AttackAction, footprint: Array[Vector2i]) -> Array[CounterAttackAction]:
 	var counters: Array[CounterAttackAction] = []
 	var volley: Array[AttackAction] = []
 	# The attack this unit fires reactively: a rune counters with whatever it would currently
@@ -47,6 +47,7 @@ static func create_counter_volley(counter_unit: Unit, origin: Vector2i, victims:
 		var counter := CounterAttackAction.new()
 		counter.init_counter(counter_unit, victim, origin, source)
 		counter.fired_attack = chosen
+		counter.footprint = footprint
 		counter.is_secondary_hit = not counters.is_empty()   # only the first lunges
 		counters.append(counter)
 		volley.append(counter)

--- a/Classes/actions/resolution/BeatSheet.gd
+++ b/Classes/actions/resolution/BeatSheet.gd
@@ -135,8 +135,9 @@ var beats: Array[Beat] = []
 # by construction, so they are never gathered separately.
 var cast: Array[Unit] = []
 
-# Every cell a MAIN ACTION touches: attacker origins, aimed cells, whole knockback flights and their
-# landings, terrain deposits, and the actor and target of every side-channel verb. Slice #521's
+# Every cell a MAIN ACTION touches: attacker origins, the blast's WHOLE FOOTPRINT (occupied or not,
+# #754 -- a volley's members all share one aim cell, so the aim alone left every secondary victim
+# and the ground under the beam on the board), whole knockback flights and their landings, terrain deposits, and the actor and target of every side-channel verb. Slice #521's
 # tear-out set is exactly this, computed once here rather than again there.
 #
 # MOVEMENT CONTRIBUTES NOTHING, and that is the rule rather than an omission (dev, 2026-08-26):
@@ -334,6 +335,9 @@ func _gather_cells(plan: ResolvedPlan) -> void:
 				continue
 			_mark(attack.origin_cell, seen)
 			_mark(attack.target_cell, seen)
+			# Origin and aim stay beside the footprint: a truncated line (#756) can cut its own aim cell.
+			for cell in attack.footprint:
+				_mark(cell, seen)
 			var out := attack.resolved
 			if out == null or not out.knockback_applied:
 				continue

--- a/Classes/actions/resolution/PlanResolver.gd
+++ b/Classes/actions/resolution/PlanResolver.gd
@@ -307,9 +307,10 @@ static func _derive_watch_shot(watch: Watch, entrant: Unit, board: BoardContext,
 		# reachable through a chain that shoved the crosser out before this watch fired.
 		var cell_shot := AttackAction.create(watch.watcher, watch.anchor_cell, null, watch.aim_cell)
 		cell_shot.fired_attack = watch.attack
+		cell_shot.footprint = watch.footprint
 		group.append(cell_shot)
 	else:
-		group = AttackAction.create_volley(watch.watcher, watch.anchor_cell, watch.aim_cell, victims, watch.attack)
+		group = AttackAction.create_volley(watch.watcher, watch.anchor_cell, watch.aim_cell, victims, watch.attack, watch.footprint)
 	for shot in group:
 		shot.is_watch_shot = true
 		shot.triggered_by = entrant

--- a/Classes/squads/SquadManager.gd
+++ b/Classes/squads/SquadManager.gd
@@ -801,9 +801,10 @@ func _resolve_actions(squad: Squad, actions: Array[BaseAction], board: BoardCont
 			# land (#50). Units are a CONSEQUENCE of the aimed cells, not the gate.
 			var cell_attack := AttackAction.create(aim.actor, origin, null, aim.target_cell)
 			cell_attack.fired_attack = aim.fired_attack
+			cell_attack.footprint = affected
 			group.append(cell_attack)
 		else:
-			group = AttackAction.create_volley(aim.actor, origin, aim.target_cell, victims, aim.fired_attack)
+			group = AttackAction.create_volley(aim.actor, origin, aim.target_cell, victims, aim.fired_attack, affected)
 
 		# Back-link every derived action to the order that produced it -- read by the whiff clause
 		# and the queue row's tint. One place, so a new expansion branch can't forget it.
@@ -853,7 +854,7 @@ func _resolve_actions(squad: Squad, actions: Array[BaseAction], board: BoardCont
 		var healing := c_attack != null and c_attack.heals
 		var c_affected := Reach.get_affected_cells_from(aim.actor, c_origin, c_aim_cell, c_attack, board)
 		var c_victims := RulesService.gather_attack_victims(aim.actor, c_affected, board, c_attack, healing)
-		for ctr in CounterAttackAction.create_counter_volley(aim.actor, c_origin, c_victims, aim.source_attack):
+		for ctr in CounterAttackAction.create_counter_volley(aim.actor, c_origin, c_victims, aim.source_attack, c_affected):
 			plan.counters.append(ctr)
 	# Phase 2: counters, now built from post-shove positions.
 	PlanResolver.resolve_counters(plan, hypo, reactions, board, terrain_reactions)

--- a/docs/design/visual-clarity.md
+++ b/docs/design/visual-clarity.md
@@ -1959,8 +1959,10 @@ reading it off the displaced point would name a cell in the sky.
 
 **A MAIN ACTION is what tears the board open — movement never does** (dev, on playing it:
 *"there have to be main actions at play. Movement by itself doesn't do it."*). `BeatSheet.cells` is
-therefore what main actions touch: an attack's origin, aim, knockback flight and terrain deposits,
-plus the actor and target of every side-channel verb. Asked of `BaseAction.is_main_action()` rather
+therefore what main actions touch: an attack's origin, its aim, the blast's **whole footprint** (occupied or not â
+[#754](https://github.com/Phaazoid/Godoiosis/issues/754): a volley's members all share one aim cell, so
+reading the aim alone left a line's far victims and the ground under the beam on the board), its
+knockback flight and terrain deposits, plus the actor and target of every side-channel verb. Asked of `BaseAction.is_main_action()` rather
 than of `SIDE_CHANNEL_ORDER` membership — the two lists agree today and nothing pins that they must.
 
 **The GATE falls out of the SET rather than sitting beside it**: no main actions means no cells

--- a/tests/ai/test_main_action_chooser.gd
+++ b/tests/ai/test_main_action_chooser.gd
@@ -66,7 +66,7 @@ func _resolve_aim(attacker: Unit, aim: AttackAction, units: Array[Unit]) -> Reso
 	var affected: Array[Vector2i] = Reach.get_affected_cells_from(attacker, aim.origin_cell, aim.target_cell, aim.fired_attack, null)
 	var victims: Array[Unit] = RulesService.gather_attack_victims(attacker, affected, _board(units), aim.fired_attack)
 	var plan: ResolvedPlan = ResolvedPlan.new()
-	for a in AttackAction.create_volley(attacker, aim.origin_cell, aim.target_cell, victims, aim.fired_attack):
+	for a in AttackAction.create_volley(attacker, aim.origin_cell, aim.target_cell, victims, aim.fired_attack, affected):
 		plan.attacks.append(a)
 	var no_reactions: Array[ElementalReaction] = []
 	PlanResolver.resolve(plan, no_reactions)

--- a/tests/squad/test_beat_sheet.gd
+++ b/tests/squad/test_beat_sheet.gd
@@ -113,6 +113,77 @@ func test_the_cast_holds_every_member_of_every_participating_squad() -> void:
 	_break_volleys(plan)
 
 
+
+# THE BLAST'S WHOLE FOOTPRINT IS ON STAGE, occupied or not (dev, 2026-09-05: "definitely B", #754).
+# create_volley stamps every member with the ONE aim cell, so marking target_cell put a line's lead
+# victim on stage and left the rest -- and the empty ground under the beam -- on the board forty
+# cells below the camera. The report's shape: four hits down a column, staged 2.
+func test_a_volley_puts_its_whole_footprint_on_stage() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	_give_a_line(attacker, 3)
+	var near := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.LDR: 3})
+	var far := H.spawn_solo(self, _sm, ENEMY, Vector2i(3, 0), {Stats.Stat.LDR: 3})
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker, near, far]))
+	var sheet := BeatSheet.read(attacker.squad, plan)
+
+	# Non-vacuity: the line reached both of them, or the far cell proves nothing.
+	assert_int(plan.attacks.size()).override_failure_message(
+			"fixture drifted: the line did not hit both").is_equal(2)
+	for cell: Vector2i in [Vector2i(1, 0), Vector2i(2, 0), Vector2i(3, 0)]:
+		assert_bool(sheet.cells.has(cell)).override_failure_message(
+				"%s is not on stage: %s" % [cell, sheet.cells]).is_true()
+	_break_volleys(plan)
+
+
+# A counter's footprint comes along too: the foe answers with a line, and the open ground its beam
+# crosses past the attacker lifts with the fight.
+func test_a_counters_footprint_is_on_stage() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(2, 0), {Stats.Stat.LDR: 3})
+	var foe := H.spawn_solo(self, _sm, ENEMY, Vector2i(3, 0), {Stats.Stat.LDR: 3})
+	_give_a_line(foe, 2)
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(3, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker, foe]))
+	var sheet := BeatSheet.read(attacker.squad, plan)
+
+	assert_array(plan.counters).override_failure_message(
+			"fixture drifted: nobody countered").is_not_empty()
+	# The foe fires back along -x: (2, 0) is the attacker, (1, 0) is open ground under the beam.
+	assert_bool(sheet.cells.has(Vector2i(1, 0))).override_failure_message(
+			"the counter's empty cell is not on stage: %s" % [sheet.cells]).is_true()
+	_break_volleys(plan)
+
+
+# A swing at open ground (#47) stages its footprint: the cell-attack branch is the one a volley
+# case cannot reach, and it fires over the same ground.
+func test_a_swing_at_open_ground_stages_its_footprint() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.LDR: 3})
+	_give_a_line(attacker, 3)
+	_sm.active_squad = attacker.squad
+	attacker.squad._queue_action(AttackAction.declare(attacker, attacker.movement.cell, Vector2i(1, 0)))
+
+	var plan := _sm.resolve_plan(attacker.squad, _board_with([attacker]))
+	var sheet := BeatSheet.read(attacker.squad, plan)
+
+	assert_int(plan.attacks.size()).is_equal(1)
+	assert_object(plan.attacks[0].target).override_failure_message(
+			"fixture drifted: somebody was hit").is_null()
+	for cell: Vector2i in [Vector2i(1, 0), Vector2i(2, 0), Vector2i(3, 0)]:
+		assert_bool(sheet.cells.has(cell)).override_failure_message(
+				"%s is not on stage: %s" % [cell, sheet.cells]).is_true()
+	_break_volleys(plan)
+
+
+# A line of the given length on the unit's own template, so declare() fires it.
+func _give_a_line(unit: Unit, length: int) -> void:
+	var line := ForwardLinePattern.new()
+	line.length = length
+	var weapon: WeaponInstance = unit.get_equipped_weapon() as WeaponInstance
+	weapon.template.main_attack.attack_pattern = line
 # --- fact cases: hand-built plans -----------------------------------------------------------
 
 # One blast is one shot however many it hits -- #410 rules an AoE striking three victims a single
@@ -157,7 +228,7 @@ func test_a_three_victim_volley_is_one_beat_in_strike_order() -> void:
 	var plan := ResolvedPlan.new()
 	var victims: Array[Unit] = [a, b, c]
 	plan.attacks.assign(AttackAction.create_volley(attacker, Vector2i(0, 0), Vector2i(1, 0),
-			victims, attacker.get_equipped_weapon().template.main_attack))
+			victims, attacker.get_equipped_weapon().template.main_attack, _cells_of(victims)))
 
 	var sheet := BeatSheet.read(attacker.squad, plan)
 	var volleys := _of_kind(sheet, BeatSheet.Kind.VOLLEY)
@@ -195,7 +266,7 @@ func test_an_all_skipped_counter_phase_produces_no_beats_and_no_turnover() -> vo
 	var source := H.stamped_attack(attacker, foe)
 	plan.attacks.append(source)
 	var victims: Array[Unit] = [attacker]
-	for counter in CounterAttackAction.create_counter_volley(foe, Vector2i(1, 0), victims, source):
+	for counter in CounterAttackAction.create_counter_volley(foe, Vector2i(1, 0), victims, source, _cells_of(victims)):
 		counter.resolved = ResolvedOutcome.new()
 		counter.resolved.skipped = true
 		plan.counters.append(counter)
@@ -382,7 +453,7 @@ func test_a_volley_gets_ONE_hold_on_the_action_that_opens_it() -> void:
 	var plan := ResolvedPlan.new()
 	var victims: Array[Unit] = [a, b, c]
 	plan.attacks.assign(AttackAction.create_volley(attacker, Vector2i(0, 0), Vector2i(1, 0),
-			victims, attacker.get_equipped_weapon().template.main_attack))
+			victims, attacker.get_equipped_weapon().template.main_attack, _cells_of(victims)))
 
 	var sheet := BeatSheet.read(attacker.squad, plan)
 	var executor := OrderExecutor.new()
@@ -420,7 +491,7 @@ func test_a_volley_lingers_ONCE_after_the_action_that_closes_it() -> void:
 	var plan := ResolvedPlan.new()
 	var victims: Array[Unit] = [a, b, c]
 	plan.attacks.assign(AttackAction.create_volley(attacker, Vector2i(0, 0), Vector2i(1, 0),
-			victims, attacker.get_equipped_weapon().template.main_attack))
+			victims, attacker.get_equipped_weapon().template.main_attack, _cells_of(victims)))
 
 	var sheet := BeatSheet.read(attacker.squad, plan)
 	var executor := OrderExecutor.new()
@@ -620,6 +691,15 @@ func _beat_of_a_hit_on_an_ally(healing: bool) -> BeatSheet.Beat:
 	return beat
 
 
+# A hand-built volley's footprint: the ground its victims stand on, which is all a fictional blast
+# can honestly claim.
+func _cells_of(units: Array[Unit]) -> Array[Vector2i]:
+	var cells: Array[Vector2i] = []
+	for unit in units:
+		cells.append(unit.movement.cell)
+	return cells
+
+
 func _board_with(units_in: Array) -> BoardContext:
 	var units: Array[Unit] = []
 	units.assign(units_in)
@@ -661,7 +741,7 @@ func test_the_emphasis_schedule_keys_on_the_action_that_OPENS_a_beat() -> void:
 	var plan := ResolvedPlan.new()
 	var victims: Array[Unit] = [a, b]
 	plan.attacks.assign(AttackAction.create_volley(attacker, Vector2i(0, 0), Vector2i(1, 0),
-			victims, attacker.get_equipped_weapon().template.main_attack))
+			victims, attacker.get_equipped_weapon().template.main_attack, _cells_of(victims)))
 
 	var sheet := BeatSheet.read(attacker.squad, plan)
 	var executor := OrderExecutor.new()
@@ -692,7 +772,7 @@ func test_every_beat_publishes_an_emphasis_INCLUDING_zero() -> void:
 	var plan := ResolvedPlan.new()
 	var victims: Array[Unit] = [victim]
 	plan.attacks.assign(AttackAction.create_volley(attacker, Vector2i(0, 0), Vector2i(1, 0),
-			victims, attacker.get_equipped_weapon().template.main_attack))
+			victims, attacker.get_equipped_weapon().template.main_attack, _cells_of(victims)))
 
 	var sheet := BeatSheet.read(attacker.squad, plan)
 	var executor := OrderExecutor.new()

--- a/tests/squad/test_volley.gd
+++ b/tests/squad/test_volley.gd
@@ -29,7 +29,10 @@ func after_test() -> void:
 
 # Make a tracked volley (so after_test can release its cycle).
 func _make_volley(attacker: Unit, aim: Vector2i, victims: Array[Unit]) -> Array[AttackAction]:
-	var volley := AttackAction.create_volley(attacker, attacker.movement.cell, aim, victims)
+	var footprint: Array[Vector2i] = []
+	for victim in victims:
+		footprint.append(victim.movement.cell)
+	var volley := AttackAction.create_volley(attacker, attacker.movement.cell, aim, victims, null, footprint)
 	_volleys.append(volley)
 	return volley
 


### PR DESCRIPTION
Closes #754 (child of #410).

## The bug

The castle-siege sage fires a line down a column and hits four units; the zoom staged two tiles, hers and the first victim's. `create_volley` stamps every member of a volley with the ONE aim cell, and `BeatSheet._gather_cells` marked origin + `target_cell` into a deduped set, so a four-victim volley contributed one target cell. Every secondary victim took the hit on the board forty cells below the camera, and the ground under the beam never lifted. Same on `main`, same for the player's own lines and AoEs, same shape for counters.

## The fix (dev ruling 2026-09-05: option B, "definitely B")

The tear-out set takes **the blast's whole footprint, occupied or not**.

- `AttackAction.footprint` — the cells the blast fired over, stamped when the resolve builds the volley, empty on an authored aim. `create_volley` and `create_counter_volley` take it as a REQUIRED parameter (the compiler found the six hand-built test volleys my grep missed).
- The four producers pass the footprint they already computed to gather victims: authored volleys and the no-victim cell attack (`SquadManager`), counters (`SquadManager`), watch shots and their cell-shot branch (`PlanResolver`, `watch.footprint`). No new geometry anywhere; the answer now travels with the volley instead of being dropped.
- `BeatSheet._gather_cells` marks every footprint cell beside origin and aim (both kept: the rule names them, and a #756-truncated line can cut its own aim cell).

An elemental line already lifted its empty cells through `plan.cell_effects` ("every cell, occupied or not"); a plain line now agrees with it.

## Tests

Three cases in `tests/squad/test_beat_sheet.gd`, driven through the real resolver:

- **a volley puts its whole footprint on stage** — a length-3 line with victims at (1,0) and (3,0) and nothing at (2,0); all three cells staged. This is the report's shape.
- **a counter's footprint is on stage** — the foe answers with a line; the open ground past the attacker lifts.
- **a swing at open ground stages its footprint** — the cell-attack branch, which a volley case cannot reach.

The wire was already pinned: `test_staging` asserts the executor lifts exactly `sheet.cells`.

**Mutants (committed first, one suite file, each reverted with `git checkout` and a clean `git status`):**
- M1 — delete the sheet's footprint marks → `(2, 0) is not on stage: [(0, 0), (1, 0)]`. Dead.
- M2 — `create_volley` stamps `[]` → same line. Dead. Two mutants because the stamp and the read are different wires.

Local: `squad presentation ai`, 1066 cases, 0 failures, 270s. CI owns the rest.

## Canon

`docs/design/visual-clarity.md`: the "what main actions touch" sentence now names the footprint. `standing-reactions.md`'s staging line stays true. No version bump in this diff.

Not touched: `aim_line()` (the camera's profile angle) still reads origin → aim, which is the right pair for a line. Framing the far end of a beam would be a separate look ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
