### PR TITLE
#694: a cast is empowered where the elements are

### DIFF
--- a/Classes/actions/resolution/PlanResolver.gd
+++ b/Classes/actions/resolution/PlanResolver.gd
@@ -351,7 +351,7 @@ static func _resolve_one(action: AttackAction, reactions: Array[ElementalReactio
 		outcome.elevation_delta = board.elevation_at(target_hypo.position) - board.elevation_at(action.origin_cell)
 
 	# --- base damage stage (E1: the calc that used to live in AttackAction.create) ---
-	var base := _source_base_damage(action)
+	var base := _source_base_damage(action, board, hypo)
 	outcome.base_damage = base
 
 	# A heal short-circuits here: reinterprets `base` as HP restored, skips every hurt-only stage below.
@@ -561,10 +561,14 @@ static func _mitigation_for(action: AttackAction, target: Unit, target_hypo: _Hy
 # now the same answer on both sides — STR damage here, adjacency-1 in Reach.
 # A rune fails the WeaponAttackData check -> contributes nothing in melee (its attack rides on
 # fired_attack instead). #30/#72.
-static func _source_base_damage(action: AttackAction) -> int:
+static func _source_base_damage(action: AttackAction, board: BoardContext = null, hypo: Dictionary = {}) -> int:
 	var attacker := action.actor
 	if action.fired_attack is TransmutationData:
-		return (action.fired_attack as TransmutationData).base_damage(attacker)
+		# Materia empowerment (#694) is read at the caster's THREADED position, not the frozen
+		# origin_cell the geometry uses: a shove earlier in this pass moves the BODY, and a body
+		# knocked off the bank casts unempowered. The aim it declared is what stays frozen.
+		var empowered := Materia.empowered_at(projected_position(attacker, hypo), board)
+		return (action.fired_attack as TransmutationData).base_damage(attacker, empowered)
 	if action.fired_attack is WeaponAttackData:
 		var weapon := attacker.get_equipped_weapon() as WeaponInstance
 		if weapon != null:

--- a/Classes/alchemy/Materia.gd
+++ b/Classes/alchemy/Materia.gd
@@ -1,0 +1,59 @@
+class_name Materia
+extends Object
+
+# The materia SOURCE layer: which elements a cell offers, and which a caster standing there may
+# draw on. Canon: docs/design/alchemy-kit.md -> Materia -- THE ONE LAW is that materia never gates
+# function, it supercharges it, so nothing here can refuse a cast. It only ever adds.
+#
+# Static, with the board as an explicit parameter -- the RulesService/SquadCohesion shape. Terrain
+# state changes mid-battle (a fire is doused, ice melts), so a cached board would answer for a
+# world that no longer exists. It lives in alchemy/ rather than in RulesService because every
+# predicate there answers a question about a unit MOVING over terrain, and that class has no
+# element vocabulary at all.
+#
+# Reads go through BoardContext METHODS, never its stores: a stub board carries a null grid and a
+# null state store, and terrain_kind_at is a method precisely so a fixture can override it.
+
+# How far a source reaches. On or adjacent -- "stand BY your source" is meant literally, and
+# cells_within_manhattan_range includes the origin, so 1 is exactly on-or-adjacent.
+const REACH := 1   # playtest-tunable
+
+# What THIS cell offers, ignoring reach -- the terrain fact. Veins (#696) extend HERE, and the
+# empowerment overlay (#699) draws it. A carried flask (#697) is NOT positional and never enters:
+# it unions in at the call site, beside whatever this returns.
+#
+# Air and Aether are deliberately absent (dev, 2026-09-05). Air's "what counts as high ground" is
+# parked as its own question; Aether waits on authored life-dense content, because a living TREE
+# is not a source -- the ambient half of that ruling is in alchemy-kit.md's source table.
+static func sources_at(cell: Vector2i, board: BoardContext) -> Array[Elemental.Element]:
+	var found: Array[Elemental.Element] = []
+	if board == null:
+		return found
+	var kind := board.terrain_kind_at(cell)
+	# WATER: the tile, unless it has frozen over -- ice is a floor, not a well. The same
+	# state-aware read is_walkable makes of the same cell, and the reason this asks the board
+	# rather than the tile alone.
+	if kind == Terrain.Kind.WATER and not board.has_tile_state(cell, Terrain.TileState.FROZEN):
+		found.append(Elemental.Element.WATER)
+	# EARTH: rock. Walls and boulders are ROCK tiles already, so "press your back to the wall"
+	# comes free from REACH rather than needing a prop rule. Cliff faces are NOT here yet.
+	if kind == Terrain.Kind.ROCK:
+		found.append(Elemental.Element.EARTH)
+	# FIRE: something actually alight. An unlit flammable is FUEL, not a source, so no Kind is
+	# consulted -- a tree becomes one the moment it catches, through the state it gains.
+	if Terrain.is_burning(board.tile_states_at(cell)) or board.prop_lit_at(cell):
+		found.append(Elemental.Element.FIRE)
+	return found
+
+# Every element a caster standing on `cell` may draw on: the union of sources within REACH.
+# Deduped, because empowerment is BINARY and never stacks -- a vein beside a river is still just
+# "empowered in water: yes" (and will be, once #696 puts veins in sources_at).
+static func empowered_at(cell: Vector2i, board: BoardContext) -> Array[Elemental.Element]:
+	var found: Array[Elemental.Element] = []
+	if board == null:
+		return found
+	for near: Vector2i in GridUtils.cells_within_manhattan_range(cell, REACH):
+		for element: Elemental.Element in sources_at(near, board):
+			if not found.has(element):
+				found.append(element)
+	return found

--- a/Classes/alchemy/Materia.gd.uid
+++ b/Classes/alchemy/Materia.gd.uid
@@ -1,0 +1,1 @@
+uid://che1decb5h8nl

--- a/Classes/alchemy/TransmutationData.gd
+++ b/Classes/alchemy/TransmutationData.gd
@@ -39,12 +39,24 @@ func cost() -> int:
 # 2 Fire scales twice off fire aura. A leeway-covered (0-aura) element adds nothing.
 # A utility carving (#126) skips the scaling entirely: aura still GATES channeling, it just
 # never adds damage to a damageless effect.
-func base_damage(wielder: Unit) -> int:
+#
+# `empowered` (#694) is the elements the caster may draw materia from where they stand — PASSED,
+# never looked up, because a carving has no board and must not grow one (Law #4). It is +1
+# EFFECTIVE aura and enters the loop rather than the total, so a 2-Fire carving beside a fire
+# gains +2, exactly as its two sigils already weight the wielder's own aura.
+#
+# It is SCALING ONLY. Nothing here may reach the channeling ladder below: the anchor, the deficit
+# and the wildcard pools all read wielder.get_element_aura directly, and RuneData.can_equip_reason
+# derives from channel_block_reason — so leaving that accessor alone is what keeps empowerment out
+# of all three at once. Never make get_element_aura position-aware.
+func base_damage(wielder: Unit, empowered: Array[Elemental.Element] = []) -> int:
 	if deals_no_damage:
 		return 0
 	var scaling := 0
 	for e in sigils:
 		scaling += wielder.get_element_aura(e)
+		if empowered.has(e):
+			scaling += 1
 	return power + scaling
 
 # --- Channeling: anchor + wildcards (dev, 2026-08-10 — REPLACES the 2026-07-04 temper/leeway

--- a/Classes/board/BoardContext.gd
+++ b/Classes/board/BoardContext.gd
@@ -50,7 +50,7 @@ func is_walkable(cell: Vector2i) -> bool:
 	#
 	# The FROZEN short-circuit deliberately runs BEFORE the tile lookup: the headless fixtures
 	# carry a bare grid with no TileSet, and ice-over-water is the one thing they need to answer.
-	if terrain_states != null and terrain_states.has_state(cell, Terrain.TileState.FROZEN):
+	if has_tile_state(cell, Terrain.TileState.FROZEN):
 		return true
 	# #109's rule (a tile that doesn't declare the flag is NOT walkable, and the guard that stops
 	# get_custom_data raising) lives in GridUtils.walkable_of since #552, because the meshlib
@@ -74,9 +74,33 @@ func terrain_kind_at(cell: Vector2i) -> Terrain.Kind:
 # whoever stands on it. Sibling of terrain_kind_at, same rationale — the resolver's mitigation
 # stage and the inspect panel's DEF readout both come through here, so they can't drift.
 func cover_def_at(cell: Vector2i) -> int:
+	return Terrain.COVER_DEF if has_tile_state(cell, Terrain.TileState.COVER) else 0
+
+# The rules' read-points for a cell's dynamic tile STATE — the null-safe forms of the store's own
+# two accessors, siblings of terrain_kind_at for the same two reasons: a board built without a
+# state store reads empty rather than crashing, and a fixture can stub them.
+#
+# `is_walkable` and `cover_def_at` each carried their own `terrain_states != null` guard before
+# #694 wanted a third; one guard, one place (Law #4). Both spellings are here because the callers
+# genuinely differ — a caller naming ONE state wants has_tile_state, while a caller asking a
+# question OVER the states (Terrain.is_burning, which owns which members count as fire) needs the
+# array and must not enumerate FIRE_STATES itself.
+func tile_states_at(cell: Vector2i) -> Array[Terrain.TileState]:
 	if terrain_states == null:
-		return 0
-	return Terrain.COVER_DEF if terrain_states.has_state(cell, Terrain.TileState.COVER) else 0
+		return []
+	return terrain_states.states_at(cell)
+
+func has_tile_state(cell: Vector2i, state: Terrain.TileState) -> bool:
+	if terrain_states == null:
+		return false
+	return terrain_states.has_state(cell, state)
+
+# Is the prop standing on this cell ALIGHT (#272's prop_lit column)? Sibling of terrain_kind_at,
+# and null-safe on the GRID as well as the tile, because a stub board carries no TileMapLayer.
+func prop_lit_at(cell: Vector2i) -> bool:
+	if grid == null:
+		return false
+	return GridUtils.prop_lit_of(grid.get_cell_tile_data(cell))
 
 # The rules' read-points for elevation (#257), siblings of terrain_kind_at / cover_def_at and there
 # for the same reason: methods rather than inline store reads, so a fixture board can stub them.

--- a/docs/design/alchemy-kit.md
+++ b/docs/design/alchemy-kit.md
@@ -6,7 +6,7 @@
 
 Supersedes the wiki's **tiered rune tree** and the **stale top half of `Alchemy.docx`** (one-rune-per-element, aura-from-casting — the dev confirmed that section is an old layer), plus all **crit / hit / avo / AP / random-level-up** framing (Law #1; `Stats Overview.docx` is otherwise pre-determinism-era). Empty wiki stubs: `Alcahest & elemental affinities.docx`, `Rune Combination Psuedocode.docx`.
 
-**Canon checked through #699 (2026-09-02).**
+**Canon checked through #782 (2026-09-05).**
 
 Tags: **[LOCKED]** · **[PROPOSED]** (awaiting sign-off) · **[WORKSHOP]** (actively being designed) · **[OPEN]** (fork).
 
@@ -100,11 +100,20 @@ A cast is **empowered** in element *E* when the caster is **on or adjacent to** 
 - **Otherwise the fallback: +1 effective aura in that element, scaling only** — used when nothing special suits the carving, or when raw power simply *is* the fitting answer. It is the limb tax's mirror twin: aura already moves by ±1, the wound takes a point and the river lends one.
 - **Three invariants, each load-bearing.** Empowerment **never** feeds the **anchor** (a carving you cannot channel stays unchannelable), **never** feeds **wildcards** (the deficit budget does not move with position), and **never** feeds the **equip gate** — otherwise walking away from a river would force-unequip a rune mid-battle (`EquippableData.can_equip`, [#157](https://github.com/Phaazoid/Godoiosis/issues/157)). Empowerment is power, never permission.
 - **Binary, never stacked.** A vein beside a river is still just *empowered in water: yes*.
-- Keyed on the caster's **projected cell at resolve time**, so the queue previews it exactly (Law #2). Reach is a **knob**, a game constant rather than mission mood.
+- Keyed on the caster's **projected cell at resolve time**, so the queue previews it exactly (Law #2). Reach is **playtest-tunable** — `Materia.REACH`, a bare `const` beside the rule that reads it, the `OVERKILL_CEILING`/`DOWN_WILL_COST` idiom. *(Not a `GameKnobs` row: that table is presentation only — board markup, camera, fire visuals, HUD colours — and structurally addresses node/class properties reachable from the Battle3D host. #694's own issue body said otherwise and was wrong.)*
 
 ### Sources — two kinds
 
-1. **Terrain-derived** (common, element-specific, no second painted layer — *terrain **is** the materia map*): **water** = water tiles · **fire** = burning tiles, flammables, lit props · **earth** = rock: walls, boulders, cliff faces · **air** = elevation: high ground and cliff edges · **aether** = life-dense features: trees, groves, herb patches. **Living units are never ambient sources** (see *Aether sourcing* under Special cases).
+1. **Terrain-derived** (common, element-specific, no second painted layer — *terrain **is** the materia map*). **Narrowed at build time, dev 2026-09-05 (#694)** — the list below is what a cell actually offers; the wider list this replaces was written at grill resolution and is kept underneath, because two of its five elements are waiting rather than rejected:
+   - **water** = a water tile, **unless it has frozen over** — ice is a floor, not a well.
+   - **earth** = a **rock** tile. Walls and boulders already are rock tiles, so *press your back to the wall* comes free from the reach rule. **Cliff faces are not in yet.**
+   - **fire** = something **actually alight**: a burning or blazing cell, or a lit prop. **An unlit flammable is FUEL, not a source** — a tree offers nothing until it catches, and then offers fire through the state it gained.
+   - **air** — **nothing. PARKED**: *what counts as high ground* (any lower neighbour? a full level's drop? an absolute height?) is a real fork, filed as [#783](https://github.com/Phaazoid/Godoiosis/issues/783) rather than guessed at.
+   - **aether** — **nothing yet, and this is a content gap rather than a rule**: ambient aether is life-dense **terrain**, and no such feature is authored. It arrives with the authored-source work ([#696](https://github.com/Phaazoid/Godoiosis/issues/696)).
+
+   *(The pre-build wording, for the record: fire = burning tiles, **flammables**, lit props · earth = rock: walls, boulders, **cliff faces** · air = elevation: high ground and cliff edges · aether = life-dense features: trees, groves, herb patches.)*
+
+   **Living units are never ambient sources** (see *Aether sourcing* under Special cases) — unchanged, and the reason the aether gap is a missing feature rather than a missing unit rule.
 2. **Veins** (authored, scarce — the contested hotspots): **element-tagged**, the common kind out in the world, and **alkahest veins**, which are **universal** — they empower any element, and are the common kind near **Paracelsus proper**, the alkahest-saturated runestone being why wildcards work at all. Their in-world substances are lore: [alchemy-lore.md](../story/world/alchemy-lore.md) → *Materia — the minerals* (**the authority on what materia IS**; this doc stays the authority on what it DOES).
 
 **Sources are permanent and empowerment consumes nothing.** A source changes only when the *terrain* changes — a fire burns out or is doused, FROZEN water is no source until it melts, and **mechanist terraforming** (drills) can open or bury a vein, so positioning/pathing matter and the alchemy economy is still reshapeable mid-battle. **Maps can still break the rules:** extreme environments (a fallout zone; the Still Point's null field) override source availability as an authored, per-map dial.

--- a/tests/items/test_transmutation_and_runes.gd
+++ b/tests/items/test_transmutation_and_runes.gd
@@ -47,6 +47,43 @@ func test_repeated_sigils_weight_the_scaling() -> void:
 	var t: TransmutationData = _carving([Elemental.Element.FIRE, Elemental.Element.FIRE, Elemental.Element.EARTH], 5)
 	assert_int(t.base_damage(u)).is_equal(13)   # 5 + 3 + 3 + 2
 
+# --- materia empowerment (#694): +1 EFFECTIVE aura in an element the caster can draw on ---
+# WHERE that list comes from is Materia's (tests/runes/test_materia_sources.gd); here it is
+# passed in, because a carving has no board and must never grow one.
+
+func test_empowerment_adds_one_per_matching_sigil() -> void:
+	var u: Unit = _alchemist({ Elemental.Element.FIRE: 7 })
+	var t: TransmutationData = _carving([Elemental.Element.FIRE], 5)
+	assert_int(t.base_damage(u, [Elemental.Element.FIRE])).is_equal(13)   # 12 + 1
+
+# It is +1 AURA, not +1 damage, so a repeated sigil weights it exactly as it weights the real
+# pool -- the reason it enters the loop rather than the total.
+func test_empowerment_weights_with_repeated_sigils() -> void:
+	var u: Unit = _alchemist({ Elemental.Element.FIRE: 3, Elemental.Element.EARTH: 2 })
+	var t: TransmutationData = _carving([Elemental.Element.FIRE, Elemental.Element.FIRE, Elemental.Element.EARTH], 5)
+	assert_int(t.base_damage(u, [Elemental.Element.FIRE])).is_equal(15)   # 13 + 1 + 1
+
+func test_empowerment_in_an_element_the_carving_lacks_does_nothing() -> void:
+	var u: Unit = _alchemist({ Elemental.Element.FIRE: 7 })
+	var t: TransmutationData = _carving([Elemental.Element.FIRE], 5)
+	assert_int(t.base_damage(u, [Elemental.Element.WATER])).is_equal(12)   # unchanged
+
+# Empowerment is SCALING, and a utility carving suppresses scaling entirely (#126) -- which is
+# the structural reason #695's authored form exists: the fallback can never reach one.
+func test_a_damageless_carving_gains_nothing_from_empowerment() -> void:
+	var u: Unit = _alchemist({ Elemental.Element.AIR: 4 })
+	var t: TransmutationData = _carving([Elemental.Element.AIR], 5)
+	t.deals_no_damage = true
+	assert_int(t.base_damage(u, [Elemental.Element.AIR])).is_equal(0)
+
+# An element the wielder has NO pool in still gains the point: empowerment is drawn from the
+# ground, not from talent. (Whether the carving may be channelled at all is a different
+# question, asked below and deliberately untouched by any of this.)
+func test_empowerment_applies_without_a_pool_in_that_element() -> void:
+	var u: Unit = _alchemist({ Elemental.Element.FIRE: 2 })
+	var t: TransmutationData = _carving([Elemental.Element.FIRE, Elemental.Element.WATER], 5)
+	assert_int(t.base_damage(u, [Elemental.Element.WATER])).is_equal(8)   # 5 + 2 + 0 + 1
+
 # --- channeling gate: anchor + wildcards (dev 2026-08-10, replacing the 2026-07-04 temper/
 # trained-leeway/strain model — repeal record in transmutation-model-proposal.md). One case per
 # row of the plan's worked-examples table. NB the dev's own two illustration carvings were

--- a/tests/runes/test_channel_reasons.gd
+++ b/tests/runes/test_channel_reasons.gd
@@ -164,3 +164,52 @@ func test_a_channelable_carving_still_queues() -> void:
 	aim.fired_attack = affordable
 
 	assert_bool(_sm.queue_action(alch.squad, aim)).is_true()
+
+
+# --- #694: empowerment is POWER, never PERMISSION -------------------------------------------
+#
+# The anchor, the deficit and both wildcard pools all read wielder.get_element_aura directly, and
+# RuneData.can_equip_reason derives from channel_block_reason (#744) -- so leaving that accessor
+# position-blind is the ONE thing keeping materia out of all three gates at once.
+#
+# Each case below proves the source is genuinely LIVE by asserting that base_damage DOES move for
+# the same wielder and carving. Without that half a green result would only mean the fixture never
+# empowered anything, which is exactly the vacuous negative this pair exists to avoid.
+
+const EMPOWERED_WATER: Array[Elemental.Element] = [Elemental.Element.WATER]
+
+func test_standing_on_a_source_does_not_grant_the_anchor() -> void:
+	# No aura anywhere: the Rebecca rule, per-carving. A river cannot lend what talent must hold.
+	var dry: Unit = _alchemist({})
+	var wet_carving: TransmutationData = _carving([Elemental.Element.WATER], "Splash")
+
+	assert_bool(wet_carving.can_channel(dry, Elemental.Element.WATER)) \
+		.override_failure_message("a materia source granted the anchor").is_false()
+	assert_str(wet_carving.channel_block_reason(dry, Elemental.Element.WATER)).is_not_empty()
+	# ...and the source really is live for this pair, so the refusal above is not vacuous:
+	assert_int(wet_carving.base_damage(dry, EMPOWERED_WATER)) \
+		.is_greater(wet_carving.base_damage(dry))
+
+
+func test_standing_on_a_source_does_not_widen_the_wildcard_budget() -> void:
+	# Anchored in fire, but the water sigils outrun every pool: deficit 2 against a capacity of 1.
+	var alch: Unit = _alchemist({ FIRE: 1 })
+	var stretched: TransmutationData = _carving(
+		[FIRE, Elemental.Element.WATER, Elemental.Element.WATER], "Steam")
+
+	assert_bool(stretched.can_channel(alch, FIRE)) \
+		.override_failure_message("a materia source paid a wildcard deficit").is_false()
+	assert_int(stretched.base_damage(alch, EMPOWERED_WATER)) \
+		.is_greater(stretched.base_damage(alch))
+
+
+func test_a_rune_does_not_become_equippable_beside_a_source() -> void:
+	# The equip gate walks inscriptions asking can_channel, so it inherits the rule above -- but
+	# it is its own door and #157 force-unequips through it, so it is asserted rather than assumed.
+	var dry: Unit = _alchemist({})
+	var wet_carving: TransmutationData = _carving([Elemental.Element.WATER], "Splash")
+	var rune: RuneData = _rune([wet_carving])
+
+	assert_bool(rune.can_equip(dry)) \
+		.override_failure_message("a materia source made a dead rune equippable").is_false()
+	assert_str(rune.can_equip_reason(dry)).is_not_empty()

--- a/tests/runes/test_materia_sources.gd
+++ b/tests/runes/test_materia_sources.gd
@@ -1,0 +1,118 @@
+# #694: which elements a cell OFFERS (Materia.sources_at) and which a caster standing there may
+# draw on (Materia.empowered_at). Canon: docs/design/alchemy-kit.md -> Materia.
+#
+# The board is stubbed rather than painted -- the fixture grid has no TileSet, which is also why
+# Materia reads through BoardContext METHODS instead of its stores: `super(null, ...)` here would
+# crash any predicate that reached for `grid` itself.
+extends GdUnitTestSuite
+
+const HERE := Vector2i(4, 4)
+const NEXT_DOOR := Vector2i(5, 4)
+const TWO_AWAY := Vector2i(6, 4)
+
+const WATER := Elemental.Element.WATER
+const EARTH := Elemental.Element.EARTH
+const FIRE := Elemental.Element.FIRE
+
+# Kinds and lit-props authored directly; STATES ride a real TerrainStateManager, because the
+# frozen-water and doused-fire cases are the whole point of asking the board rather than the tile.
+class _MateriaBoard extends BoardContext:
+	var kinds: Dictionary
+	var lit: Dictionary
+	func _init(states: TerrainStateManager, k: Dictionary, l: Dictionary = {}) -> void:
+		var no_units: Array[Unit] = []
+		super(null, no_units, null, states)
+		kinds = k
+		lit = l
+	func terrain_kind_at(cell: Vector2i) -> Terrain.Kind:
+		return kinds.get(cell, Terrain.Kind.NONE)
+	func prop_lit_at(cell: Vector2i) -> bool:
+		return lit.get(cell, false)
+
+func _store(cell_states: Dictionary = {}) -> TerrainStateManager:
+	var tsm: TerrainStateManager = auto_free(TerrainStateManager.new())
+	add_child(tsm)
+	for cell: Vector2i in cell_states:
+		var effect := ResolvedCellEffect.new()
+		effect.cell = cell
+		effect.states_added.assign(cell_states[cell])
+		tsm.apply(effect)
+	return tsm
+
+func _board(kinds: Dictionary, cell_states: Dictionary = {}, lit: Dictionary = {}) -> _MateriaBoard:
+	return _MateriaBoard.new(_store(cell_states), kinds, lit)
+
+# --- what a cell offers -------------------------------------------------------------------
+
+func test_a_water_tile_is_a_water_source() -> void:
+	var board := _board({ HERE: Terrain.Kind.WATER })
+	assert_array(Materia.sources_at(HERE, board)).contains([WATER])
+
+# Ice is a floor, not a well -- the same state-aware read is_walkable makes of the same cell.
+func test_frozen_water_is_not_a_water_source() -> void:
+	var board := _board({ HERE: Terrain.Kind.WATER }, { HERE: [Terrain.TileState.FROZEN] })
+	assert_array(Materia.sources_at(HERE, board)).is_empty()
+
+func test_a_rock_tile_is_an_earth_source() -> void:
+	var board := _board({ HERE: Terrain.Kind.ROCK })
+	assert_array(Materia.sources_at(HERE, board)).contains([EARTH])
+
+func test_a_burning_cell_is_a_fire_source() -> void:
+	var board := _board({ HERE: Terrain.Kind.GRASS }, { HERE: [Terrain.TileState.BURNING] })
+	assert_array(Materia.sources_at(HERE, board)).contains([FIRE])
+
+# BLAZE is authored set-dressing fire; Terrain.is_burning owns which members count, and asking it
+# rather than naming BURNING is what makes this pass without a second list here.
+func test_a_blazing_cell_is_a_fire_source() -> void:
+	var board := _board({ HERE: Terrain.Kind.GRASS }, { HERE: [Terrain.TileState.BLAZE] })
+	assert_array(Materia.sources_at(HERE, board)).contains([FIRE])
+
+func test_a_lit_prop_is_a_fire_source() -> void:
+	var board := _board({ HERE: Terrain.Kind.ROCK }, {}, { HERE: true })
+	assert_array(Materia.sources_at(HERE, board)).contains([FIRE])
+
+# The dev's 2026-09-05 ruling: an unlit flammable is FUEL, not a source. A tree offers nothing
+# until it catches -- and nothing for AETHER either, which awaits authored life-dense content.
+func test_an_unlit_tree_offers_nothing() -> void:
+	var board := _board({ HERE: Terrain.Kind.TREE })
+	assert_array(Materia.sources_at(HERE, board)).is_empty()
+
+# AIR is parked and AETHER unauthored, so no terrain kind may yield either. Walking every kind
+# states that as a rule rather than trusting the three positive cases above to have covered it.
+func test_no_terrain_kind_offers_air_or_aether() -> void:
+	for kind: int in Terrain.Kind.values():
+		var board := _board({ HERE: kind })
+		var offered := Materia.sources_at(HERE, board)
+		assert_bool(offered.has(Elemental.Element.AIR)) \
+			.override_failure_message("kind %d offered AIR" % kind).is_false()
+		assert_bool(offered.has(Elemental.Element.AETHER)) \
+			.override_failure_message("kind %d offered AETHER" % kind).is_false()
+
+func test_a_null_board_offers_nothing() -> void:
+	assert_array(Materia.sources_at(HERE, null)).is_empty()
+
+# --- what a caster standing there may draw on ---------------------------------------------
+
+func test_standing_on_the_source_empowers() -> void:
+	var board := _board({ HERE: Terrain.Kind.WATER })
+	assert_array(Materia.empowered_at(HERE, board)).contains([WATER])
+
+func test_standing_beside_the_source_empowers() -> void:
+	var board := _board({ NEXT_DOOR: Terrain.Kind.WATER })
+	assert_array(Materia.empowered_at(HERE, board)).contains([WATER])
+
+func test_two_cells_away_does_not_empower() -> void:
+	var board := _board({ TWO_AWAY: Terrain.Kind.WATER })
+	assert_array(Materia.empowered_at(HERE, board)).is_empty()
+
+# Empowerment is BINARY: two sources of one element still read as empowered once, which is what
+# stops a vein beside a river paying twice when #696 lands.
+func test_two_sources_of_one_element_do_not_stack() -> void:
+	var board := _board({ HERE: Terrain.Kind.WATER, NEXT_DOOR: Terrain.Kind.WATER })
+	assert_array(Materia.empowered_at(HERE, board)).is_equal([WATER])
+
+func test_different_elements_in_reach_both_empower() -> void:
+	var board := _board({ HERE: Terrain.Kind.WATER, NEXT_DOOR: Terrain.Kind.ROCK })
+	var empowered := Materia.empowered_at(HERE, board)
+	assert_bool(empowered.has(WATER)).is_true()
+	assert_bool(empowered.has(EARTH)).is_true()

--- a/tests/runes/test_materia_sources.gd.uid
+++ b/tests/runes/test_materia_sources.gd.uid
@@ -1,0 +1,1 @@
+uid://b4pqgphtsolf3

--- a/tests/runes/test_rune_firing.gd
+++ b/tests/runes/test_rune_firing.gd
@@ -189,3 +189,76 @@ func test_rune_carving_hits_allies_includes_a_friendly() -> void:
 	var units: Array[Unit] = [alch, ally]
 	var victims := RulesService.gather_attack_victims(alch, [Vector2i(0, 1)], _StubBoard.new(_sm.grid, units, _sm, {}), alch.get_fired_attack())
 	assert_array(victims).contains([ally])
+
+
+# --- #694: empowerment reaches the resolver, keyed on the THREADED position -------------------
+#
+# Materia's own rules are pinned in tests/runes/test_materia_sources.gd. What these cases pin is
+# the WIRE: that the one production damage chokepoint asks Materia at all, and asks it about the
+# cell the caster will actually be standing on when the cast resolves.
+
+const SPRING := Vector2i(5, 5)     # the lone water tile these cases stand beside
+
+func _water_carving(power: int) -> TransmutationData:
+	var t: TransmutationData = TransmutationData.new()
+	t.power = power
+	t.sigils.assign([Elemental.Element.WATER])
+	t.targets = EquippableData.TargetMode.UNIT
+	return t
+
+# A damageless shove, the Gust shape -- it must move the caster without downing them, or the
+# cast that follows would be refused for a reason that has nothing to do with materia.
+func _shove(distance: int) -> TransmutationData:
+	var t: TransmutationData = TransmutationData.new()
+	t.sigils.assign([Elemental.Element.AIR])
+	t.deals_no_damage = true
+	t.hits_allies = true
+	t.knockback = distance
+	t.targets = EquippableData.TargetMode.UNIT
+	return t
+
+func _spring_board(units: Array[Unit]) -> _StubBoard:
+	return _StubBoard.new(_sm.board_source.call().grid, units, _sm, { SPRING: Terrain.Kind.WATER })
+
+func test_a_cast_made_standing_on_a_source_is_empowered() -> void:
+	var caster: Unit = H.spawn_solo(self, _sm, PLAYER, SPRING)
+	caster.unit_instance.aura = { Elemental.Element.WATER: 3 }
+	var foe: Unit = H.spawn_solo(self, _sm, ENEMY, SPRING + Vector2i(1, 0))
+	var cast: AttackAction = AttackAction.create(caster, caster.movement.cell, foe, foe.movement.cell)
+	cast.fired_attack = _water_carving(5)
+
+	var plan: ResolvedPlan = ResolvedPlan.new()
+	plan.attacks.append(cast)
+	var no_reactions: Array[ElementalReaction] = []
+	PlanResolver.resolve(plan, no_reactions, _spring_board([caster, foe]))
+
+	assert_int(cast.resolved.base_damage).is_equal(9)   # 5 power + 3 aura + 1 spring
+
+# THE case for the threaded read (dev ruling, 2026-09-05): the aim is frozen at declare, the BODY
+# is not. A squadmate's shove earlier in the same pass carries the caster off the bank, and the
+# cast that follows resolves unempowered. Reading action.origin_cell instead leaves this at 9 --
+# every other case in this suite stays green, which is why this one is written first.
+func test_a_caster_shoved_off_the_source_this_pass_casts_unempowered() -> void:
+	var caster: Unit = H.spawn_solo(self, _sm, PLAYER, SPRING)
+	caster.unit_instance.aura = { Elemental.Element.WATER: 3 }
+	var shover: Unit = H.spawn_solo(self, _sm, PLAYER, SPRING - Vector2i(0, 1))
+	var foe: Unit = H.spawn_solo(self, _sm, ENEMY, SPRING + Vector2i(1, 0))
+
+	# Shoved straight away from the shover, two cells -- clear of the spring's reach, not merely
+	# off the tile itself, since standing NEXT to water still empowers.
+	var shove: AttackAction = AttackAction.create(
+		shover, shover.movement.cell, caster, caster.movement.cell)
+	shove.fired_attack = _shove(2)
+	var cast: AttackAction = AttackAction.create(
+		caster, caster.movement.cell, foe, foe.movement.cell)
+	cast.fired_attack = _water_carving(5)
+
+	var plan: ResolvedPlan = ResolvedPlan.new()
+	plan.attacks.append(shove)
+	plan.attacks.append(cast)
+	var no_reactions: Array[ElementalReaction] = []
+	PlanResolver.resolve(plan, no_reactions, _spring_board([caster, shover, foe]))
+
+	assert_bool(shove.resolved.knockback_applied) \
+		.override_failure_message("the shove never moved the caster -- the case proves nothing").is_true()
+	assert_int(cast.resolved.base_damage).is_equal(8)   # 5 power + 3 aura, no spring


### PR DESCRIPTION
Closes #694. First build off the materia doctrine (#693).

> **THE ONE LAW: materia never gates function — it supercharges it.** Nothing here can refuse a cast; it only ever adds.

## What landed

**`Materia` (`Classes/alchemy/`, static, board as a parameter — `SquadCohesion`'s shape)** answers two questions kept deliberately apart, because that split is what the next three tickets plug into without rework:

- **`sources_at(cell, board)`** — what a CELL offers. Veins (#696) extend *here*; the overlay (#699) draws *this*.
- **`empowered_at(cell, board)`** — the REACH rule over it (on or adjacent; `GridUtils.cells_within_manhattan_range` already includes the origin, so `REACH = 1` is exactly that with no special case).
- A carried flask (#697) is **not positional** and enters at neither — it unions in at the call site.

**The payload:** `+1 EFFECTIVE aura`, entering `base_damage`'s sigil loop rather than its total — so a 2-Fire carving beside a fire gains **+2**, exactly as its two sigils already weight the real pool. **Passed, never looked up**: a carving has no board and must not grow one.

## The source set is narrower than the doc's first draft

Your rulings at build time, now recorded in canon with dates so neither gap reads later as an oversight:

| | Built | Was written as |
|---|---|---|
| **Water** | water tile, **not while FROZEN** | unchanged |
| **Earth** | **ROCK tile** | rock: walls, boulders, **cliff faces** |
| **Fire** | **actually alight** — burning/blazing cell, or a lit prop | burning tiles, **flammables**, lit props |
| **Air** | **nothing — PARKED** | elevation: high ground, cliff edges |
| **Aether** | **nothing** — awaits authored content | life-dense features: trees, groves, herbs |

Both gaps are **filed, not noted**: **#783** carries air's *what counts as high ground* fork; **#696** picked up aether's authored-source job as a comment, since veins are already the authored-source ticket.

## The threaded position — your ruling, and the case that pins it

Empowerment keys on `PlanResolver.projected_position(actor, hypo)`, **not** the frozen `origin_cell`. A squadmate's shove earlier in the same pass carries the caster off the bank and the cast that follows resolves unempowered. The split is declared: **the aim stays frozen, the body is threaded — a shove moves you, it does not re-aim your spell.**

Worth knowing: a *Move-then-cast* case reads post-move under **both** readings and cannot tell them apart, because `origin_cell` is itself stamped from `get_projected_destination()`. Only a same-pass **shove** discriminates, which is why that is the case that exists.

## The three invariants hold by construction

The anchor, the deficit and both wildcard pools all read `wielder.get_element_aura` directly, and `RuneData.can_equip_reason` derives from `channel_block_reason` (#744) — so **leaving that accessor position-blind is the whole of keeping all three**. Making it position-aware is the one change that would leak materia into every gate at once, and the comment at `base_damage` says so.

## Also

**`BoardContext`** gains `tile_states_at` / `has_tile_state` / `prop_lit_at`. The first two are **one guard where `is_walkable` and `cover_def_at` each had their own** and `Materia` wanted a third (Law #4); both spellings exist because a caller naming one state and a caller asking `Terrain.is_burning` need different shapes — and **no reader may enumerate `FIRE_STATES` itself**, which is that file's own rule.

**Law #2 needed no work, and that is a finding rather than a task:** there is no separate preview computation. The queue reads `action.resolved` off the same `ResolvedPlan` the resolver produces, and the AI's scorer re-resolves through the same path — one number, three consumers. The one path that does *not* see empowerment is `TransmutationData.mechanical_text` (the inventory hover), which has no board and answers a deliberately position-free question.

## How to check this

**In play:** put an alchemist with water aura on or beside a water tile and fire a water carving — the queue's damage should read **one higher per water sigil** than the same cast made away from water. Walk them two cells clear and it drops back. A frozen water tile should give nothing (freeze it and watch the number fall). Rock does the same for an earth carving; a burning or blazing cell, or a lit prop, does it for fire.

**What a failure looks like:** the number never moves (empowerment is not reaching the resolver), or it moves when it should not — standing two cells away, or beside frozen water, or beside an unlit tree.

**The one worth poking deliberately:** have a squadmate **Gust the caster off the bank** in the same plan, ordered *before* the cast. The preview should show the *unempowered* number, because the queue and the resolver are the same pass.

**What the tests already cover:** the source rules per element including frozen water and the unlit tree (14 cases, `tests/runes/test_materia_sources.gd`); the payload arithmetic including the repeated-sigil weighting and a `deals_no_damage` carving gaining nothing (`tests/items/`); the resolver wire and the same-pass shove (`tests/runes/test_rune_firing.gd`); and the invariants as negatives (`tests/runes/test_channel_reasons.gd`).

**What they do not cover, and is yours to feel:** whether **+1 is a big enough carrot to move you toward terrain** — that is the tuning question the doctrine left open, and `Materia.REACH` and the size of the bonus are both playtest knobs. Nothing here has been balanced, only made real.

## Verification

- `runes` **53/53**, `items` **81/81**, `terrain` **74/74**, `rules` **60/60** — the four areas this reaches. Not the full tree; CI owns that.
- **Falsified, two mutants**, committed first:
  - reading `origin_cell` instead of the threaded position → **exactly one** failure, the shove case, everything else green. That is the case earning its place.
  - deleting the `+1` → the payload case reds **and so does `test_standing_on_a_source_does_not_grant_the_anchor`**, which is the point: each invariant guard asserts the source is genuinely live, so a green negative cannot be vacuous.
- Rebased onto `main` after #745 merged mid-build — **no file overlap**.
- Nothing embeds `TransmutationData` with a new authored field (the empowerment argument is a parameter, not a `@export`), so no `.tres` fixture sweep is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
