### PR TITLE
Make the vials actually obtainable

### DIFF
--- a/Classes/alchemy/VialCatalog.gd
+++ b/Classes/alchemy/VialCatalog.gd
@@ -1,0 +1,17 @@
+extends Object
+class_name VialCatalog
+
+# Registry for authored vials (#697). ArmorCatalog's shape exactly: a vial carries no per-instance
+# state, so a catalog entry IS the item, scanned straight off disk.
+#
+# It exists because without it the vials were UNREACHABLE -- four .tres nothing in the project
+# referenced, so the only way to hold one was to hand-edit a scenario. A content kind with no
+# catalog is a content kind the editors cannot offer and the game cannot grant.
+const VARIANT_DIR := "res://Resources/Vials/"
+
+static func get_variants() -> Dictionary:
+	return ResourceCatalog.by_name(VARIANT_DIR, VialData)
+
+# Authored vials -- for the editors' item list (mirrors WeaponCatalog/ArmorCatalog/RuneCatalog).
+static func get_editable() -> Dictionary:
+	return get_variants()

--- a/Classes/alchemy/VialCatalog.gd.uid
+++ b/Classes/alchemy/VialCatalog.gd.uid
@@ -1,0 +1,1 @@
+uid://cai5qvy38wxai

--- a/Classes/dev/CharacterEditorTool.gd
+++ b/Classes/dev/CharacterEditorTool.gd
@@ -404,16 +404,16 @@ func _on_job_toggled(id: String, pressed: bool) -> void:
 
 # The Unit Editor's weapons+armor+runes merge, CALLED rather than copied (Law #4) -- one answer
 # to "what can a dev put in a hand".
-func _equippable_catalog() -> Dictionary:
+func _item_catalog() -> Dictionary:
 	var unit_editor: UnitEditorTool = get_node("%Unit Editor")
-	return unit_editor._equippable_catalog()
+	return unit_editor._item_catalog()
 
 # The kit: what the character carries into any board, seeded through the gated doors at spawn
 # (#177). Slot picks stage the catalog FILE resource itself -- no copy -- so a save writes an
 # ExtResource reference and the spawn grants copy_for_grant() copies off it.
 func _add_kit_section() -> void:
 	DevWidgets.add_label(editor_container, "Starting inventory (no Equip checked = auto-equip decides)")
-	var catalog := _equippable_catalog()
+	var catalog := _item_catalog()
 	var keys: Array = catalog.keys()
 	var equip_group := ButtonGroup.new()
 	equip_group.allow_unpress = true
@@ -477,7 +477,7 @@ func _on_slot_picked(index: int, opt_index: int) -> void:
 		current.starting_inventory.resize(Unit.MAX_INVENTORY_SIZE)
 	var entry: EquippableData = null
 	if opt_index > 0:
-		var catalog := _equippable_catalog()
+		var catalog := _item_catalog()
 		entry = catalog[catalog.keys()[opt_index - 1]]
 	current.starting_inventory[index] = entry
 	if current.starting_equipped_index == index:

--- a/Classes/dev/UnitEditorTool.gd
+++ b/Classes/dev/UnitEditorTool.gd
@@ -389,7 +389,11 @@ func _stage_unit_name(new_name: String) -> void:
 # Weapons, armor, and authored rune variants in one ordered list, so a unit can equip any of
 # them. Built here and reused by both the picker and the pick handler so their indices stay in
 # lockstep. #30 D.
-func _equippable_catalog() -> Dictionary:
+# Everything a unit can be given, by display name. NOT equippables only since #697 -- a vial is
+# CARRIED and never slotted, and leaving it out made the four authored ones unreachable from any
+# editor. The Equip/Wear checkbox beside each slot already reads `is EquippableData` and greys
+# itself, so a carried non-equippable needs nothing else here.
+func _item_catalog() -> Dictionary:
 	var items := {}
 	var weapons := WeaponCatalog.get_editable()
 	for k in weapons:
@@ -400,12 +404,15 @@ func _equippable_catalog() -> Dictionary:
 	var runes := RuneCatalog.get_editable()
 	for k in runes:
 		items[k] = runes[k]
+	var vials := VialCatalog.get_editable()
+	for k in vials:
+		items[k] = vials[k]
 	return items
 
 func _add_inventory_section(into: VBoxContainer):
 	DevWidgets.add_label(into, "Inventory")
 
-	var weapons := _equippable_catalog()   # name -> EquippableData (weapons + authored runes)
+	var weapons := _item_catalog()   # name -> Item (weapons, armor, runes, vials)
 	var weapon_keys := weapons.keys()
 	var equip_group := ButtonGroup.new()
 
@@ -487,7 +494,7 @@ func _on_slot_picked(index: int, opt_index: int):
 	if opt_index == 0:
 		_set_slot(index, null)
 	else:
-		var items := _equippable_catalog()
+		var items := _item_catalog()
 		_set_slot(index, items[items.keys()[opt_index - 1]])
 
 func _set_slot(index: int, entry: Resource):

--- a/Resources/Rosters/Company.tres
+++ b/Resources/Rosters/Company.tres
@@ -18,6 +18,10 @@
 [ext_resource type="Resource" path="res://Resources/Armor/BallastHarness.tres" id="16_ballast"]
 [ext_resource type="Resource" path="res://Resources/RuneVariants/Fire Rune.tres" id="17_fire"]
 [ext_resource type="Resource" path="res://Resources/Weapons/WeaponVariants/Gun.tres" id="18_gun"]
+[ext_resource type="Resource" path="res://Resources/Vials/FireVial.tres" id="19_firevial"]
+[ext_resource type="Resource" path="res://Resources/Vials/WaterVial.tres" id="20_watervial"]
+[ext_resource type="Resource" path="res://Resources/Vials/EarthVial.tres" id="21_earthvial"]
+[ext_resource type="Resource" path="res://Resources/Vials/AlkahestVial.tres" id="22_alkavial"]
 
 [sub_resource type="Resource" id="Resource_aldin"]
 script = ExtResource("2_entry")
@@ -72,4 +76,4 @@ state_saved = false
 [resource]
 script = ExtResource("1_roster")
 entries = Array[ExtResource("2_entry")]([SubResource("Resource_aldin"), SubResource("Resource_aster"), SubResource("Resource_bram"), SubResource("Resource_celest"), SubResource("Resource_dorian"), SubResource("Resource_isaac"), SubResource("Resource_noemie"), SubResource("Resource_rebecca"), SubResource("Resource_ross"), SubResource("Resource_torv")])
-stash = Array[ExtResource("13_equippable")]([ExtResource("14_bulwark"), ExtResource("15_mail"), ExtResource("16_ballast"), ExtResource("17_fire"), ExtResource("18_gun")])
+stash = Array[ExtResource("13_equippable")]([ExtResource("14_bulwark"), ExtResource("15_mail"), ExtResource("16_ballast"), ExtResource("17_fire"), ExtResource("18_gun"), ExtResource("19_firevial"), ExtResource("20_watervial"), ExtResource("21_earthvial"), ExtResource("22_alkavial")])

--- a/tests/dev/test_character_editor.gd
+++ b/tests/dev/test_character_editor.gd
@@ -110,7 +110,7 @@ func test_slot_pick_stages_the_catalog_file_itself() -> void:
 	# The by-construction fix for the hand-inlined-WeaponInstance trap: a slot pick stages the
 	# catalog FILE resource, so a save writes an ExtResource reference, never an embedded copy.
 	var tool := _tool()
-	var catalog := tool._equippable_catalog()
+	var catalog := tool._item_catalog()
 	if catalog.is_empty():   # content-absent: warn, never fail (tests/README.md rule 9)
 		push_warning("the equippable catalog is empty, so no slot pick can stage a file")
 		return

--- a/tests/law/test_authored_content_is_reachable.gd
+++ b/tests/law/test_authored_content_is_reachable.gd
@@ -1,0 +1,61 @@
+# Authored content has to be OBTAINABLE. #697 shipped four vials nothing in the project referenced:
+# no catalog scanned Resources/Vials/, no roster listed one, and both dev editors built their item
+# picker from a weapons+armor+runes union, so the only way to hold one was to hand-edit a .tres.
+# Every test passed, the rule was correct end to end, and the feature was unplayable.
+#
+# What this law asks is the question the suite could not: can the dev GET one. It is deliberately
+# about the ITEM CATALOGS rather than about vials -- the next content kind added without a catalog
+# fails here rather than being noticed in play.
+extends GdUnitTestSuite
+
+const VIAL_DIR := "res://Resources/Vials/"
+
+
+func _authored_vial_names() -> Array:
+	return VialCatalog.get_variants().keys()
+
+
+func test_the_authored_vials_are_actually_on_disk() -> void:
+	assert_array(_authored_vial_names()).override_failure_message(
+			"no vial resources under %s -- every case below would pass vacuously" % VIAL_DIR
+			).is_not_empty()
+
+
+# The catalog is what every editor and grant path reads. Without one the folder is invisible.
+func test_every_authored_vial_is_in_the_catalog() -> void:
+	var on_disk := ResourceDir.files_with_extension(VIAL_DIR, "tres")
+	assert_int(_authored_vial_names().size()).override_failure_message(
+			"%d vial files on disk, %d in the catalog -- one of them cannot be granted"
+			% [on_disk.size(), _authored_vial_names().size()]).is_equal(on_disk.size())
+
+
+func test_a_catalogued_vial_is_a_VialData_carrying_something() -> void:
+	for name: String in _authored_vial_names():
+		var vial := VialCatalog.get_variants()[name] as VialData
+		assert_object(vial).override_failure_message(
+				"'%s' is in the vial catalog but is not a VialData" % name).is_not_null()
+		assert_array(vial.granted_elements()).override_failure_message(
+				"'%s' grants no element at all -- using it would buy nothing" % name).is_not_empty()
+
+
+# THE case the ticket's gap would have failed. A vial is an Item and never an EquippableData, so a
+# picker built from equippables alone cannot offer one however many exist.
+func test_the_editors_item_picker_offers_vials() -> void:
+	var tool_node: UnitEditorTool = auto_free(UnitEditorTool.new())
+	var offered: Array = tool_node._item_catalog().keys()
+
+	assert_array(offered).is_not_empty()
+	for name: String in _authored_vial_names():
+		assert_bool(offered.has(name)).override_failure_message(
+				"the dev editors cannot offer '%s' -- it exists and nobody can be given one" % name
+				).is_true()
+
+
+# A carried non-equippable must survive the pipeline it is authored into, or the stash entry below
+# is a file that silently vanishes at deploy.
+func test_a_vial_survives_a_grant_copy() -> void:
+	for name: String in _authored_vial_names():
+		var granted := (VialCatalog.get_variants()[name] as VialData).copy_for_grant() as VialData
+		assert_object(granted).override_failure_message(
+				"copying '%s' for a grant did not hand back a VialData" % name).is_not_null()
+		assert_array(granted.granted_elements()).is_not_empty()

--- a/tests/law/test_authored_content_is_reachable.gd.uid
+++ b/tests/law/test_authored_content_is_reachable.gd.uid
@@ -1,0 +1,1 @@
+uid://cdppws6y18ixn


### PR DESCRIPTION
Follow-up to #697 (merged as #792). You asked how to actually get a vial, and the answer was **you couldn't** — so this is a completeness fix on work I called done, not a new feature.

## What was wrong

Nothing in the project referenced `Resources/Vials/`. No catalog scanned the directory, no roster listed one, and both dev editors built their picker from `_equippable_catalog()` — weapons + armor + runes — which a `VialData` can never be in, because a vial is an `Item` and never an `EquippableData`. Four authored files, obtainable only by hand-editing a `.tres`.

**Every #697 test passed the whole time**, because each one constructs its own vial in code. That is exactly how authored content ends up orphaned: the rule is exercised end to end and the content is never asked for by the path a person would use.

## Three doors, for three different needs

| | |
|---|---|
| **`VialCatalog`** (`ArmorCatalog`'s shape) | the missing registry. A content kind with no catalog is invisible to every editor and every grant path. |
| **`_equippable_catalog()` → `_item_catalog()`**, now including vials | the old name was the bug in miniature — it described what the pipeline *used* to carry. Both editors read it. |
| **Four vials in `Company.tres`'s stash** | so you can drag one onto a unit in the pre-mission screen without opening dev tools at all. |

The Equip/Wear checkbox beside each slot already reads `is EquippableData` and greys itself, so a carried non-equippable needed nothing else in the picker UI.

**The stash entries are a playtest convenience, not an economy decision** — #790 owns where vials actually come from. Delete those four lines whenever they stop being useful.

## The law

`tests/law/test_authored_content_is_reachable.gd` asks the question the suite could not: **can the dev get one.** It is written about the item catalogs rather than about vials, so the next content kind added without one fails here rather than being noticed in play.

**Falsified** by reverting `_item_catalog()` to equippables-only — the exact state that shipped in #792. It reds and names each unreachable file:

> `the dev editors cannot offer 'Vial of Sulfur' -- it exists and nobody can be given one`

## How to check this

**Without dev tools:** start a mission, and in the pre-mission screen the stash now holds **Vial of Sulfur / Mercury / Salt / Alkahest** alongside the armour and the gun. Drag one onto a unit, deploy, then open that unit's inspect panel — the slot offers **Use**, not Equip. Pop it and any fire carving that unit casts gains +1 per fire sigil, with a **Vial** chip on the queue row.

**With dev tools:** the Unit Editor and Character Editor inventory dropdowns now list all four by name. The Equip checkbox beside a vial slot is greyed, which is correct — it fills no slot.

**What a failure looks like:** the vials missing from the stash or the dropdown, or an Equip checkbox that is live beside one.

**What the tests cover:** the catalog matches the folder, every catalogued vial is a `VialData` granting something, the editors' picker offers each one, and a vial survives `copy_for_grant`. **What they do not:** whether four in the stash is the right number, or whether the tria-prima names read well in play.

## Verification

`law` 215/215 (5 new) · `dev` 434/434 · `flow` 322/322 — the suites that load `Company.tres` and build the editors. Clean headless import.

Rebuilt onto `main` after #792 merged, so this carries one commit and no duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
