### PR TITLE
#424: damage kinds — the delivery axis, kind-aware DEF, and the content sweep (PR 1 of 2)

### DIFF
--- a/Classes/actions/resolution/PlanResolver.gd
+++ b/Classes/actions/resolution/PlanResolver.gd
@@ -413,7 +413,9 @@ static func _resolve_one(action: AttackAction, reactions: Array[ElementalReactio
 	# final damage (E8): round(base * mult + bonus), then flat DEF mitigation (#84), never negative.
 	# DEF subtracts AFTER elemental scaling and BEFORE the 0-floor; a revved Chainsword attacker
 	# pierces it entirely. Iron Will (below) stays the last clamp — an absolute cap on damage taken.
+	outcome.kind = _source_kind(action)
 	var mitigation := _mitigation_for(action, target, target_hypo, board, outcome)
+	outcome.mitigation = mitigation
 	outcome.damage = max(0, int(round(base * mult + bonus)) - mitigation)
 
 	# Insulation (a granted PASSIVE ability, #90 — from gear today, from any source the kit knows
@@ -535,11 +537,14 @@ static func _surviving_elements(elements: Array[Elemental.Element], target: Unit
 # read from RulesService's shared breakdown so the inspect panel's DEF readout is the same number.
 # DEF is gear-and-terrain only (stats.md — no base DEF), so "ignore DEF bonuses" means ignore all
 # of it: a revved Chainsword attacker (WeaponInstance.ignores_def()) returns 0, armor AND cover.
+# Since #424 the armour term also answers to the hit's KIND (RulesService.def_against): a piece that
+# does not cover the kind contributes nothing, cover still does. Reads the kind already stamped on
+# the outcome rather than re-deriving it, so the number and its explanation cannot disagree.
 static func _mitigation_for(action: AttackAction, target: Unit, target_hypo: _Hypo, board: BoardContext, outcome: ResolvedOutcome) -> int:
 	var weapon := action.actor.get_equipped_weapon() as WeaponInstance
 	if weapon != null and weapon.ignores_def():
 		return 0   # brace_bonus stays 0: a Chainsword pierces it with the rest of DEF
-	var def := RulesService.def_breakdown(target, target_hypo.position, board)
+	var def := RulesService.def_against(target, target_hypo.position, board, outcome.kind)
 	# The brace bonus (#414): extra DEF the blocker brings to a hit it ABSORBED, on top of its own
 	# armour and cover, and only ever on a substituted instance -- which is why it is added here and
 	# not inside def_breakdown, whose sum is also the inspect panel's standing DEF readout. Stamped
@@ -598,6 +603,19 @@ static func _source_base_damage(action: AttackAction, board: BoardContext = null
 		if weapon != null:
 			return weapon.base_damage(attacker, action.fired_attack as WeaponAttackData)
 	return attacker.get_effective_stat(Stats.Stat.STR)
+
+# The kind the hit DELIVERS (#424), _source_elements' shape: a carving answers its own authored field,
+# a weapon attack answers the wielding weapon (a fitted mod may have replaced it), and a null stamp
+# is bare fists -- BLUNT, the one kind with no resource to author it on.
+static func _source_kind(action: AttackAction) -> AttackData.Kind:
+	if action.fired_attack is TransmutationData:
+		return action.fired_attack.delivered_kind()
+	if action.fired_attack is WeaponAttackData:
+		var weapon := action.actor.get_equipped_weapon() as WeaponInstance
+		if weapon != null:
+			return weapon.effective_kind(action.actor, action.fired_attack)
+		return action.fired_attack.delivered_kind()
+	return AttackData.Kind.BLUNT
 
 static func _source_elements(action: AttackAction) -> Array[Elemental.Element]:
 	if action.fired_attack is TransmutationData:

--- a/Classes/actions/resolution/ResolvedOutcome.gd
+++ b/Classes/actions/resolution/ResolvedOutcome.gd
@@ -45,6 +45,11 @@ var knockback_landing_index: int = 0
 # from the same answer (brace_bonus's reason, one stage over).
 var burned_vial: VialData = null
 var brace_bonus: int = 0
+# The kind this hit DELIVERED and the DEF subtracted from it (#424), stamped in the same breath as
+# the mitigation so the queue row can say "DEF 6 vs slash" or "plate does not cover fire" without a
+# second derivation. `kind` is the composed answer (mods included); NONE for a heal or utility hit.
+var kind: AttackData.Kind = AttackData.Kind.NONE
+var mitigation: int = 0
 var fall_damage: int = 0    # the drop's own component (#259), already folded into `damage` above
 var fall_levels: int = 0    # how far the unit actually FELL (#259 follow-up): the flight drop plus
 							# any tumble-then-plummet. The distance fall_damage is derived from and

--- a/Classes/alchemy/TransmutationData.gd
+++ b/Classes/alchemy/TransmutationData.gd
@@ -130,7 +130,7 @@ func sigil_text() -> String:
 # both numbers depend on them: damage scales off their aura, wildcards off their gaps.
 func mechanical_text(wielder: Unit, _temper: Elemental.Element) -> String:
 	var parts: Array[String] = [sigil_text(),
-		"%s %s" % [payload_text(base_damage(wielder)), targets_text()]]
+		"%s %s" % [payload_text(base_damage(wielder), delivered_kind()), targets_text()]]
 	var deficit := total_deficit(wielder)
 	if deficit > 0:
 		parts.append("Wildcards %d" % deficit)

--- a/Classes/board/RulesService.gd
+++ b/Classes/board/RulesService.gd
@@ -396,6 +396,18 @@ static func def_breakdown(unit: Unit, cell: Vector2i, board: BoardContext) -> Di
 	var result: Dictionary[String, int] = {"armor": armor, "cover": cover, "total": armor + cover}
 	return result
 
+# The breakdown AGAINST ONE HIT (#424): the standing sum above with the armour term zeroed when the
+# worn piece does not cover the hit's kind. Layered on def_breakdown rather than beside it, so the
+# panel's standing readout and the number the resolver subtracts are still one composition -- the
+# kind gate is the only thing this adds, and it lives here so the queue row can explain a subtraction
+# without restating it. Cover is kind-blind: a wall stops a fireball as well as a bullet.
+static func def_against(unit: Unit, cell: Vector2i, board: BoardContext, kind: AttackData.Kind) -> Dictionary[String, int]:
+	var def := def_breakdown(unit, cell, board)
+	if unit.worn_armor != null and not unit.worn_armor.covers(kind):
+		def["armor"] = 0
+		def["total"] = def["cover"]
+	return def
+
 # Hop-distance (BFS over cells `unit` can traverse) from `source` -> { cell: hops }. Unweighted by
 # design: it answers how terrain CONNECTS, not what a move costs. Read it as the counterpart to
 # compute_move_range -- that says where you can stand THIS turn, this says how much of the way is

--- a/Classes/core/Glossary.gd
+++ b/Classes/core/Glossary.gd
@@ -26,7 +26,7 @@ enum Term {
 	# Squads
 	SQUAD, LEADER, COHESION, SQUAD_SIZE,
 	# Stats (one per Stats.Stat, plus the derived readout rows)
-	MHP, STR, LDR, WIL, DEX, PER, CON, COH, MOV, WEIGHT, DEF,
+	MHP, STR, LDR, WIL, DEX, PER, CON, COH, MOV, WEIGHT, DEF, DAMAGE_KIND,
 	# Actions (one per MainActionMenu.ACTION_DATA row, one per MainActionMenu.CATEGORIES row --
 	# a radial category is a row the player hovers and so owes a readout like any other (#467) --
 	# plus ATTACK_TARGETING, the channel axis)
@@ -277,7 +277,17 @@ static func _build_entries() -> Dictionary:
 	e[Term.DEF] = {"category": Category.STATS, "title": "Defense (DEF)",
 		"short": "Subtracted from incoming damage: armor scaled by CON, plus terrain cover.",
 		"long": "Damage mitigation. Worn armor contributes its power scaled by CON, dug-in Cover "
-			+ "adds +%d, and the total comes straight off every incoming hit." % Terrain.COVER_DEF}
+			+ "adds +%d, and the total comes straight off every incoming hit. " % Terrain.COVER_DEF
+			+ "Armor only answers the damage KINDS it covers -- plate stops a blade and lets a fireball "
+			+ "through; Cover stops everything."}
+	e[Term.DAMAGE_KIND] = {"category": Category.STATS, "title": "Damage kinds",
+		"short": "How a hit arrives: blunt, slash, pierce, fire, shock, cold or corrosion. Armor covers some kinds and not others.",
+		"long": "Every damaging attack delivers ONE kind. Pierce is a point (spear, bullet, ice spear), "
+			+ "slash a line (blade), blunt a plane (hammer, fist, a jet of water); fire, shock, cold and "
+			+ "corrosion are not physical at all. A piece of armor lists the kinds its DEF applies to, and a "
+			+ "kind it does not list goes straight through. Separate from the element a hit carries: a "
+			+ "fireball is fire-kind damage AND applies the fire effect, an ice spear is pierce AND applies "
+			+ "the ice effect -- insulation stops the effect, only DEF stops the damage."}
 
 	# Actions — the short line doubles as the action menu's hover tooltip.
 	e[Term.EXECUTE_ORDERS] = {"category": Category.ACTIONS, "title": "Execute Orders",

--- a/Classes/dev/AttackEditorTool.gd
+++ b/Classes/dev/AttackEditorTool.gd
@@ -37,8 +37,8 @@ enum Mode { TRANSMUTATION, WEAPON_ATTACK, FAMILY }
 # coverage law in tests/dev/test_property_tips.gd have to agree about which fields are skipped --
 # a field skipped in one and not the other is a field that either loses its tooltip or fails a law
 # it was never drawn by.
-const POOL_SKIP := ["display_name", "scaling_blend"]                # name and blend have bespoke UI above
-const CARVING_SKIP := ["display_name", "sigils", "flourishes"]     # the latter two get bespoke UI
+const POOL_SKIP := ["display_name", "scaling_blend", "damage_kind"]        # name, blend and kind have bespoke UI
+const CARVING_SKIP := ["display_name", "sigils", "flourishes", "damage_kind"]   # the latter three get bespoke UI
 
 var _mode := Mode.TRANSMUTATION
 var current: AttackData = null
@@ -296,10 +296,29 @@ func populate():
 			_populate_sigils(carving)
 			_populate_flourishes(carving)
 			DevWidgets.build_resource_editor(editor_container, current, populate, CARVING_SKIP)
+			_populate_kind(current)
 		Mode.WEAPON_ATTACK:
 			DevWidgets.build_resource_editor(editor_container, current, populate, POOL_SKIP)
+			_populate_kind(current)
 			_populate_blend()
 			_populate_carriers()
+
+# The damage-kind row (#424), bespoke rather than reflective for one reason: NONE is on the roster so
+# delivered_kind() can answer it, and must never be OFFERED -- a heal or a no-damage attack reads as
+# None by rule, so the row says so and draws no picker. The reflective row would list all eight.
+func _populate_kind(attack: AttackData) -> void:
+	var first := editor_container.get_child_count()
+	if attack.delivered_kind() == AttackData.Kind.NONE:
+		DevWidgets.add_label(editor_container, "Damage kind: None (a heal or no-damage attack delivers no kind)")
+	else:
+		var names: Array[String] = []
+		for key: String in AttackData.Kind.keys():
+			var value: int = AttackData.Kind[key]
+			if value != AttackData.Kind.NONE:
+				names.append("%s:%d" % [key.capitalize(), value])
+		DevWidgets.add_enum_option(editor_container, "Damage kind", ",".join(names), attack.damage_kind,
+			func(v: int): attack.damage_kind = v as AttackData.Kind)
+	DevWidgets._tip_rows_from(editor_container, first, DevWidgets.property_tip(attack, "damage_kind"))
 
 # The family form: its main (edited live, in place) AND its extras. Extras render whether or not
 # there is a main -- the old early return on a null `current` made a main-less family's extras
@@ -316,6 +335,7 @@ func _populate_family() -> void:
 		DevWidgets.add_lineedit(editor_container, "Display name", edited.display_name, func(s: String): edited.display_name = s)
 		DevWidgets.add_label(editor_container, "Editing the MAIN attack for %s — changes every weapon of this family." % family_label)
 		DevWidgets.build_resource_editor(editor_container, current, populate, POOL_SKIP)
+		_populate_kind(current)
 		_populate_blend()
 	_populate_extras(family_label)
 

--- a/Classes/items/ArmorData.gd
+++ b/Classes/items/ArmorData.gd
@@ -7,6 +7,28 @@ extends EquippableData
 @export var def_power: int = 0
 @export var flat_def: int = 0
 
+# Which damage kinds this piece's DEF applies to (#424). EMPTY means every kind -- the storage's own
+# default, so a piece authored before kinds existed keeps stopping everything until someone says
+# otherwise. A piece that lists kinds stops ONLY those: plate lists the three physical kinds and a
+# fireball goes straight through it. On/off deliberately, not a number per kind (dev, 2026-09-05:
+# "too early to make a call"); a per-kind table would be a superset of this list if content ever
+# asks. Cover and the brace bonus are kind-blind; only armour carries this.
+@export var covered_kinds: Array[AttackData.Kind] = []
+
+# Does this piece's DEF apply to a hit delivered as `kind`? The one reader of covered_kinds'
+# empty-means-all rule; RulesService.def_against asks it and nothing else does.
+func covers(kind: AttackData.Kind) -> bool:
+	return covered_kinds.is_empty() or covered_kinds.has(kind)
+
+# "vs blunt, slash, pierce" for the readouts, or "" when the piece covers everything.
+func coverage_text() -> String:
+	if covered_kinds.is_empty():
+		return ""
+	var names: Array[String] = []
+	for kind: AttackData.Kind in covered_kinds:
+		names.append(AttackData.kind_name(kind))
+	return "vs " + ", ".join(names)
+
 # Wear gates, generalized past #55's single con_requirement: a piece can demand a floor on any
 # stat AND a ceiling on any other (bulky rigs only a slow unit can move in). Empty = no gate.
 @export var stat_minimums: Dictionary[Stats.Stat, int] = {}
@@ -88,6 +110,9 @@ func mechanical_text(wearer: Unit) -> String:
 			lines.append("DEF %d  (flat)" % total)
 		else:
 			lines.append("DEF 0")
+		var coverage := coverage_text()
+		if coverage != "":
+			lines[lines.size() - 1] += "  " + coverage
 	var gate := requirement_text()
 	if gate != "":
 		lines.append("Requires: %s" % gate)

--- a/Classes/items/AttackData.gd
+++ b/Classes/items/AttackData.gd
@@ -60,6 +60,34 @@ enum VerticalRule { RANGED, MELEE }
 # mod-grantable through WeaponModData.can_overwatch_override -- the watch is the attack, so nothing
 # about its geometry or payload is duplicated here.
 @export var can_overwatch := false
+
+# The physical DELIVERY of this attack's damage (#424) -- how the force arrives, which is what armour
+# has an answer to. SEPARATE from the element set: a Fireball deals FIRE-kind damage and, separately,
+# applies the fire effect; an ice spear deals PIERCE-kind damage and applies the ice effect. One kind
+# per attack and one damage number, so mitigation stays a single subtraction. AUTHORED, never derived
+# from sigils or family (dev, 2026-09-05: "too many of the transmutations pull from flavor rather than
+# derivation" -- sheer cold is COLD, an ice spear is PIERCE). Members keep their order: BLUNT is the
+# storage's own zero, and NONE is LAST because it is never authored -- delivered_kind() answers it
+# for anything that deals no damage or heals, so "does this attack deal damage" keeps its one answer.
+# The physical three, mechanically: PIERCE is a point (0D), SLASH a line (1D), BLUNT a plane (2D).
+enum Kind { BLUNT, SLASH, PIERCE, FIRE, SHOCK, COLD, CORROSION, NONE }
+@export var damage_kind: Kind = Kind.BLUNT
+
+# What this attack would deliver if it delivered `kind`: NONE for a heal or a pure-utility attack,
+# the kind itself otherwise. ONE home for that rule -- delivered_kind() reads it for the authored
+# field, WeaponInstance.effective_kind for the field with a mod's override composed on top.
+func deliver(kind: Kind) -> Kind:
+	if heals or deals_no_damage:
+		return Kind.NONE
+	return kind
+
+func delivered_kind() -> Kind:
+	return deliver(damage_kind)
+
+# Player-facing spelling, lower case so it sits inside a sentence ("Damage 12, slash").
+static func kind_name(kind: Kind) -> String:
+	return Kind.keys()[kind].to_lower()
+
 func hits_map() -> bool:
 	return targets == EquippableData.TargetMode.MAP or targets == EquippableData.TargetMode.BOTH
 
@@ -69,12 +97,14 @@ func hits_units() -> bool:
 # How a readout PHRASES this attack's payload. The number stays per-kind (a carving scales off
 # aura, a weapon attack off its weapon — #72 keeps damage math off this base), but the three-state
 # question damages/heals/neither is answered HERE, so the two kinds can never word it differently.
-func payload_text(amount: int) -> String:
+# Takes the DELIVERED kind rather than reading damage_kind (#424): a fitted mod may have replaced
+# it, and the caller holds the composed answer.
+func payload_text(amount: int, kind: Kind) -> String:
 	if deals_no_damage:
 		return "No damage"
 	if heals:
 		return "Heals %d" % amount
-	return "Damage %d" % amount
+	return "Damage %d, %s" % [amount, kind_name(kind)]
 
 # The targeting channel's readout token (#135 round 2) — same one-spelling rule as payload_text,
 # deliberately its own function: payload and targeting are different questions. Concise parens by
@@ -111,5 +141,6 @@ static func property_tips() -> Dictionary:
 		"heals": "Reinterprets the damage number as HP restored instead. An attack is either damage or a heal, never both.",
 		"deals_no_damage": "Pure utility: scaling is suppressed, so neither aura nor a weapon's stat blend can sneak damage into a damageless effect. Mutually exclusive with Heals.",
 		"pierces_guard": "Ignores a Guard -- the hit lands on whoever it was aimed at, bodyguard or no.",
+		"damage_kind": "How the damage ARRIVES -- the thing armour can answer. Blunt is a plane (hammer, fist, thrown rock, a jet of water), slash a line (blade), pierce a point (spear, bullet, arrow, ice spear). Fire, shock, cold and corrosion are non-physical deliveries. SEPARATE from the element: a fireball is Fire kind AND applies the fire effect; an ice spear is Pierce AND applies the ice effect. Ignored on a heal or a no-damage attack, which read as None.",
 		"can_overwatch": "Makes this an OVERWATCH attack, and only that -- it is aimed as a standing watch and never fired directly, so it does not appear in the attack menu, the AI never picks it, and it cannot be a weapon's main. It fires on the first enemy who enters the aimed cells during someone else's turn, once, then it is spent.",
 	}

--- a/Classes/ui/panels/info_panel.gd
+++ b/Classes/ui/panels/info_panel.gd
@@ -136,16 +136,18 @@ func _refresh_stats():
 	_add_stat("WT", str(unit.get_weight()), Glossary.Term.WEIGHT, weight_tooltip(unit.get_weight()))
 	var armor_name := ""
 	var armor_power := 0
+	var armor_coverage := ""
 	if unit.worn_armor != null:
 		armor_name = unit.worn_armor.display_name
 		armor_power = unit.worn_armor.def_power
+		armor_coverage = unit.worn_armor.coverage_text()
 	# One shared breakdown (the resolver sums the same call). Yellow = a temporary source is
 	# contributing — terrain you're standing on, not gear you own.
 	var def := RulesService.def_breakdown(unit, unit.movement.cell, board)
 	var def_color: Color = TERRAIN_BUFF_COLOR if def["cover"] > 0 else NO_TINT
 	_add_stat("DEF", str(def["total"]), Glossary.Term.DEF, def_tooltip(
 		armor_name, armor_power, unit.get_effective_stat(Stats.Stat.CON),
-		def["armor"], def["cover"], def["total"]), def_color)
+		def["armor"], def["cover"], def["total"], armor_coverage), def_color)
 	_add_stat("LDR", str(unit.get_effective_ldr()), Glossary.term_for_stat(Stats.Stat.LDR),
 		"LDR %d %+d PER band" % [
 			unit.get_effective_stat(Stats.Stat.LDR),
@@ -278,7 +280,7 @@ static func effect_source_text(source_name: String, delta: int, turns_remaining:
 static func weight_tooltip(carried: int) -> String:
 	return "Carried gear %d\nTracked only -- no effect yet" % carried
 
-static func def_tooltip(armor_name: String, def_power: int, con: int, armor_def: int, cover_def: int, total: int) -> String:
+static func def_tooltip(armor_name: String, def_power: int, con: int, armor_def: int, cover_def: int, total: int, coverage: String = "") -> String:
 	# `total` is passed, not re-added: RulesService.def_breakdown already composed it, and a
 	# second addition of a number that already exists is a seam waiting to diverge — the next
 	# DEF source added there would reach the value and miss this line.
@@ -287,6 +289,11 @@ static func def_tooltip(armor_name: String, def_power: int, con: int, armor_def:
 		lines.append("No armor worn")
 	else:
 		lines.append("%s: %d armor x CON %d = %d" % [armor_name, def_power, con, armor_def])
+		# Which kinds the piece answers (#424): "" when it covers everything, which is what every piece
+		# authored before kinds existed still does. The standing readout shows the full number; the
+		# queue row is where a specific hit learns whether the piece covers it.
+		if coverage != "":
+			lines.append("Covers: %s" % coverage.trim_prefix("vs "))
 	if cover_def > 0:
 		lines.append("Cover (terrain): +%d" % cover_def)
 	lines.append("Total: %d" % total)

--- a/Classes/ui/queue/ActionQueueRow.gd
+++ b/Classes/ui/queue/ActionQueueRow.gd
@@ -213,6 +213,13 @@ func _show_hp_delta(outcome: ResolvedOutcome, subject: Unit) -> void:
 	# The "->" spelling is load-bearing: tests/presentation/test_predicted_health.gd finds this
 	# label by searching for it and parses split("->")[1].
 	readout.text = "%d->%d" % [hp_before, hp_after]
+	# The number explains itself on hover (#424, Law #2): what kind the hit delivered and what the
+	# target's DEF did with it, read off the outcome's own stamps so this can never name a
+	# subtraction other than the one made.
+	var tip := damage_tip(outcome, subject)
+	readout.tooltip_text = tip
+	readout_card.tooltip_text = tip
+	readout.mouse_filter = Control.MOUSE_FILTER_STOP
 
 	# Team-color the readout: green when a friendly is losing HP, red for an enemy.
 	var friendly := true
@@ -220,6 +227,21 @@ func _show_hp_delta(outcome: ResolvedOutcome, subject: Unit) -> void:
 		friendly = not Team.is_enemy(subject.get_faction(), Team.Faction.PLAYER)
 	var role: QueueStyle.Role = QueueStyle.Role.READOUT_ALLY if friendly else QueueStyle.Role.READOUT_ENEMY
 	_show_readout(QueueStyle.ink(role))
+
+# The damage number's hover text (#424): the delivered kind, then the mitigation and why. A heal or a
+# utility hit has no kind and says nothing. Static and string-only so tests/ui can read it without a
+# scene, the def_tooltip shape.
+static func damage_tip(outcome: ResolvedOutcome, subject: Unit) -> String:
+	if outcome.kind == AttackData.Kind.NONE:
+		return ""
+	var kind := AttackData.kind_name(outcome.kind)
+	var lines: Array[String] = ["%s damage" % kind.capitalize()]
+	if subject != null and is_instance_valid(subject) and subject.worn_armor != null \
+			and not subject.worn_armor.covers(outcome.kind):
+		lines.append("%s does not cover %s" % [subject.worn_armor.display_name, kind])
+	if outcome.mitigation > 0:
+		lines.append("DEF %d subtracted" % outcome.mitigation)
+	return UiText.wrap("\n".join(lines))
 
 # The number wears the same tinted card the elemental chips do (dev, 2026-09-03: the digits "are a
 # bit odd on their own... the damage numbers should have that feel too"). One card language across

--- a/Classes/weapons/AttackLint.gd
+++ b/Classes/weapons/AttackLint.gd
@@ -38,6 +38,7 @@ static func check(attack: AttackData) -> Array[Dictionary]:
 		return found
 	_check_reaches_anything(attack, found)
 	_check_blend_totals(attack, found)
+	_check_kind_is_authored(attack, found)
 	return found
 
 
@@ -61,6 +62,19 @@ static func _check_blend_totals(attack: AttackData, found: Array[Dictionary]) ->
 	var name := attack.display_name if attack.display_name != "" else "This attack"
 	_add(found, Severity.DEGRADES, "%s's scaling blend totals %d, not %d, so what it really scales off is %s -- not what the numbers say." % [
 		name, total, Stats.BLEND_TOTAL, Stats.blend_text(weapon_attack.scaling_blend)])
+
+
+# NONE is the kind of a heal or a utility attack and nothing else -- delivered_kind() answers it from
+# those flags, so the stored field never needs to say it, and the editor never offers it. The one door
+# left is a hand-edited .tres, and a damaging attack stored as NONE would read as armour-proof to
+# every piece that lists its kinds, silently. BLOCKS, like the range fault: it is a file that lies.
+static func _check_kind_is_authored(attack: AttackData, found: Array[Dictionary]) -> void:
+	if attack.damage_kind != AttackData.Kind.NONE:
+		return
+	if attack.deliver(AttackData.Kind.BLUNT) == AttackData.Kind.NONE:
+		return   # a heal or a utility attack delivers NONE by rule, whatever the field says
+	var name := attack.display_name if attack.display_name != "" else "This attack"
+	_add(found, Severity.BLOCKS, "%s deals damage but its kind is None -- None is only for heals and no-damage attacks. Pick how the damage arrives." % name)
 
 
 # Reach's own union-over-facings query, so a directional spread is judged by the same call the red

--- a/Classes/weapons/WeaponInstance.gd
+++ b/Classes/weapons/WeaponInstance.gd
@@ -170,6 +170,11 @@ func fit_block_reason(index: int, mod: WeaponModData) -> String:
 		if already != null:
 			var whose: String = already.display_name if already.display_name != "" else "Another fitted mod"
 			return "%s already replaces this weapon's main attack — a weapon has one main." % whose
+	if mod.overrides_kind:
+		var holder := _kind_overrider()
+		if holder != null:
+			var name: String = holder.display_name if holder.display_name != "" else "Another fitted mod"
+			return "%s already changes this weapon's damage kind -- one kind-changing mod at a time, so fitting order can never decide what armour does to a swing." % name
 	var capacity: int = template.mod_spaces[index]
 	if used_capacity(index) + mod.size > capacity:
 		return "Space %d holds %d of %d — this needs %d more." % [index + 1, used_capacity(index), capacity, mod.size]
@@ -185,6 +190,15 @@ func _main_replacer() -> WeaponModData:
 	for i in range(space_count()):
 		for mod: WeaponModData in space(i):
 			if mod.replaces_main != null:
+				return mod
+	return null
+
+# The fitted mod overriding the damage kind, if any (#424). Same every-space scan and the same reason:
+# a parked kind-changer still occupies the one kind an attack delivers.
+func _kind_overrider() -> WeaponModData:
+	for i in range(space_count()):
+		for mod: WeaponModData in space(i):
+			if mod.overrides_kind:
 				return mod
 	return null
 
@@ -329,7 +343,7 @@ func attack_detail(wielder: Unit, attack: AttackData) -> String:
 	if weapon_attack == null:
 		return ""
 	var damage := base_damage(wielder, weapon_attack)
-	var headline := "%s %s" % [weapon_attack.payload_text(damage), weapon_attack.targets_text()]
+	var headline := "%s %s" % [weapon_attack.payload_text(damage, effective_kind(wielder, weapon_attack)), weapon_attack.targets_text()]
 	if weapon_attack.deals_no_damage:
 		return headline   # scaling is suppressed entirely (#126) -- printing a blend would be a lie
 	var mods := _mods_for(wielder, weapon_attack)
@@ -414,6 +428,20 @@ func get_elements(wielder: Unit, attack: WeaponAttackData) -> Array[Elemental.El
 
 # The two overrides a fitted mod may make (#529), composed the same way power and elements are and
 # gated by the same applies_to selector -- one answer to what a mod reaches, not one per field.
+# The kind the attack DELIVERS for this wielder (#424): the authored kind, replaced by the one fitted
+# kind-overriding mod that reaches it, then AttackData.deliver applies the heal / no-damage rule --
+# one home for that rule, so a modded utility swing cannot come out blunt. A carving never comes
+# through here; it has no mods and answers delivered_kind() itself.
+func effective_kind(wielder: Unit, attack: AttackData) -> AttackData.Kind:
+	var weapon_attack := attack as WeaponAttackData
+	if weapon_attack == null:
+		return attack.delivered_kind()
+	var kind := weapon_attack.damage_kind
+	for mod in _mods_for(wielder, weapon_attack):
+		if mod.overrides_kind:
+			kind = mod.kind
+	return weapon_attack.deliver(kind)
+
 func effective_knockback(wielder: Unit, attack: AttackData) -> int:
 	var weapon_attack := attack as WeaponAttackData
 	if weapon_attack == null:

--- a/Classes/weapons/WeaponModData.gd
+++ b/Classes/weapons/WeaponModData.gd
@@ -45,6 +45,15 @@ enum Override { UNCHANGED, ON, OFF }
 # rearranging fitted mods must not change what an attack does (design law #1), and a safety device
 # a later mod could silently cancel is worse than no safety device at all.
 
+@export var overrides_kind: bool = false
+@export var kind: AttackData.Kind = AttackData.Kind.BLUNT
+# REPLACES the damage kind of the attacks applies_to names (#424) -- a spiked head makes a mace's
+# swing PIERCE. A bool plus a kind rather than an UNCHANGED member on the roster, because AttackData.Kind
+# is the roster armour reads and a sentinel there would be a value armour could be authored against.
+# `false` is the storage's own default and means unchanged. Two mods overriding the kind on one weapon
+# is refused at the FIT (fit_block_reason), never composed: fitting order must not decide what armour
+# does to a swing (design law #1), and there is no OFF-beats-ON reading of two different kinds.
+
 @export var can_overwatch_override: Override = Override.UNCHANGED
 # Whether the attacks applies_to names may be declared as a standing watch, overriding what each one
 # authored (#413) -- Watchman's Sear's original job. Same OFF-beats-ON composition as
@@ -141,6 +150,8 @@ static func property_tips() -> Dictionary:
 		"scaling_change": "How this mod re-mixes damage scaling. You author the absolute percentages you want; what is STORED is the shift from the family main attack's own blend, so the attacks Applies To names move by the same amount and keep their own character.",
 		"family": "Which weapon family this mod fits. Required once it changes scaling -- the shift is measured against that family's main attack and means nothing on another. Leave it unset for a mod that fits anything.",
 		"added_element": "An element this mod adds ON TOP of whatever the attack already carries, on whichever attacks Applies To names. NONE = adds nothing.",
+		"overrides_kind": "Whether this mod REPLACES the damage kind of the attacks it affects. Only one kind-changing mod fits a weapon at a time.",
+		"kind": "The damage kind the affected attacks deliver while Overrides Kind is on -- a spiked head turns a mace's blunt swing into pierce. Ignored otherwise.",
 		"knockback_delta": "Tiles this mod ADDS to the shove of the attacks it affects. Stacks with other mods; 0 changes nothing. A negative total is no shove, never a pull.",
 		"hits_allies_override": "Whether the attacks this mod affects splash allies, overriding what each attack authored. Unchanged leaves them alone. Off wins over On no matter which space each mod sits in, so rearranging your mods never changes what an attack does.",
 		"can_overwatch_override": "Whether the attacks this mod affects are OVERWATCH attacks -- On makes them watch-only, aimed as a standing watch and never fired directly. Unchanged leaves each attack's own setting alone; Off wins over On whichever space each mod sits in, same as ally splash above.",

--- a/Resources/Armor/BallastHarness.tres
+++ b/Resources/Armor/BallastHarness.tres
@@ -5,6 +5,7 @@
 [resource]
 script = ExtResource("1_armor")
 def_power = 2
+covered_kinds = Array[int]([0, 1, 2])
 stat_maximums = Dictionary[int, int]({
 4: 4
 })

--- a/Resources/Armor/BulwarkPlate.tres
+++ b/Resources/Armor/BulwarkPlate.tres
@@ -7,6 +7,7 @@
 [resource]
 script = ExtResource("1_armor")
 def_power = 3
+covered_kinds = Array[int]([0, 1, 2])
 flat_def = 1
 stat_minimums = Dictionary[int, int]({
 6: 8

--- a/Resources/Armor/RivetedMail.tres
+++ b/Resources/Armor/RivetedMail.tres
@@ -5,6 +5,7 @@
 [resource]
 script = ExtResource("1_armor")
 def_power = 4
+covered_kinds = Array[int]([0, 1, 2])
 stat_modifiers = Dictionary[int, int]({
 4: -1
 })

--- a/Resources/TransmutationData/Fireball.tres
+++ b/Resources/TransmutationData/Fireball.tres
@@ -17,6 +17,7 @@ sigils = Array[int]([1])
 popup = "Fireball!"
 icon = ExtResource("2_bcr2w")
 display_name = "Fireball"
+damage_kind = 3
 power = 5
 attack_pattern = SubResource("Resource_mq7ng")
 hits_allies = true

--- a/Resources/TransmutationData/Freeze.tres
+++ b/Resources/TransmutationData/Freeze.tres
@@ -12,6 +12,7 @@ script = ExtResource("2_24q66")
 sigils = Array[int]([2, 2])
 flourishes = Array[int]([4, 3])
 display_name = "Freeze"
+damage_kind = 5
 power = 4
 attack_pattern = SubResource("Resource_xrrob")
 hits_allies = true

--- a/Resources/TransmutationData/Zap Cannon.tres
+++ b/Resources/TransmutationData/Zap Cannon.tres
@@ -11,6 +11,7 @@ length = 5
 script = ExtResource("2_l1t8p")
 sigils = Array[int]([1, 1, 6])
 display_name = "Zap Cannon"
+damage_kind = 4
 power = 7
 attack_pattern = SubResource("Resource_1bq0e")
 hits_allies = true

--- a/Resources/WeaponAttacks/Line Snipe.tres
+++ b/Resources/WeaponAttacks/Line Snipe.tres
@@ -15,6 +15,7 @@ scaling_blend = Dictionary[int, int]({
 5: 60
 })
 display_name = "Line Snipe"
+damage_kind = 2
 power = 5
 attack_pattern = SubResource("Resource_w8rux")
 hits_allies = true

--- a/Resources/WeaponAttacks/MainAttacks/Carbine.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Carbine.tres
@@ -18,6 +18,7 @@ scaling_blend = Dictionary[int, int]({
 requires_readiness = true
 consumes_readiness = true
 display_name = "Shot"
+damage_kind = 2
 power = 4
 attack_pattern = SubResource("Resource_main")
 metadata/_custom_type_script = "uid://ddqeee7njjjq2"

--- a/Resources/WeaponAttacks/MainAttacks/ChainSword.tres
+++ b/Resources/WeaponAttacks/MainAttacks/ChainSword.tres
@@ -14,6 +14,7 @@ scaling_blend = Dictionary[int, int]({
 4: 40
 })
 display_name = "Slash"
+damage_kind = 1
 power = 3
 attack_pattern = SubResource("Resource_main")
 vertical_rule = 1

--- a/Resources/WeaponAttacks/MainAttacks/Chemical_Spitter.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Chemical_Spitter.tres
@@ -5,5 +5,6 @@
 [resource]
 script = ExtResource("1_wad")
 display_name = "Spray"
+damage_kind = 6
 vertical_rule = 1
 metadata/_custom_type_script = "uid://ddqeee7njjjq2"

--- a/Resources/WeaponAttacks/MainAttacks/Drill.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Drill.tres
@@ -14,6 +14,7 @@ scaling_blend = Dictionary[int, int]({
 6: 20
 })
 display_name = "Gouge"
+damage_kind = 2
 power = 3
 attack_pattern = SubResource("Resource_main")
 vertical_rule = 1

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/Bow.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/Bow.tres
@@ -16,5 +16,6 @@ scaling_blend = Dictionary[int, int]({
 5: 50
 })
 display_name = "Loose"
+damage_kind = 2
 power = 3
 attack_pattern = SubResource("Resource_juf0b")

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/Firespitter.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/Firespitter.tres
@@ -14,6 +14,7 @@ scaling_blend = Dictionary[int, int]({
 5: 100
 })
 display_name = "Scald"
+damage_kind = 3
 power = 5
 attack_pattern = SubResource("Resource_d2h5t")
 hits_allies = true

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/POINT.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/POINT.tres
@@ -15,6 +15,7 @@ scaling_blend = Dictionary[int, int]({
 4: 30
 })
 display_name = "Lance"
+damage_kind = 2
 power = 5
 attack_pattern = SubResource("Resource_mrekx")
 hits_allies = true

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/Shock Rod.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/Shock Rod.tres
@@ -6,5 +6,6 @@
 script = ExtResource("1_o52ed")
 elemental_damage_type = 3
 display_name = "Jolt"
+damage_kind = 4
 power = 4
 vertical_rule = 1

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/Sweeper.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/Sweeper.tres
@@ -13,5 +13,6 @@ scaling_blend = Dictionary[int, int]({
 4: 40
 })
 display_name = "Cleave"
+damage_kind = 1
 power = 3
 attack_pattern = SubResource("Resource_5w2v2")

--- a/Resources/WeaponAttacks/MainAttacks/Prototypes/TheJaw.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Prototypes/TheJaw.tres
@@ -14,6 +14,7 @@ scaling_blend = Dictionary[int, int]({
 4: 30
 })
 display_name = "Bite"
+damage_kind = 1
 power = 5
 attack_pattern = SubResource("Resource_main")
 vertical_rule = 1

--- a/Resources/WeaponAttacks/MainAttacks/Springspear.tres
+++ b/Resources/WeaponAttacks/MainAttacks/Springspear.tres
@@ -10,6 +10,7 @@ metadata/_custom_type_script = "uid://dsxc14gee2d01"
 [resource]
 script = ExtResource("2_wad")
 display_name = "Stab"
+damage_kind = 2
 power = 3
 attack_pattern = SubResource("Resource_main")
 requires_readiness = true

--- a/Resources/WeaponAttacks/Overwatch.tres
+++ b/Resources/WeaponAttacks/Overwatch.tres
@@ -16,6 +16,7 @@ scaling_blend = Dictionary[int, int]({
 requires_readiness = true
 consumes_readiness = true
 display_name = "Overwatch"
+damage_kind = 2
 power = 4
 attack_pattern = SubResource("Resource_hdsxh")
 can_overwatch = true

--- a/Resources/WeaponAttacks/Spring.tres
+++ b/Resources/WeaponAttacks/Spring.tres
@@ -10,6 +10,7 @@ metadata/_custom_type_script = "uid://bbbfksnb0tted"
 [resource]
 script = ExtResource("2_wad")
 display_name = "Spring"
+damage_kind = 2
 power = 5
 attack_pattern = SubResource("Resource_main")
 hits_allies = true

--- a/Resources/WeaponAttacks/Super Gun.tres
+++ b/Resources/WeaponAttacks/Super Gun.tres
@@ -12,6 +12,7 @@ min_range = 1
 [resource]
 script = ExtResource("2_p0lyu")
 display_name = "Super Gun"
+damage_kind = 2
 power = 9
 attack_pattern = SubResource("Resource_iwbj5")
 hits_allies = true

--- a/tests/dev/test_attack_lint.gd
+++ b/tests/dev/test_attack_lint.gd
@@ -86,3 +86,35 @@ func test_carriers_round_trips_against_every_family() -> void:
 func test_an_attack_with_no_file_has_no_carriers() -> void:
 	assert_array(AttackLint.carriers_of(WeaponAttackData.new())).is_empty()
 	assert_array(AttackLint.carriers_of(null)).is_empty()
+
+
+# --- damage kind (#424): NONE is a rule, never an authoring ---
+
+func test_a_damaging_attack_stored_as_none_is_blocked_and_named() -> void:
+	var attack := _manhattan(2, 2)
+	attack.damage_kind = AttackData.Kind.NONE
+	var findings := AttackLint.check(attack)
+	assert_array(findings).is_not_empty()
+	assert_int(findings[0]["severity"]).is_equal(AttackLint.Severity.BLOCKS)
+	assert_str(findings[0]["text"]).contains("Probe")
+	assert_str(findings[0]["text"]).contains("None")
+
+
+func test_none_on_a_heal_is_the_rule_and_not_a_fault() -> void:
+	var attack := _manhattan(2, 2)
+	attack.heals = true
+	attack.damage_kind = AttackData.Kind.NONE
+	assert_array(AttackLint.check(attack)).is_empty()
+
+
+func test_none_on_a_no_damage_attack_is_clean() -> void:
+	var attack := _manhattan(2, 2)
+	attack.deals_no_damage = true
+	attack.damage_kind = AttackData.Kind.NONE
+	assert_array(AttackLint.check(attack)).is_empty()
+
+
+func test_an_authored_kind_is_clean() -> void:
+	var attack := _manhattan(2, 2)
+	attack.damage_kind = AttackData.Kind.CORROSION
+	assert_array(AttackLint.check(attack)).is_empty()

--- a/tests/law/test_def_mitigation.gd
+++ b/tests/law/test_def_mitigation.gd
@@ -211,3 +211,117 @@ func test_def_breakdown_total_is_what_the_resolver_subtracts() -> void:
 
 	var shown := RulesService.def_breakdown(target, Vector2i(1, 0), board)
 	assert_int(attack.resolved.damage).is_equal(10 - shown["total"])
+
+
+# --- damage kinds (#424): armour answers only the kinds it covers ---
+#
+# A piece that lists kinds stops ONLY those; a piece that lists none stops everything, which is what
+# every piece authored before kinds existed still does. Cover is kind-blind. The kind and the
+# subtraction are stamped on the outcome so the queue row explains the number it shows (Law #2).
+
+func _armor_covering(def_power: int, kinds: Array[AttackData.Kind]) -> ArmorData:
+	var armor := _make_armor(def_power)
+	armor.covered_kinds = kinds
+	return armor
+
+
+func test_an_uncovered_kind_zeroes_the_armor_term_and_not_cover() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.STR: 4})
+	var target := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.MHP: 20, Stats.Stat.CON: 5})
+	target.worn_armor = _armor_covering(4, [AttackData.Kind.SLASH])   # the swing below is BLUNT
+	var board := _board_with_cover(Vector2i(1, 0))
+
+	var attack := _attack(attacker, target)   # base 10, the fixture main's kind is the zero: BLUNT
+	var plan := ResolvedPlan.new()
+	plan.attacks.append(attack)
+	PlanResolver.resolve(plan, ReactionCatalog.get_all(), board)
+
+	assert_int(attack.resolved.damage).is_equal(10 - Terrain.COVER_DEF)
+	var against := RulesService.def_against(target, Vector2i(1, 0), board, AttackData.Kind.BLUNT)
+	assert_int(against["armor"]).is_equal(0)
+	assert_int(against["cover"]).is_equal(Terrain.COVER_DEF)
+	assert_int(against["total"]).is_equal(Terrain.COVER_DEF)
+
+
+func test_a_covered_kind_is_mitigated_in_full() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.STR: 4})
+	var target := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.MHP: 20, Stats.Stat.CON: 5})
+	target.worn_armor = _armor_covering(4, [AttackData.Kind.SLASH, AttackData.Kind.BLUNT])
+
+	var attack := _attack(attacker, target)
+	var plan := ResolvedPlan.new()
+	plan.attacks.append(attack)
+	PlanResolver.resolve(plan)
+
+	assert_int(attack.resolved.damage).is_equal(10 - target.get_effective_def())
+
+
+func test_a_piece_listing_no_kinds_covers_every_kind() -> void:
+	# The storage default: a piece authored before kinds existed keeps stopping a fireball.
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.STR: 4})
+	var target := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.MHP: 20, Stats.Stat.CON: 5})
+	target.worn_armor = _make_armor(4)
+
+	var attack := _attack(attacker, target)
+	(attack.fired_attack as WeaponAttackData).damage_kind = AttackData.Kind.FIRE
+	var plan := ResolvedPlan.new()
+	plan.attacks.append(attack)
+	PlanResolver.resolve(plan)
+
+	assert_int(attack.resolved.damage).is_equal(10 - target.get_effective_def())
+
+
+func test_the_outcome_stamps_the_kind_and_the_subtraction_it_made() -> void:
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.STR: 4})
+	var target := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.MHP: 20, Stats.Stat.CON: 5})
+	target.worn_armor = _make_armor(4)
+
+	var attack := _attack(attacker, target)
+	(attack.fired_attack as WeaponAttackData).damage_kind = AttackData.Kind.SLASH
+	var plan := ResolvedPlan.new()
+	plan.attacks.append(attack)
+	PlanResolver.resolve(plan)
+
+	assert_that(attack.resolved.kind).is_equal(AttackData.Kind.SLASH)
+	assert_int(attack.resolved.mitigation).is_equal(10 - attack.resolved.damage)
+	assert_int(attack.resolved.mitigation).is_greater(0)   # premise: something was subtracted
+
+
+func test_a_fitted_mod_changes_what_armor_answers() -> void:
+	# The WIRE from the mod to the mitigation stage: the resolver must read the COMPOSED kind. A
+	# mutant reading the authored field passes every other case in this file.
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.STR: 4})
+	var target := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.MHP: 20, Stats.Stat.CON: 5})
+	target.worn_armor = _armor_covering(4, [AttackData.Kind.BLUNT])   # covers the AUTHORED kind
+
+	var attack := _attack(attacker, target)
+	attacker.unit_instance.set_proficiency(WeaponData.WeaponType.CHAINSWORD, 3)
+	var spike := WeaponModData.new()
+	spike.overrides_kind = true
+	spike.kind = AttackData.Kind.PIERCE
+	assert_bool((attacker.equipped_weapon as WeaponInstance).fit(0, spike)) \
+		.override_failure_message("fixture: the spike must fit, or the override is simply absent") \
+		.is_true()
+	var plan := ResolvedPlan.new()
+	plan.attacks.append(attack)
+	PlanResolver.resolve(plan)
+
+	assert_that(attack.resolved.kind).is_equal(AttackData.Kind.PIERCE)
+	assert_int(attack.resolved.damage).is_equal(10)   # plate covers blunt; the spike made it pierce
+
+
+func test_bare_fists_are_blunt() -> void:
+	# The one attack with no resource to author a kind on; the resolver answers BLUNT for a null stamp.
+	var attacker := H.spawn_solo(self, _sm, PLAYER, Vector2i(0, 0), {Stats.Stat.STR: 4})
+	var target := H.spawn_solo(self, _sm, ENEMY, Vector2i(1, 0), {Stats.Stat.MHP: 20, Stats.Stat.CON: 5})
+	target.worn_armor = _armor_covering(4, [AttackData.Kind.BLUNT])
+
+	attacker.equipped_weapon = null
+	var attack := H.stamped_attack(attacker, target)   # no weapon -> null stamp -> STR damage
+	assert_object(attack.fired_attack).is_null()
+	var plan := ResolvedPlan.new()
+	plan.attacks.append(attack)
+	PlanResolver.resolve(plan)
+
+	assert_that(attack.resolved.kind).is_equal(AttackData.Kind.BLUNT)
+	assert_int(attack.resolved.damage).is_equal(4 - target.get_effective_def())

--- a/tests/ui/test_info_panel_text.gd
+++ b/tests/ui/test_info_panel_text.gd
@@ -168,3 +168,16 @@ func test_ability_tooltip_without_description_is_a_single_line() -> void:
 	assert_str(tip).contains("Taunt")
 	assert_str(tip).contains("Reaction")
 	assert_int(tip.split("\n").size()).is_equal(1)   # no dangling blank line
+
+
+# --- def_tooltip: armour coverage (#424) ---
+
+func test_def_tooltip_lists_the_kinds_the_piece_covers() -> void:
+	var tip: String = InfoPanel.def_tooltip("Scrap Plate", 10, 5, 10, 0, 10, "vs blunt, slash, pierce")
+	assert_str(tip).contains("Covers: blunt, slash, pierce")
+
+
+func test_def_tooltip_says_nothing_about_coverage_for_a_piece_that_covers_all() -> void:
+	# "" is what every piece authored before kinds existed answers; the row stays as it was.
+	var tip: String = InfoPanel.def_tooltip("Scrap Plate", 10, 5, 10, 0, 10)
+	assert_str(tip).not_contains("Covers")

--- a/tests/ui/test_queue_row_readout.gd
+++ b/tests/ui/test_queue_row_readout.gd
@@ -559,3 +559,57 @@ func test_the_widest_row_still_fits_inside_its_section() -> void:
 			% [row.get_global_rect().end.x, dock.get_global_rect().end.x]) \
 		.is_less_equal(dock.get_global_rect().end.x)
 	assert_object(attacker).is_not_null()
+
+
+# --- the damage number explains itself (#424) ---
+#
+# The kind the hit delivered and what the target's DEF did with it, on the number's own hover.
+# Read off the LABEL the player hovers, not off damage_tip() alone: a tip that is composed and never
+# assigned is the transparent-surface failure (#506), and the label's default mouse filter would make
+# it dead text even when assigned.
+
+func test_the_damage_number_says_what_kind_it_delivered() -> void:
+	var no_states: Array[Elemental.State] = []
+	await _queue_elemental_attack(Elemental.Element.NONE, no_states)
+	var row := _attack_row()
+	assert_object(row).is_not_null()
+
+	assert_str(row.readout.tooltip_text).contains("Blunt damage")   # the fixture main's kind is the zero
+	assert_int(row.readout.mouse_filter).is_not_equal(Control.MOUSE_FILTER_IGNORE)
+
+
+func test_the_damage_number_says_when_armor_does_not_cover_the_kind() -> void:
+	var attacker := _spawn(Team.Faction.PLAYER, Vector2i(1, 1))
+	var victim := _spawn(Team.Faction.ENEMY, Vector2i(2, 1))
+	var plate := ArmorData.new()
+	plate.display_name = "Fencing Jacket"
+	plate.flat_def = 3
+	plate.covered_kinds = [AttackData.Kind.SLASH]   # the swing below is BLUNT
+	victim.worn_armor = plate
+	attacker.equipped_weapon = H.make_weapon(4)
+	game.squad_manager.active_squad = attacker.squad
+	game.squad_manager.queue_action(attacker.squad, H.stamped_attack(attacker, victim))
+	game.refresh_action_queue(attacker.squad)
+	await await_idle_frame()
+
+	var row := _attack_row()
+	assert_object(row).is_not_null()
+	assert_str(row.readout.tooltip_text).contains("Fencing Jacket does not cover blunt")
+
+
+func test_the_damage_number_names_the_def_it_subtracted() -> void:
+	var attacker := _spawn(Team.Faction.PLAYER, Vector2i(1, 1))
+	var victim := _spawn(Team.Faction.ENEMY, Vector2i(2, 1))
+	var plate := ArmorData.new()
+	plate.flat_def = 3
+	victim.worn_armor = plate
+	attacker.equipped_weapon = H.make_weapon(4)
+	game.squad_manager.active_squad = attacker.squad
+	game.squad_manager.queue_action(attacker.squad, H.stamped_attack(attacker, victim))
+	game.refresh_action_queue(attacker.squad)
+	await await_idle_frame()
+
+	var row := _attack_row()
+	var outcome := (row.action as AttackAction).resolved
+	assert_int(outcome.mitigation).is_greater(0)   # premise: the jacket paid out
+	assert_str(row.readout.tooltip_text).contains("DEF %d subtracted" % outcome.mitigation)

--- a/tests/weapons/test_attack_scaling.gd
+++ b/tests/weapons/test_attack_scaling.gd
@@ -110,7 +110,7 @@ func test_the_attack_tooltip_itemises_power_and_scaling() -> void:
 	assert_str(detail).contains("4 power")
 	assert_str(detail).contains("STR 100%")
 	# The headline survives above it -- the scaling line is an ADDITION, not a replacement.
-	assert_str(detail).contains(main.payload_text(weapon.base_damage(unit, main)))
+	assert_str(detail).contains(main.payload_text(weapon.base_damage(unit, main), weapon.effective_kind(unit, main)))
 
 func test_a_damageless_attack_prints_no_blend() -> void:
 	# Scaling is suppressed entirely for a utility attack (#126), so naming a blend would describe

--- a/tests/weapons/test_mod_overrides.gd
+++ b/tests/weapons/test_mod_overrides.gd
@@ -115,3 +115,84 @@ func test_off_beats_on_whichever_space_each_sits_in() -> void:
 		assert_bool(RulesService.is_attack_victim(hero, ally, swing)) \
 			.override_failure_message("OFF must win with off_first = %s" % off_first) \
 			.is_false()
+
+# --- Damage kind (#424) ---
+#
+# The third override: a mod REPLACES the kind of the attacks it reaches. No OFF-beats-ON reading
+# exists for two different kinds, so two kind-changers on one weapon are refused at the fit instead.
+
+func _spike(kind: AttackData.Kind) -> WeaponModData:
+	var m := WeaponModData.new()
+	m.display_name = "Spiked Head"
+	m.overrides_kind = true
+	m.kind = kind
+	return m
+
+func test_a_mod_can_replace_the_kind_of_the_attacks_it_reaches() -> void:
+	var hero := _unit(Team.Faction.PLAYER, Vector2i(0, 0))
+	var swing := _attack(0, false)
+	var weapon := _weapon(swing)
+	hero.equipped_weapon = weapon
+	assert_that(weapon.effective_kind(hero, swing)).is_equal(AttackData.Kind.BLUNT)   # the contrast
+
+	_fit(weapon, 0, _spike(AttackData.Kind.PIERCE))
+
+	assert_that(weapon.effective_kind(hero, swing)).is_equal(AttackData.Kind.PIERCE)
+
+func test_a_main_attack_kind_mod_leaves_the_extras_alone() -> void:
+	var hero := _unit(Team.Faction.PLAYER, Vector2i(0, 0))
+	var swing := _attack(0, false)
+	var extra := _attack(0, false)
+	var weapon := _weapon(swing, extra)
+	hero.equipped_weapon = weapon
+
+	var mod := _spike(AttackData.Kind.SLASH)
+	mod.applies_to = WeaponModData.AppliesTo.MAIN_ATTACK
+	_fit(weapon, 0, mod)
+
+	assert_that(weapon.effective_kind(hero, swing)).is_equal(AttackData.Kind.SLASH)
+	assert_that(weapon.effective_kind(hero, extra)).is_equal(AttackData.Kind.BLUNT)
+
+func test_a_kind_override_never_makes_a_utility_swing_deliver_a_kind() -> void:
+	# NONE is a rule off the flags, not a stored value -- and the rule has ONE home, so a modded
+	# no-damage attack reads NONE exactly as an unmodded one does.
+	var hero := _unit(Team.Faction.PLAYER, Vector2i(0, 0))
+	var shove := _attack(1, false)
+	shove.deals_no_damage = true
+	var weapon := _weapon(shove)
+	hero.equipped_weapon = weapon
+	_fit(weapon, 0, _spike(AttackData.Kind.PIERCE))
+
+	assert_that(weapon.effective_kind(hero, shove)).is_equal(AttackData.Kind.NONE)
+	assert_that(shove.delivered_kind()).is_equal(AttackData.Kind.NONE)
+
+func test_a_heal_delivers_no_kind_whatever_is_authored() -> void:
+	var mend := _attack(0, false)
+	mend.heals = true
+	mend.damage_kind = AttackData.Kind.FIRE
+	assert_that(mend.delivered_kind()).is_equal(AttackData.Kind.NONE)
+
+func test_a_second_kind_changer_is_refused_with_its_reason() -> void:
+	var weapon := _weapon(_attack(0, false))
+	var first := _spike(AttackData.Kind.PIERCE)
+	_fit(weapon, 0, first)
+
+	# Space 1 holds 2 and is empty, so capacity cannot be what refuses.
+	assert_bool(weapon.can_fit(1, WeaponModData.new())) \
+		.override_failure_message("fixture: space 1 must have room, or the refusal below is capacity's") \
+		.is_true()
+
+	var second := _spike(AttackData.Kind.SLASH)
+	assert_bool(weapon.can_fit(1, second)).is_false()
+	assert_str(weapon.fit_block_reason(1, second)).contains(first.display_name)
+
+func test_the_readout_names_the_composed_kind() -> void:
+	# The hover line says what the modded swing DELIVERS, not what its file says (Law #2).
+	var hero := _unit(Team.Faction.PLAYER, Vector2i(0, 0))
+	var swing := _attack(0, false)
+	var weapon := _weapon(swing)
+	hero.equipped_weapon = weapon
+	_fit(weapon, 0, _spike(AttackData.Kind.PIERCE))
+
+	assert_str(weapon.attack_detail(hero, swing)).contains("pierce")
+	assert_str(weapon.attack_detail(hero, swing)).not_contains("blunt")


### PR DESCRIPTION
Closes nothing yet — **PR 1 of 2 for #424** (damage kinds). PR 2 carries the insulation repeal and the docs sweep.

## What lands

**The axis.** `AttackData.Kind` — BLUNT (the zero), SLASH, PIERCE, FIRE, SHOCK, COLD, CORROSION, and NONE, which is never authored: `AttackData.deliver()` answers it for a heal or a `deals_no_damage` attack, the one home for that rule. `damage_kind` is authored on every attack and carving, never derived (dev ruling 2026-09-05). A weapon mod may REPLACE it (`WeaponModData.overrides_kind` + `kind`), composed in `WeaponInstance.effective_kind`; a second kind-changing mod on one weapon is refused at the fit, the main-replacer precedent, so fitting order can never decide what armour does to a swing.

**Kind-aware DEF.** `ArmorData.covered_kinds` lists the kinds a piece's DEF applies to; empty = every kind, the storage default, so every piece authored before this behaved identically until swept. `RulesService.def_against(unit, cell, board, kind)` is LAYERED on `def_breakdown` — the standing readout is unchanged and the kind gate is applied once. The resolver stamps `outcome.kind` and `outcome.mitigation` in the same breath as the subtraction. Cover and the brace bonus stay kind-blind; the Chainsword's total bypass is untouched.

**The player can see it (Law #2).** The attack tooltip's payload line names the kind ("Damage 12, slash"). The queue row's damage number explains itself on hover — "Blunt damage / Fencing Jacket does not cover blunt" or "DEF 4 subtracted" — read off the outcome's own stamps. The inspect panel's DEF tooltip lists what the worn piece covers. Glossary gains *Damage kinds*. The Attack Editor draws a bespoke kind row that never offers NONE and says so for heals/utility attacks. `AttackLint` BLOCKS a damaging attack whose file says NONE.

**Content sweep.** 18 attacks/carvings authored per the rulings — Spray is CORROSION, Bite is SLASH, Freeze is COLD, the shots/spears PIERCE, blades SLASH, Scald FIRE, Jolt and Zap Cannon SHOCK; blunt ones keep the zero. Bulwark Plate, Riveted Mail and Ballast Harness now cover the three physical kinds only, which is the ticket's founding sentence made real: a fireball goes straight through plate. Insulated Weave is untouched (DEF 0, effect-only — PR 2's territory).

## Tests

- `tests/law/test_def_mitigation.gd`: uncovered kind zeroes the armour term and not cover; covered kind mitigates in full; empty coverage covers everything; the outcome stamps kind + mitigation; **a fitted mod changes what armour answers (the mod→resolver wire)**; bare fists are BLUNT.
- `tests/weapons/test_mod_overrides.gd`: override replaces the kind; main-only mod leaves extras alone; a utility swing stays NONE under an override; a heal delivers no kind; second kind-changer refused with its reason; the readout names the composed kind.
- `tests/dev/test_attack_lint.gd`: NONE on a damaging attack BLOCKS and is named; NONE on a heal / no-damage attack is clean.
- `tests/ui/test_queue_row_readout.gd`: the damage LABEL carries the kind, the not-covered line, and the DEF subtracted (asserted on the label, not the helper — the transparent-surface trap).
- `tests/ui/test_info_panel_text.gd`: coverage line present / absent.

Areas run locally: law, weapons, dev, ui, items, elemental — all green (654 + 492 cases). CI owns the tree.

**Falsified, one mutant at a time, committed first:** (a) the resolver reading the authored kind instead of `effective_kind` → `test_a_fitted_mod_changes_what_armor_answers` red; (b) `def_against` zeroing cover along with armour → `test_an_uncovered_kind_zeroes_the_armor_term_and_not_cover` red; (c) the queue row composing the tip and never assigning it → `test_the_damage_number_says_what_kind_it_delivered` red. Each mutant reddened exactly the case written for it and nothing else.

## Not in this PR

The insulation repeal (never-arrives → effect-strip only), the Weave's description, the docs sweep and markers, and the two heirs (temporary DEF sources by kind; the #77 note). Open by ruling: a per-kind DEF *table* — the list shape here is its subset, so it can land later without a migration of meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
